### PR TITLE
Fixed issue where bundle extension could return null when resource exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,12 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+## Mac OS generated
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/BundleExtensions.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/BundleExtensions.cs
@@ -41,21 +41,28 @@ namespace Microsoft.Health.Extensions.Fhir
             }
         }
 
-        public static TResource ReadOneFromBundle<TResource>(this Bundle bundle, bool throwOnMultipleFound = true)
+        public static async Task<TResource> ReadOneFromBundleWithContinuationAsync<TResource>(this Bundle bundle, IFhirClient fhirClient, bool throwOnMultipleFound = true)
             where TResource : Resource, new()
         {
-            var bundleCount = bundle?.Entry?.Count ?? 0;
-            if (bundleCount == 0)
+            if (bundle == null)
             {
                 return null;
             }
 
-            if (throwOnMultipleFound && bundleCount > 1)
+            var resources = await bundle?.ReadFromBundleWithContinuationAsync<TResource>(fhirClient, 2);
+
+            var resourceCount = resources.Count();
+            if (resourceCount == 0)
+            {
+                return null;
+            }
+
+            if (throwOnMultipleFound && resourceCount > 1)
             {
                 throw new MultipleResourceFoundException<TResource>();
             }
 
-            return bundle.Entry.ByResourceType<TResource>().FirstOrDefault();
+            return resources.FirstOrDefault();
         }
 
         /// <summary>

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Service/ResourceManagementService.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Service/ResourceManagementService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             EnsureArg.IsNotNull(identifier, nameof(identifier));
             var searchParams = identifier.ToSearchParams();
             var result = await client.SearchAsync<TResource>(searchParams).ConfigureAwait(false);
-            return result.ReadOneFromBundle<TResource>();
+            return await result.ReadOneFromBundleWithContinuationAsync<TResource>(client);
         }
 
         protected static async Task<TResource> CreateResourceByIdentityAsync<TResource>(IFhirClient client, Model.Identifier identifier, Action<TResource, Model.Identifier> propertySetter)

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         {
             var searchParams = identifier.ToSearchParams();
             var result = await _client.SearchAsync<Model.Observation>(searchParams).ConfigureAwait(false);
-            return result.ReadOneFromBundle<Model.Observation>();
+            return await result.ReadOneFromBundleWithContinuationAsync<Model.Observation>(_client);
         }
     }
 }

--- a/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/BundleExtensionsTests.cs
+++ b/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/BundleExtensionsTests.cs
@@ -1,0 +1,121 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
+using System.Collections.Generic;
+using NSubstitute;
+
+namespace Microsoft.Health.Extensions.Fhir.R4.UnitTests
+{
+    public class BundleExtensionsTests
+    {
+        [Fact]
+        public async void GivenNoEntriesAndNoContinuationToken_ReadOneFromBundleWithContinuationAsync_ThenNullIsReturned_Test()
+        {
+            var bundle = new Bundle();
+            bundle.Entry = new List<Bundle.EntryComponent>();
+            bundle.Link = new List<Bundle.LinkComponent>();
+
+            var client = Substitute.For<IFhirClient>();
+            client.ContinueAsync(Arg.Any<Bundle>()).Returns(System.Threading.Tasks.Task.FromResult<Bundle>(null));
+
+            Assert.Null(await bundle.ReadOneFromBundleWithContinuationAsync<Observation>(client));
+        }
+
+        [Fact]
+        public async void GivenOneEntryAndNoContinuationToken_ReadOneFromBundleWithContinuationAsync_ThenResourceIsReturned_Test()
+        {
+            var bundle = new Bundle();
+            bundle.Entry = new List<Bundle.EntryComponent>();
+            bundle.Link = new List<Bundle.LinkComponent>();
+
+            var observation = new Observation();
+            var entry = new Bundle.EntryComponent();
+            entry.Resource = observation;
+            bundle.Entry.Add(entry);
+
+            var client = Substitute.For<IFhirClient>();
+            client.ContinueAsync(Arg.Any<Bundle>()).Returns(System.Threading.Tasks.Task.FromResult<Bundle>(null));
+
+            Assert.Equal(observation, await bundle.ReadOneFromBundleWithContinuationAsync<Observation>(client));
+        }
+
+        [Fact]
+        public async void GivenOneEntryAfterContinuationToken_ReadOneFromBundleWithContinuationAsync_ThenResourceIsReturned_Test()
+        {
+            var bundle = new Bundle();
+            bundle.Entry = new List<Bundle.EntryComponent>();
+            bundle.Link = new List<Bundle.LinkComponent>();
+
+            var continuationBundle = new Bundle();
+            continuationBundle.Entry = new List<Bundle.EntryComponent>();
+            continuationBundle.Link = new List<Bundle.LinkComponent>();
+
+            var observation = new Observation();
+            var entry = new Bundle.EntryComponent();
+            entry.Resource = observation;
+            continuationBundle.Entry.Add(entry);
+
+            var client = Substitute.For<IFhirClient>();
+            client.ContinueAsync(Arg.Any<Bundle>()).Returns(ret => System.Threading.Tasks.Task.FromResult(continuationBundle), ret => System.Threading.Tasks.Task.FromResult<Bundle>(null));
+
+            Assert.Equal(observation, await bundle.ReadOneFromBundleWithContinuationAsync<Observation>(client));
+        }
+
+        [Fact]
+        public async void GivenTwoEntriesAndNoContinuationToken_ReadOneFromBundleWithContinuationAsync_ThenThrows_Test()
+        {
+            var bundle = new Bundle();
+            bundle.Entry = new List<Bundle.EntryComponent>();
+            bundle.Link = new List<Bundle.LinkComponent>();
+
+            var observation1 = new Observation();
+            var entry1 = new Bundle.EntryComponent();
+            entry1.Resource = observation1;
+            bundle.Entry.Add(entry1);
+
+            var observation2 = new Observation();
+            var entry2 = new Bundle.EntryComponent();
+            entry2.Resource = observation2;
+            bundle.Entry.Add(entry2);
+
+            var client = Substitute.For<IFhirClient>();
+            client.ContinueAsync(Arg.Any<Bundle>()).Returns(System.Threading.Tasks.Task.FromResult<Bundle>(null));
+
+            await Assert.ThrowsAsync<MultipleResourceFoundException<Observation>>(() => bundle.ReadOneFromBundleWithContinuationAsync<Observation>(client));
+        }
+
+        [Fact]
+        public async void GivenOneEntryBeforeAndAfterContinuationToken_ReadOneFromBundleWithContinuationAsync_ThenThrows_Test()
+        {
+            var bundle = new Bundle();
+            bundle.Entry = new List<Bundle.EntryComponent>();
+            bundle.Link = new List<Bundle.LinkComponent>();
+
+            var observation1 = new Observation();
+            var entry1 = new Bundle.EntryComponent();
+            entry1.Resource = observation1;
+            bundle.Entry.Add(entry1);
+
+            var continuationBundle = new Bundle();
+            continuationBundle.Entry = new List<Bundle.EntryComponent>();
+            continuationBundle.Link = new List<Bundle.LinkComponent>();
+
+            var observation2 = new Observation();
+            var entry2 = new Bundle.EntryComponent();
+            entry2.Resource = observation2;
+            continuationBundle.Entry.Add(entry2);
+
+            var client = Substitute.For<IFhirClient>();
+            client.ContinueAsync(Arg.Any<Bundle>()).Returns(ret => System.Threading.Tasks.Task.FromResult(continuationBundle), ret => System.Threading.Tasks.Task.FromResult<Bundle>(null));
+
+            await Assert.ThrowsAsync<MultipleResourceFoundException<Observation>>(() => bundle.ReadOneFromBundleWithContinuationAsync<Observation>(client));
+        }
+    }
+}

--- a/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/BundleExtensionsTests.cs
+++ b/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/BundleExtensionsTests.cs
@@ -3,13 +3,11 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using System.Threading.Tasks;
-using Xunit;
+using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
-using System.Collections.Generic;
 using NSubstitute;
+using Xunit;
 
 namespace Microsoft.Health.Extensions.Fhir.R4.UnitTests
 {

--- a/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/Microsoft.Health.Extensions.Fhir.R4.UnitTests.csproj
+++ b/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/Microsoft.Health.Extensions.Fhir.R4.UnitTests.csproj
@@ -23,8 +23,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Hl7.Fhir.R4" Version="1.2.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\lib\Microsoft.Health.Extensions.Fhir.R4\Microsoft.Health.Extensions.Fhir.R4.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/EventDataWithJsonBodyToJTokenConverterTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/EventDataWithJsonBodyToJTokenConverterTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Ingest.Data
         }
 
         [Theory]
-        [FileData(@"TestInput\data_IotHubPayloadExample.json")]
+        [FileData(@"TestInput/data_IotHubPayloadExample.json")]
         public void GivenIoTCentralPopulatedEvent_WhenConvert_ThenTokenWithNonSerializedBodyAndPropertiesReturned_Test(string json)
         {
             var evt = EventDataTestHelper.BuildEventFromJson(json);

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/CodeValueFhirTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/CodeValueFhirTemplateFactoryTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
     public class CodeValueFhirTemplateFactoryTests
     {
         [Theory]
-        [FileData(@"TestInput\data_CodeValueFhirTemplate_SampledData.json")]
+        [FileData(@"TestInput/data_CodeValueFhirTemplate_SampledData.json")]
         public void GivenValidTemplateJsonWithValueSampledDataType_WhenFactoryCreate_ThenTemplateCreated_Test(string json)
         {
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_CodeValueFhirTemplate_Components.json")]
+        [FileData(@"TestInput/data_CodeValueFhirTemplate_Components.json")]
         public void GivenValidTemplateJsonWithComponentValueSampledDataType_WhenFactoryCreate_ThenTemplateCreated_Test(string json)
         {
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_CodeValueFhirTemplate_CodeableConceptData.json")]
+        [FileData(@"TestInput/data_CodeValueFhirTemplate_CodeableConceptData.json")]
         public void GivenValidTemplateJsonWithCodeableConceptDataType_WhenFactoryCreate_ThenTemplateCreated_Test(string json)
         {
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
@@ -141,7 +141,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_CodeValueFhirTemplate_Quantity.json")]
+        [FileData(@"TestInput/data_CodeValueFhirTemplate_Quantity.json")]
         public void GivenValidTemplateJsonWithComponentValueQuantityType_WhenFactoryCreate_ThenTemplateCreated_Test(string json)
         {
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/CollectionContentTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/CollectionContentTemplateFactoryTests.cs
@@ -12,14 +12,14 @@ namespace Microsoft.Health.Fhir.Ingest.Template
     public class CollectionContentTemplateFactoryTests
     {
         [Theory]
-        [FileData(@"TestInput\data_CollectionContentTemplateEmpty.json")]
+        [FileData(@"TestInput/data_CollectionContentTemplateEmpty.json")]
         public void GivenEmptyConfig_WhenCreate_ThenInvalidTemplateException_Test(string json)
         {
             Assert.Throws<InvalidTemplateException>(() => CollectionContentTemplateFactory.Default.Create(json));
         }
 
         [Theory]
-        [FileData(@"TestInput\data_CollectionContentTemplateEmptyWithType.json")]
+        [FileData(@"TestInput/data_CollectionContentTemplateEmptyWithType.json")]
         public void GivenEmptyTemplateCollection_WhenCreate_ThenTemplateReturned_Test(string json)
         {
             var template = CollectionContentTemplateFactory.Default.Create(json);
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_CollectionContentTemplateMultipleMocks.json")]
+        [FileData(@"TestInput/data_CollectionContentTemplateMultipleMocks.json")]
         public void GivenInputWithMatchingFactories_WhenCreate_ThenTemplateReturned_Test(string json)
         {
             IContentTemplate nullReturn = null;
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_CollectionContentTemplateMultipleMocks.json")]
+        [FileData(@"TestInput/data_CollectionContentTemplateMultipleMocks.json")]
         public void GivenInputWithNoMatchingFactories_WhenCreate_ThenException_Test(string json)
         {
             IContentTemplate nullReturn = null;
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_CollectionFhirTemplateMixed.json")]
+        [FileData(@"TestInput/data_CollectionFhirTemplateMixed.json")]
         public void GivenInputWithMultipleTemplates_WhenCreate_ThenTemplateReturn_Test(string json)
         {
             var template = CollectionContentTemplateFactory.Default.Create(json);

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/CollectionFhirTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/CollectionFhirTemplateFactoryTests.cs
@@ -12,14 +12,14 @@ namespace Microsoft.Health.Fhir.Ingest.Template
     public class CollectionFhirTemplateFactoryTests
     {
         [Theory]
-        [FileData(@"TestInput\data_CollectionFhirTemplateEmpty.json")]
+        [FileData(@"TestInput/data_CollectionFhirTemplateEmpty.json")]
         public void GivenEmptyConfig_WhenCreate_ThenInvalidTemplateException_Test(string json)
         {
             Assert.Throws<InvalidTemplateException>(() => CollectionFhirTemplateFactory.Default.Create(json));
         }
 
         [Theory]
-        [FileData(@"TestInput\data_CollectionFhirTemplateEmptyWithType.json")]
+        [FileData(@"TestInput/data_CollectionFhirTemplateEmptyWithType.json")]
         public void GivenEmptyTemplateCollection_WhenCreate_ThenTemplateReturned_Test(string json)
         {
             var template = CollectionFhirTemplateFactory.Default.Create(json);
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_CollectionFhirTemplateMultipleMocks.json")]
+        [FileData(@"TestInput/data_CollectionFhirTemplateMultipleMocks.json")]
         public void GivenInputWithRegisteredFactories_WhenCreate_ThenTemplateReturned_Test(string json)
         {
             IFhirTemplate nullReturn = null;
@@ -56,7 +56,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_CollectionFhirTemplateMultipleMocks.json")]
+        [FileData(@"TestInput/data_CollectionFhirTemplateMultipleMocks.json")]
         public void GivenInputWithUnregisteredFactories_WhenCreate_ThenException_Test(string json)
         {
             IFhirTemplate nullReturn = null;

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/IotJsonPathContentTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/IotJsonPathContentTemplateFactoryTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
     public class IotJsonPathContentTemplateFactoryTests
     {
         [Theory]
-        [FileData(@"TestInput\data_IotJsonPathContentTemplateValid.json")]
+        [FileData(@"TestInput/data_IotJsonPathContentTemplateValid.json")]
         public void GivenValidTemplateJson_WhenFactoryCreate_ThenTemplateCreated_Test(string json)
         {
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_IotJsonPathContentTemplateValidWithOptional.json")]
+        [FileData(@"TestInput/data_IotJsonPathContentTemplateValidWithOptional.json")]
         public void GivenValidTemplateJsonWithOptionalExpressions_WhenFactoryCreate_ThenTemplateCreated_Test(string json)
         {
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/IotJsonPathContentTemplateTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/IotJsonPathContentTemplateTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         };
 
         [Theory]
-        [FileData(@"TestInput\data_IotHubPayloadExample.json")]
+        [FileData(@"TestInput/data_IotHubPayloadExample.json")]
         public void GivenTemplateAndSingleValidToken_WhenGetMeasurements_ThenSingleMeasurementReturned_Test(string eventJson)
         {
             var evt = EventDataTestHelper.BuildEventFromJson(eventJson);
@@ -58,7 +58,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_IotHubPayloadMultiValueExample.json")]
+        [FileData(@"TestInput/data_IotHubPayloadMultiValueExample.json")]
         public void GivenTemplateAndSingleMultiValueValidToken_WhenGetMeasurements_ThenSingleMeasurementReturned_Test(string eventJson)
         {
             var evt = EventDataTestHelper.BuildEventFromJson(eventJson);
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_IoTHubPayloadExampleMissingCreateTime.json")]
+        [FileData(@"TestInput/data_IoTHubPayloadExampleMissingCreateTime.json")]
         public void GivenTemplateAndSingleValidTokenWithoutCreationTime_WhenGetMeasurements_ThenSingleMeasurementReturned_Test(string eventJson)
         {
             var evt = EventDataTestHelper.BuildEventFromJson(eventJson);

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/JsonContentTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Template/JsonContentTemplateFactoryTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
     public class JsonContentTemplateFactoryTests
     {
         [Theory]
-        [FileData(@"TestInput\data_JsonPathContentTemplateValid.json")]
+        [FileData(@"TestInput/data_JsonPathContentTemplateValid.json")]
         public void GivenValidTemplateJson_WhenFactoryCreate_ThenTemplateCreated_Test(string json)
         {
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         }
 
         [Theory]
-        [FileData(@"TestInput\data_JsonPathContentTemplateValidWithOptional.json")]
+        [FileData(@"TestInput/data_JsonPathContentTemplateValidWithOptional.json")]
         public void GivenValidTemplateJsonWithOptionalExpressions_WhenFactoryCreate_ThenTemplateCreated_Test(string json)
         {
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);


### PR DESCRIPTION
A condition exists, where, a search request can return an empty bundle with a continuation token. The ReadOneFromBundle method assumed that if any Resource meeting the search criteria was found, the first bundle returned would contain at least one resource.

These changes include:

- A fix to ensure the continuation token is respected.
- Fixes to unit tests so they can be run on Linux and Mac machines.
- An update to the .gitignore file to ignore Mac OS system files.