### PR TITLE
Remove default value from ARM template resource location

### DIFF
--- a/deploy/templates/consumption-azuredeploy.json
+++ b/deploy/templates/consumption-azuredeploy.json
@@ -103,7 +103,6 @@
         "UK West",
         "UK South"
       ],
-      "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "The location of the deployed resources."
       }

--- a/deploy/templates/default-azuredeploy-sandbox.json
+++ b/deploy/templates/default-azuredeploy-sandbox.json
@@ -124,7 +124,6 @@
         "UK West",
         "UK South"
       ],
-      "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "The location of the deployed resources."
       }

--- a/deploy/templates/default-azuredeploy.json
+++ b/deploy/templates/default-azuredeploy.json
@@ -124,7 +124,6 @@
         "UK West",
         "UK South"
       ],
-      "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "The location of the deployed resources."
       }

--- a/deploy/templates/premium-azuredeploy.json
+++ b/deploy/templates/premium-azuredeploy.json
@@ -103,7 +103,6 @@
         "UK West",
         "UK South"
       ],
-      "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "The location of the deployed resources."
       }


### PR DESCRIPTION
Remove default value from ARM template resource location. Function didn't work as intended and prevented field from showing as required in template editor.

#27 