### PR TITLE
Fix a mismatch in the FHIR  server audience in the sandbox deployment

### DIFF
--- a/deploy/scripts/Create-IomtFhirSandboxEnvironment.ps1
+++ b/deploy/scripts/Create-IomtFhirSandboxEnvironment.ps1
@@ -99,8 +99,6 @@ $iomtConnectorTemplate = "${githubRawBaseUrl}/${SourceRevision}/deploy/templates
 $tenantDomain = $tenantInfo.TenantDomain
 $aadAuthority = "https://login.microsoftonline.com/${tenantDomain}"
 
-$fhirServiceResource = "https://azurehealthcareapis.com"
-
 $fhirServerUrl = "https://${EnvironmentName}.azurehealthcareapis.com"
 
 $serviceClientId = (Get-AzKeyVaultSecret -VaultName "${EnvironmentName}-ts" -Name "${EnvironmentName}-service-client-id").SecretValueText
@@ -113,7 +111,7 @@ $accessPolicies += @{ "objectId" = $serviceClientObjectId.ToString() }
 
 # Deploy the template
 Write-Host "Deploying resources..."
-New-AzResourceGroupDeployment -TemplateFile $sandboxTemplate -ResourceGroupName $EnvironmentName -ServiceName $EnvironmentName -FhirServiceLocation $FhirApiLocation -FhirServiceAuthority $aadAuthority -FhirServiceResource $fhirServiceResource -FhirServiceClientId $serviceClientId -FhirServiceClientSecret $serviceClientSecret -FhirServiceAccessPolicies $accessPolicies -RepositoryUrl $SourceRepository -RepositoryBranch $SourceRevision -FhirServiceUrl $fhirServerUrl -ResourceLocation $EnvironmentLocation -IomtConnectorTemplateUrl $iomtConnectorTemplate
+New-AzResourceGroupDeployment -TemplateFile $sandboxTemplate -ResourceGroupName $EnvironmentName -ServiceName $EnvironmentName -FhirServiceLocation $FhirApiLocation -FhirServiceAuthority $aadAuthority -FhirServiceResource $fhirServerUrl -FhirServiceClientId $serviceClientId -FhirServiceClientSecret $serviceClientSecret -FhirServiceAccessPolicies $accessPolicies -RepositoryUrl $SourceRepository -RepositoryBranch $SourceRevision -FhirServiceUrl $fhirServerUrl -ResourceLocation $EnvironmentLocation -IomtConnectorTemplateUrl $iomtConnectorTemplate
 
 # Copy the config templates to storage
 Write-Host "Copying templates to storage..."

--- a/deploy/templates/default-azuredeploy-sandbox.json
+++ b/deploy/templates/default-azuredeploy-sandbox.json
@@ -230,7 +230,7 @@
       "properties": {
         "accessPolicies": "[parameters('FhirServiceAccessPolicies')]",
         "authenticationConfiguration": {
-          "audience": "[variables('fhir_service_url')]",
+          "audience": "[parameters('FhirServiceResource')]",
           "authority": "[parameters('FhirServiceAuthority')]",
           "smartProxyEnabled": true
         },


### PR DESCRIPTION
In fixing the FHIR server audience previously for SMART on FHIR apps, a second place was missed, causing a mismatch that didn't allow the sandbox connector to write into the FHIR server. Both the Connector and the FHIR server now use the same parameter, and the fixed audience is passed in on that parameter.