### PR TITLE
support docker containers for functions code

### DIFF
--- a/DockerRun.ps1
+++ b/DockerRun.ps1
@@ -1,0 +1,39 @@
+<#
+    This script can be used to build and run the IoMT Azure Function code in a docker container.
+    It can be used for local development to build and run Docker images, and images can be used for cloud deployment.
+    By default console logging is turned on, but can be turned off by removing AzureFunctionsJobHost__Logging__Console__IsEnabled
+    One caveat with local development is that Docker cannot easily communicate with the Azure Storage Emulator, and it is easiest use a cloud storage container instead.
+#>
+
+if(-not (Test-Path .\src\func\Microsoft.Health.Fhir.Ingest.Host\local.settings.json)) {
+    Write-Output 'Could not locate local.settings.json'
+    Exit
+}
+
+$json = Get-Content .\src\func\Microsoft.Health.Fhir.Ingest.Host\local.settings.json | ConvertFrom-Json
+$env = $json.Values
+
+if($env.AzureWebJobsStorage -eq "UseDevelopmentStorage=true") {
+    Write-Output 'Setting "AzureWebJobsStorage":"UseDevelopmentStorage=true" in local.settings.json not supported with Docker, must use connection string'
+    Exit
+}
+
+docker build --tag iomt:v1.0.0 .
+docker run -p 8080:80 `
+    -e AzureFunctionsJobHost__Logging__Console__IsEnabled='true' `
+    -e AzureWebJobsScriptRoot='/home/site/wwwroot' `
+    -e AzureWebJobsStorage="$($env."AzureWebJobsStorage")" `
+    -e AzureWebJobsSecretStorageType="$($env."AzureWebJobsSecretStorageType")" `
+    -e FhirService:Authority="$($env."FhirService:Authority")" `
+    -e FhirService:ClientId="$($env."FhirService:ClientId")" `
+    -e FhirService:ClientSecret="$($env."FhirService:ClientSecret")" `
+    -e FhirService:Resource="$($env."FhirService:Resource")" `
+    -e FhirService:Url="$($env."FhirService:Url")" `
+    -e FUNCTIONS_WORKER_RUNTIME="$($env."FUNCTIONS_WORKER_RUNTIME")" `
+    -e InputEventHub="$($env."InputEventHub")" `
+    -e OutputEventHub="$($env."OutputEventHub")" `
+    -e ResourceIdentity:ResourceIdentityServiceType="$($env."ResourceIdentity:ResourceIdentityServiceType")" `
+    -e ResourceIdentity:DefaultDeviceIdentifierSystem="$($env."ResourceIdentity:DefaultDeviceIdentifierSystem")" `
+    -e Template:DeviceContent="$($env."Template:DeviceContent")" `
+    -e Template:FhirMapping="$($env."Template:FhirMapping")" `
+    -it iomt:v1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS installer-env
+
+COPY ./src/func/Microsoft.Health.Fhir.Ingest.Host/ /src/iomt
+COPY ./src/lib/ /lib
+ADD stylecop.json /
+ADD CustomAnalysisRules.ruleset /
+
+RUN cd /src/iomt && \
+    mkdir -p /home/site/wwwroot && \
+    dotnet publish *.csproj --output /home/site/wwwroot
+
+FROM mcr.microsoft.com/azure-functions/dotnet:3.0
+
+COPY --from=installer-env ["/home/site/wwwroot", "/home/site/wwwroot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS installer-env
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS installer-env
 
 COPY ./src/func/Microsoft.Health.Fhir.Ingest.Host/ /src/iomt
 COPY ./src/lib/ /lib
@@ -9,6 +9,6 @@ RUN cd /src/iomt && \
     mkdir -p /home/site/wwwroot && \
     dotnet publish *.csproj --output /home/site/wwwroot
 
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0
+FROM mcr.microsoft.com/azure-functions/dotnet:2.0
 
 COPY --from=installer-env ["/home/site/wwwroot", "/home/site/wwwroot"]

--- a/deploy/docker/DockerRun.ps1
+++ b/deploy/docker/DockerRun.ps1
@@ -3,6 +3,7 @@
     It can be used for local development to build and run Docker images, and images can be used for cloud deployment.
     By default console logging is turned on, but can be turned off by removing AzureFunctionsJobHost__Logging__Console__IsEnabled
     One caveat with local development is that Docker cannot easily communicate with the Azure Storage Emulator, and it is easiest use a cloud storage container instead.
+    Run this script from the project root .\deploy\docker\DockerRun.ps1
 #>
 
 if(-not (Test-Path .\src\func\Microsoft.Health.Fhir.Ingest.Host\local.settings.json)) {

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -13,7 +13,6 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.11" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="3.0.5" />

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
@@ -13,7 +13,6 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.11" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.6" />
@@ -21,11 +20,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.28" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
     <PackageReference Include="Ensure.That" Version="8.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
@@ -13,8 +13,11 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.11" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="3.0.5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
@@ -24,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.28" />
     <PackageReference Include="Ensure.That" Version="8.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>

--- a/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
+++ b/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>

--- a/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
+++ b/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Extensions.Fhir/Microsoft.Health.Extensions.Fhir.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/Microsoft.Health.Extensions.Fhir.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>

--- a/src/lib/Microsoft.Health.Extensions.Fhir/Microsoft.Health.Extensions.Fhir.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/Microsoft.Health.Extensions.Fhir.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>

--- a/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <AssemblyName>Microsoft.Health.Fhir.Ingest</AssemblyName>
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.4" />
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <AssemblyName>Microsoft.Health.Fhir.Ingest</AssemblyName>

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Microsoft.Health.Fhir.R4.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Microsoft.Health.Fhir.R4.Ingest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <AssemblyName>Microsoft.Health.Fhir.Ingest.R4</AssemblyName>
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.0.0" />
     <PackageReference Include="Hl7.Fhir.R4" Version="1.2.1" />
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Microsoft.Health.Fhir.R4.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Microsoft.Health.Fhir.R4.Ingest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <AssemblyName>Microsoft.Health.Fhir.Ingest.R4</AssemblyName>

--- a/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
+++ b/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
@@ -12,7 +12,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/Microsoft.Health.Extensions.Fhir.R4.UnitTests.csproj
+++ b/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/Microsoft.Health.Extensions.Fhir.R4.UnitTests.csproj
@@ -11,7 +11,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Extensions.Fhir.UnitTests/Microsoft.Health.Extensions.Fhir.UnitTests.csproj
+++ b/test/Microsoft.Health.Extensions.Fhir.UnitTests/Microsoft.Health.Extensions.Fhir.UnitTests.csproj
@@ -11,7 +11,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
@@ -13,7 +13,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj
@@ -13,7 +13,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Tests.Common/Microsoft.Health.Tests.Common.csproj
+++ b/test/Microsoft.Health.Tests.Common/Microsoft.Health.Tests.Common.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.10.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This PR may be controversial since it requires some package references to be updated.

"Microsoft.Net.Compilers" was changed to "Microsoft.Net.Compilers.Toolset" since only the Toolset can successfully compile for Linux. 

"Microsoft.Net.Compilers" also appeared to be deprecated, so we should probably migrate off of it anyway. https://github.com/dotnet/roslyn/issues/40129#issuecomment-565661236

The controversial part is that switching to Microsoft.Net.Compilers.Toolset seems to require Microsoft.NET.Sdk.Functions to be upgraded and TargetFramework to be updated to 3.1
