### PR TITLE
Include TemplateNotFound in the handled exceptions

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/ExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/ExceptionTelemetryProcessor.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Extensions.Fhir;
 using Microsoft.Health.Fhir.Ingest.Service;
+using Microsoft.Health.Fhir.Ingest.Template;
 
 namespace Microsoft.Health.Fhir.Ingest.Telemetry
 {
@@ -23,7 +24,8 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
                 typeof(ResourceIdentityNotDefinedException),
                 typeof(NotSupportedException),
                 typeof(FhirResourceNotFoundException),
-                typeof(MultipleResourceFoundException<>))
+                typeof(MultipleResourceFoundException<>),
+                typeof(TemplateNotFoundException))
         {
         }
 

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/ExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/ExceptionTelemetryProcessorTests.cs
@@ -7,6 +7,7 @@ using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Extensions.Fhir;
 using Microsoft.Health.Fhir.Ingest.Service;
+using Microsoft.Health.Fhir.Ingest.Template;
 using NSubstitute;
 using Xunit;
 
@@ -20,6 +21,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
         [InlineData(typeof(NotSupportedException))]
         [InlineData(typeof(FhirResourceNotFoundException))]
         [InlineData(typeof(ResourceIdentityNotDefinedException))]
+        [InlineData(typeof(TemplateNotFoundException))]
         public void GivenHandledExceptionTypes_WhenHandleExpection_ThenMetricLoggedAndTrueReturned_Test(Type exType)
         {
             var log = Substitute.For<ILogger>();


### PR DESCRIPTION
When a FhirMappingTemplate isn't found it currently causes an internal server error and prevents the stream analytics job from proceeding.  Change behavior to capture exception and report as telemetry.