### PR TITLE
Fixed issue where observation version conflicts weren't always handled

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
@@ -68,18 +68,23 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             else
             {
                 var policyResult = await Policy<Model.Observation>
-                     .Handle<FhirOperationException>(ex => ex.Status == System.Net.HttpStatusCode.Conflict)
-                     .FallbackAsync(async ct =>
+                     .Handle<FhirOperationException>(ex => ex.Status == System.Net.HttpStatusCode.Conflict || ex.Status == System.Net.HttpStatusCode.PreconditionFailed)
+                     .RetryAsync(2, async (polyRes, attempt) =>
                      {
-                         var refreshObservation = await GetObservationFromServerAsync(identifier).ConfigureAwait(false);
-                         var mergedObservation = MergeObservation(config, refreshObservation, observationGroup);
-                         return await _client.UpdateAsync(mergedObservation, versionAware: true).ConfigureAwait(false);
+                         existingObservation = await GetObservationFromServerAsync(identifier).ConfigureAwait(false);
                      })
                      .ExecuteAndCaptureAsync(async () =>
                      {
                          var mergedObservation = MergeObservation(config, existingObservation, observationGroup);
                          return await _client.UpdateAsync(mergedObservation, versionAware: true).ConfigureAwait(false);
                      }).ConfigureAwait(false);
+
+                var exception = policyResult.FinalException;
+
+                if (exception != null)
+                {
+                    throw exception;
+                }
 
                 result = policyResult.Result;
             }


### PR DESCRIPTION
The FHIR Server may respond with either a 409 Conflict or a 412 Precondition Failed if a PUT operation is performed on an Observation Resource and the Version Id is not identical. The current code handles 409 but not 412.

This pull request includes:

- Support for handling a 412 response.
- Updating retry logic to happen 2 times (3 attempts total) if a update fails because of a version conflict.
- A fix that was causing exceptions that happened while trying to update an Observation to be 'swallowed'.