### PR TITLE
Fixed issue that caused token audience to be incorrect

### DIFF
--- a/deploy/templates/default-azuredeploy-sandbox.json
+++ b/deploy/templates/default-azuredeploy-sandbox.json
@@ -217,8 +217,7 @@
     "iot_central_name": "[parameters('ServiceName')]",
     "fhir_service_name": "[parameters('ServiceName')]",
     "fhir_service_url": "[concat('https://', parameters('ServiceName'),'.azurehealthcareapis.com')]",
-    "fhir_service_cosmos_throughput": 1000,
-    "aad_fhir_server_audience": "[concat('https://', parameters('ServiceName'),'.azurehealthcareapis.com')]"
+    "fhir_service_cosmos_throughput": 1000
   },
   "resources": [
     {
@@ -231,7 +230,7 @@
       "properties": {
         "accessPolicies": "[parameters('FhirServiceAccessPolicies')]",
         "authenticationConfiguration": {
-          "audience": "[variables('aad_fhir_server_audience')]",
+          "audience": "[variables('fhir_service_url')]",
           "authority": "[parameters('FhirServiceAuthority')]",
           "smartProxyEnabled": true
         },

--- a/deploy/templates/default-azuredeploy-sandbox.json
+++ b/deploy/templates/default-azuredeploy-sandbox.json
@@ -218,7 +218,7 @@
     "fhir_service_name": "[parameters('ServiceName')]",
     "fhir_service_url": "[concat('https://', parameters('ServiceName'),'.azurehealthcareapis.com')]",
     "fhir_service_cosmos_throughput": 1000,
-    "aad_fhir_server_audience": "https://azurehealthcareapis.com"
+    "aad_fhir_server_audience": "[concat('https://', parameters('ServiceName'),'.azurehealthcareapis.com')]"
   },
   "resources": [
     {


### PR DESCRIPTION
The Sandbox ARM template would set Audience in the authentication settings to "https://azurehealthcareapis.com" instead of "https://{SERVICE_NAME}.azurehealthcareapis.com". This causes tokens issued to the service client application to be denied access to the FHIR Server.