### PR TITLE
Update the resource identity service type with Assembly attribute and short names

### DIFF
--- a/deploy/templates/consumption-azuredeploy.json
+++ b/deploy/templates/consumption-azuredeploy.json
@@ -180,7 +180,8 @@
     "app_service_resource_id": "[resourceId('Microsoft.Web/sites', variables('app_service_name'))]",
     "deploy_source_code": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
     "sender_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '2b629674-e913-4c01-ae53-ef4638d8f975')]",
-    "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]"
+    "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]",
+    "iomt_fhir_connector_name": "[concat(parameters('FhirVersion'), ':', 'ResourceIdentity', parameters('ResourceIdentityServiceType'))]"
   },
   "resources": [
     {
@@ -196,7 +197,7 @@
         "[resourceId('Microsoft.EventHub/namespaces/eventhubs/consumergroups', variables('eventhub_namespace_name'), 'normalizeddata', '$Default')]"
       ],
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "identity": {
         "type": "SystemAssigned"
@@ -274,7 +275,7 @@
       "name": "[variables('eventhub_namespace_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "Standard",
@@ -430,7 +431,7 @@
       "name": "[variables('storage_account_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "Standard_RAGRS",
@@ -496,7 +497,7 @@
       "name": "[variables('app_plan_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "Y1",
@@ -523,7 +524,7 @@
       "name": "[variables('app_service_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('app_plan_name'))]",
@@ -707,7 +708,7 @@
       "name": "[variables('app_insights_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "kind": "web",
       "properties": {
@@ -722,7 +723,7 @@
       "name": "[variables('key_vault_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "dependsOn": [
         "[variables('app_service_resource_id')]"

--- a/deploy/templates/consumption-azuredeploy.json
+++ b/deploy/templates/consumption-azuredeploy.json
@@ -150,11 +150,11 @@
     "ResourceIdentityServiceType": {
       "type": "string",
       "allowedValues": [
-        "R4DeviceAndPatientLookupIdentityService",
-        "R4DeviceAndPatientCreateIdentityService",
-        "R4DeviceAndPatientWithEncounterLookupIdentityService"
+        "Lookup",
+        "Create",
+        "LookupWithEncounter"
       ],
-      "defaultValue": "R4DeviceAndPatientLookupIdentityService",
+      "defaultValue": "Lookup",
       "metadata": {
         "description": "Configures how patient, device, and other FHIR resource identities are resolved from the ingested data stream."
       }

--- a/deploy/templates/consumption-azuredeploy.json
+++ b/deploy/templates/consumption-azuredeploy.json
@@ -181,7 +181,7 @@
     "deploy_source_code": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
     "sender_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '2b629674-e913-4c01-ae53-ef4638d8f975')]",
     "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]",
-    "iomt_fhir_connector_name": "[concat(parameters('FhirVersion'), ':', 'ResourceIdentity', parameters('ResourceIdentityServiceType'))]"
+    "iomt_fhir_connector_name": "[concat('ResourceIdentity', ':', parameters('ResourceIdentityServiceType'))]"
   },
   "resources": [
     {
@@ -197,7 +197,8 @@
         "[resourceId('Microsoft.EventHub/namespaces/eventhubs/consumergroups', variables('eventhub_namespace_name'), 'normalizeddata', '$Default')]"
       ],
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "identity": {
         "type": "SystemAssigned"
@@ -275,7 +276,8 @@
       "name": "[variables('eventhub_namespace_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "Standard",
@@ -431,7 +433,8 @@
       "name": "[variables('storage_account_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "Standard_RAGRS",
@@ -497,7 +500,8 @@
       "name": "[variables('app_plan_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "Y1",
@@ -524,7 +528,8 @@
       "name": "[variables('app_service_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('app_plan_name'))]",
@@ -708,7 +713,8 @@
       "name": "[variables('app_insights_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "kind": "web",
       "properties": {
@@ -723,7 +729,8 @@
       "name": "[variables('key_vault_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "dependsOn": [
         "[variables('app_service_resource_id')]"

--- a/deploy/templates/default-azuredeploy-sandbox.json
+++ b/deploy/templates/default-azuredeploy-sandbox.json
@@ -171,11 +171,11 @@
     "ResourceIdentityServiceType": {
       "type": "string",
       "allowedValues": [
-        "R4DeviceAndPatientLookupIdentityService",
-        "R4DeviceAndPatientCreateIdentityService",
-        "R4DeviceAndPatientWithEncounterLookupIdentityService"
+        "Lookup",
+        "Create",
+        "LookupWithEncounter"
       ],
-      "defaultValue": "R4DeviceAndPatientCreateIdentityService",
+      "defaultValue": "Create",
       "metadata": {
         "description": "Configures how patient, device, and other FHIR resource identities are resolved from the ingested data stream."
       }

--- a/deploy/templates/default-azuredeploy.json
+++ b/deploy/templates/default-azuredeploy.json
@@ -201,7 +201,8 @@
     "app_service_resource_id": "[resourceId('Microsoft.Web/sites', variables('app_service_name'))]",
     "deploy_source_code": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
     "sender_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '2b629674-e913-4c01-ae53-ef4638d8f975')]",
-    "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]"
+    "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]",
+    "iomt_fhir_connector_name": "[concat(parameters('FhirVersion'), ':', 'ResourceIdentity', parameters('ResourceIdentityServiceType'))]"
   },
   "resources": [
     {
@@ -217,7 +218,7 @@
         "[resourceId('Microsoft.EventHub/namespaces/eventhubs/consumergroups', variables('eventhub_namespace_name'), 'normalizeddata', '$Default')]"
       ],
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "identity": {
         "type": "SystemAssigned"
@@ -295,7 +296,7 @@
       "name": "[variables('eventhub_namespace_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "Standard",
@@ -451,7 +452,7 @@
       "name": "[variables('storage_account_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "Standard_RAGRS",
@@ -517,7 +518,7 @@
       "name": "[variables('app_plan_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "[parameters('AppServicePlanSku')]"
@@ -537,7 +538,7 @@
       "name": "[variables('app_service_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('app_plan_name'))]",
@@ -721,7 +722,7 @@
       "name": "[variables('app_insights_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "kind": "web",
       "properties": {
@@ -736,7 +737,7 @@
       "name": "[variables('key_vault_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "dependsOn": [
         "[variables('app_service_resource_id')]"

--- a/deploy/templates/default-azuredeploy.json
+++ b/deploy/templates/default-azuredeploy.json
@@ -202,7 +202,7 @@
     "deploy_source_code": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
     "sender_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '2b629674-e913-4c01-ae53-ef4638d8f975')]",
     "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]",
-    "iomt_fhir_connector_name": "[concat(parameters('FhirVersion'), ':', 'ResourceIdentity', parameters('ResourceIdentityServiceType'))]"
+    "iomt_fhir_connector_name": "[concat('ResourceIdentity', ':', parameters('ResourceIdentityServiceType'))]"
   },
   "resources": [
     {
@@ -218,7 +218,8 @@
         "[resourceId('Microsoft.EventHub/namespaces/eventhubs/consumergroups', variables('eventhub_namespace_name'), 'normalizeddata', '$Default')]"
       ],
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "identity": {
         "type": "SystemAssigned"
@@ -296,7 +297,8 @@
       "name": "[variables('eventhub_namespace_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "Standard",
@@ -452,7 +454,8 @@
       "name": "[variables('storage_account_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "Standard_RAGRS",
@@ -518,7 +521,8 @@
       "name": "[variables('app_plan_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "[parameters('AppServicePlanSku')]"
@@ -538,7 +542,8 @@
       "name": "[variables('app_service_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('app_plan_name'))]",
@@ -722,7 +727,8 @@
       "name": "[variables('app_insights_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "kind": "web",
       "properties": {
@@ -737,7 +743,8 @@
       "name": "[variables('key_vault_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "dependsOn": [
         "[variables('app_service_resource_id')]"

--- a/deploy/templates/default-azuredeploy.json
+++ b/deploy/templates/default-azuredeploy.json
@@ -171,11 +171,11 @@
     "ResourceIdentityServiceType": {
       "type": "string",
       "allowedValues": [
-        "R4DeviceAndPatientLookupIdentityService",
-        "R4DeviceAndPatientCreateIdentityService",
-        "R4DeviceAndPatientWithEncounterLookupIdentityService"
+        "Lookup",
+        "Create",
+        "LookupWithEncounter"
       ],
-      "defaultValue": "R4DeviceAndPatientLookupIdentityService",
+      "defaultValue": "Lookup",
       "metadata": {
         "description": "Configures how patient, device, and other FHIR resource identities are resolved from the ingested data stream."
       }

--- a/deploy/templates/managed-identity-azuredeploy.json
+++ b/deploy/templates/managed-identity-azuredeploy.json
@@ -177,7 +177,8 @@
     "app_service_resource_id": "[resourceId('Microsoft.Web/sites', variables('app_service_name'))]",
     "deploy_source_code": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
     "sender_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '2b629674-e913-4c01-ae53-ef4638d8f975')]",
-    "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]"
+    "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]",
+    "iomt_fhir_connector_name": "[concat(parameters('FhirVersion'), ':', 'ResourceIdentity', parameters('ResourceIdentityServiceType'))]"
   },
   "resources": [
     {
@@ -193,7 +194,7 @@
         "[resourceId('Microsoft.EventHub/namespaces/eventhubs/consumergroups', variables('eventhub_namespace_name'), 'normalizeddata', '$Default')]"
       ],
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "identity": {
         "type": "SystemAssigned"
@@ -271,7 +272,7 @@
       "name": "[variables('eventhub_namespace_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "Standard",
@@ -427,7 +428,7 @@
       "name": "[variables('storage_account_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "Standard_RAGRS",
@@ -493,7 +494,7 @@
       "name": "[variables('app_plan_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "[parameters('AppServicePlanSku')]"
@@ -513,7 +514,7 @@
       "name": "[variables('app_service_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('app_plan_name'))]",
@@ -690,7 +691,7 @@
       "name": "[variables('app_insights_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "kind": "web",
       "properties": {
@@ -705,7 +706,7 @@
       "name": "[variables('key_vault_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "dependsOn": [
         "[variables('app_service_resource_id')]"

--- a/deploy/templates/managed-identity-azuredeploy.json
+++ b/deploy/templates/managed-identity-azuredeploy.json
@@ -147,11 +147,11 @@
     "ResourceIdentityServiceType": {
       "type": "string",
       "allowedValues": [
-        "R4DeviceAndPatientLookupIdentityService",
-        "R4DeviceAndPatientCreateIdentityService",
-        "R4DeviceAndPatientWithEncounterLookupIdentityService"
+        "Lookup",
+        "Create",
+        "LookupWithEncounter"
       ],
-      "defaultValue": "R4DeviceAndPatientLookupIdentityService",
+      "defaultValue": "Lookup",
       "metadata": {
         "description": "Configures how patient, device, and other FHIR resource identities are resolved from the ingested data stream."
       }

--- a/deploy/templates/managed-identity-azuredeploy.json
+++ b/deploy/templates/managed-identity-azuredeploy.json
@@ -178,7 +178,7 @@
     "deploy_source_code": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
     "sender_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '2b629674-e913-4c01-ae53-ef4638d8f975')]",
     "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]",
-    "iomt_fhir_connector_name": "[concat(parameters('FhirVersion'), ':', 'ResourceIdentity', parameters('ResourceIdentityServiceType'))]"
+    "iomt_fhir_connector_name": "[concat('ResourceIdentity', ':', parameters('ResourceIdentityServiceType'))]"
   },
   "resources": [
     {
@@ -194,7 +194,8 @@
         "[resourceId('Microsoft.EventHub/namespaces/eventhubs/consumergroups', variables('eventhub_namespace_name'), 'normalizeddata', '$Default')]"
       ],
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "identity": {
         "type": "SystemAssigned"
@@ -272,7 +273,8 @@
       "name": "[variables('eventhub_namespace_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "Standard",
@@ -428,7 +430,8 @@
       "name": "[variables('storage_account_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "Standard_RAGRS",
@@ -494,7 +497,8 @@
       "name": "[variables('app_plan_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "[parameters('AppServicePlanSku')]"
@@ -514,7 +518,8 @@
       "name": "[variables('app_service_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('app_plan_name'))]",
@@ -691,7 +696,8 @@
       "name": "[variables('app_insights_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "kind": "web",
       "properties": {
@@ -706,7 +712,8 @@
       "name": "[variables('key_vault_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "dependsOn": [
         "[variables('app_service_resource_id')]"

--- a/deploy/templates/premium-azuredeploy.json
+++ b/deploy/templates/premium-azuredeploy.json
@@ -180,7 +180,8 @@
     "app_service_resource_id": "[resourceId('Microsoft.Web/sites', variables('app_service_name'))]",
     "deploy_source_code": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
     "sender_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '2b629674-e913-4c01-ae53-ef4638d8f975')]",
-    "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]"
+    "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]",
+    "iomt_fhir_connector_name": "[concat(parameters('FhirVersion'), ':', 'ResourceIdentity', parameters('ResourceIdentityServiceType'))]"
   },
   "resources": [
     {
@@ -196,7 +197,7 @@
         "[resourceId('Microsoft.EventHub/namespaces/eventhubs/consumergroups', variables('eventhub_namespace_name'), 'normalizeddata', '$Default')]"
       ],
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "identity": {
         "type": "SystemAssigned"
@@ -274,7 +275,7 @@
       "name": "[variables('eventhub_namespace_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "Standard",
@@ -430,7 +431,7 @@
       "name": "[variables('storage_account_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "Standard_RAGRS",
@@ -496,7 +497,7 @@
       "name": "[variables('app_plan_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "sku": {
         "name": "EP1",
@@ -523,7 +524,7 @@
       "name": "[variables('app_service_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('app_plan_name'))]",
@@ -707,7 +708,7 @@
       "name": "[variables('app_insights_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "kind": "web",
       "properties": {
@@ -722,7 +723,7 @@
       "name": "[variables('key_vault_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[parameters('ResourceIdentityServiceType')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
       },
       "dependsOn": [
         "[variables('app_service_resource_id')]"

--- a/deploy/templates/premium-azuredeploy.json
+++ b/deploy/templates/premium-azuredeploy.json
@@ -150,11 +150,11 @@
     "ResourceIdentityServiceType": {
       "type": "string",
       "allowedValues": [
-        "R4DeviceAndPatientLookupIdentityService",
-        "R4DeviceAndPatientCreateIdentityService",
-        "R4DeviceAndPatientWithEncounterLookupIdentityService"
+        "Lookup",
+        "Create",
+        "LookupWithEncounter"
       ],
-      "defaultValue": "R4DeviceAndPatientLookupIdentityService",
+      "defaultValue": "Lookup",
       "metadata": {
         "description": "Configures how patient, device, and other FHIR resource identities are resolved from the ingested data stream."
       }

--- a/deploy/templates/premium-azuredeploy.json
+++ b/deploy/templates/premium-azuredeploy.json
@@ -181,7 +181,7 @@
     "deploy_source_code": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
     "sender_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '2b629674-e913-4c01-ae53-ef4638d8f975')]",
     "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]",
-    "iomt_fhir_connector_name": "[concat(parameters('FhirVersion'), ':', 'ResourceIdentity', parameters('ResourceIdentityServiceType'))]"
+    "iomt_fhir_connector_name": "[concat('ResourceIdentity', ':', parameters('ResourceIdentityServiceType'))]"
   },
   "resources": [
     {
@@ -197,7 +197,8 @@
         "[resourceId('Microsoft.EventHub/namespaces/eventhubs/consumergroups', variables('eventhub_namespace_name'), 'normalizeddata', '$Default')]"
       ],
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "identity": {
         "type": "SystemAssigned"
@@ -275,7 +276,8 @@
       "name": "[variables('eventhub_namespace_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "Standard",
@@ -431,7 +433,8 @@
       "name": "[variables('storage_account_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "Standard_RAGRS",
@@ -497,7 +500,8 @@
       "name": "[variables('app_plan_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "sku": {
         "name": "EP1",
@@ -524,7 +528,8 @@
       "name": "[variables('app_service_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('app_plan_name'))]",
@@ -708,7 +713,8 @@
       "name": "[variables('app_insights_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "kind": "web",
       "properties": {
@@ -723,7 +729,8 @@
       "name": "[variables('key_vault_name')]",
       "location": "[parameters('ResourceLocation')]",
       "tags": {
-        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]"
+        "IomtFhirConnector": "[variables('iomt_fhir_connector_name')]",
+        "IomtFhirVersion": "[parameters('FhirVersion')]"
       },
       "dependsOn": [
         "[variables('app_service_resource_id')]"

--- a/docs/ARMInstallation.md
+++ b/docs/ARMInstallation.md
@@ -50,9 +50,9 @@ The following parameters are provided by the ARM template:
 
 |Type|Behavior
 |---|---
-|**R4DeviceAndPatientLookupIdentityService**|Default setting.  Device identifier from ingested messages is retrieved from the FHIR server. Patient is expected to be linked to the device.
-|**R4DeviceAndPatientCreateIdentityService**|System attempts to retrieve the device identifier and associated patient from the FHIR server. If either isn't found a shell resource with just the identity will be created. Requires a patient identifier be mapped in the device content configuration template.
-|**R4DeviceAndPatientWithEncounterLookupIdentityService**|Like the first setting but allows you to include an encounter identifier with the message to associate with the device/patient.  The encounter is looked up during processing and any observations created are linked to the encounter. The association here is assumed to be one encounter per device.
+|**Lookup**|Default setting.  Device identifier from ingested messages is retrieved from the FHIR server. Patient is expected to be linked to the device.
+|**Create**|System attempts to retrieve the device identifier and associated patient from the FHIR server. If either isn't found a shell resource with just the identity will be created. Requires a patient identifier be mapped in the device content configuration template.
+|**LookupWithEncounter**|Like the first setting but allows you to include an encounter identifier with the message to associate with the device/patient.  The encounter is looked up during processing and any observations created are linked to the encounter. The association here is assumed to be one encounter per device.
 
 ## Post Deployment
 After the ARM template is successfully deployed the mapping configurations for device content and converting to FHIR need to be added to the template container in the deployed Azure Storage blob.  You can use a tool like [Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/) to easily upload and update the configurations. Navigate to the Azure Storage account deployed by the ARM template (it will be service name you selected) and select the template storage to container.  From there upload the configurations and you are done.

--- a/docs/ARMInstallationManagedIdentity.md
+++ b/docs/ARMInstallationManagedIdentity.md
@@ -46,9 +46,9 @@ The following parameters are provided by the ARM template:
 
 |Type|Behavior
 |---|---
-|**R4DeviceAndPatientLookupIdentityService**|Default setting.  Device identifier from ingested messages is retrieved from the FHIR server. Patient is expected to be linked to the device.
-|**R4DeviceAndPatientCreateIdentityService**|System attempts to retrieve the device identifier and associated patient from the FHIR server. If either isn't found a shell resource with just the identity will be created. Requires a patient identifier be mapped in the device content configuration template.
-|**R4DeviceAndPatientWithEncounterLookupIdentityService**|Like the first setting but allows you to include an encounter identifier with the message to associate with the device/patient.  The encounter is looked up during processing and any observations created are linked to the encounter. The association here is assumed to be one encounter per device.
+|**Lookup**|Default setting.  Device identifier from ingested messages is retrieved from the FHIR server. Patient is expected to be linked to the device.
+|**Create**|System attempts to retrieve the device identifier and associated patient from the FHIR server. If either isn't found a shell resource with just the identity will be created. Requires a patient identifier be mapped in the device content configuration template.
+|**LookupWithEncounter**|Like the first setting but allows you to include an encounter identifier with the message to associate with the device/patient.  The encounter is looked up during processing and any observations created are linked to the encounter. The association here is assumed to be one encounter per device.
 
 ## Post Deployment
 After the ARM template is successfully deployed, add the Managed Identity ID output by the ARM deployment to the Allowed Object IDs on the Authentication page of your Azure API for FHIR. This is the identity in Azure Active Directory that the IoMT FHIR Connector for Azure uses to connect to Azure API for FHIR. Also, the Authority on the Authentication page of your Azure API for FHIR should NOT be changed from the Azure Active Directory in your subscription, or this connection will be broken.

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -59,7 +59,7 @@ In addition to the Azure Functions prerequisites the following tasks need to be 
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "InputEventHub": "<<Insert deviceinput reader SharedAccessKey connection string>>",
     "OutputEventHub": "<<Insert normalizeddata writer SharedAccessKey connection string>>",
-    "ResourceIdentity:ResourceIdentityServiceType": "R4DeviceAndPatientLookupIdentityService",
+    "ResourceIdentity:ResourceIdentityServiceType": "Lookup",
     "ResourceIdentity:DefaultDeviceIdentifierSystem": "",
     "Template:DeviceContent": "devicecontent.json",
     "Template:FhirMapping": "fhirmapping.json"

--- a/docs/Sandbox.md
+++ b/docs/Sandbox.md
@@ -18,7 +18,7 @@ For the ease of using the sandbox, a few steps will be taken for you:
 
 1. Simulated devices are set up in IoT Central to generate data.
 2. Template files for those devices will be copied to the IoMT FHIR Connector for Azure storage account "Template" blob.
-3. The IoMT FHIR Connector for Azure will be configured with the "R4DeviceAndPatientCreateIdentityService" so that patients will automatically be created for each device.
+3. The IoMT FHIR Connector for Azure will be configured with the Resource Identity Service Type "Create" so that patients will automatically be created for each device.
 
 ## Prerequisites
 

--- a/docs/local.settings.json
+++ b/docs/local.settings.json
@@ -11,7 +11,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "InputEventHub": "",
     "OutputEventHub": "",
-    "ResourceIdentity:ResourceIdentityServiceType": "R4DeviceAndPatientLookupIdentityService",
+    "ResourceIdentity:ResourceIdentityServiceType": "Lookup",
     "ResourceIdentity:DefaultDeviceIdentifierSystem": "",
     "Template:DeviceContent": "devicecontent.json",
     "Template:FhirMapping": "fhirmapping.json"

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Config/ResourceIdentityOptions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Config/ResourceIdentityOptions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Health.Fhir.Ingest.Config
 {
     public class ResourceIdentityOptions
     {
-        public string ResourceIdentityServiceType { get; set; } = "R4DeviceAndPatientLookupIdentityService";
+        public ResourceIdentityServiceType ResourceIdentityServiceType { get; set; } = ResourceIdentityServiceType.Lookup;
 
         public string DefaultDeviceIdentifierSystem { get; set; } = null;
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Config/ResourceIdentityOptions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Config/ResourceIdentityOptions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Health.Fhir.Ingest.Config
 {
     public class ResourceIdentityOptions
     {
-        public ResourceIdentityServiceType ResourceIdentityServiceType { get; set; } = ResourceIdentityServiceType.Lookup;
+        public string ResourceIdentityServiceType { get; set; } = "Lookup";
 
         public string DefaultDeviceIdentifierSystem { get; set; } = null;
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Config/ResourceIdentityOptions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Config/ResourceIdentityOptions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Health.Fhir.Ingest.Config
 {
     public class ResourceIdentityOptions
     {
-        public string ResourceIdentityServiceType { get; set; } = "Lookup";
+        public string ResourceIdentityServiceType { get; set; } = Config.ResourceIdentityServiceType.Lookup.ToString();
 
         public string DefaultDeviceIdentifierSystem { get; set; } = null;
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Config/ResourceIdentityServiceType.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Config/ResourceIdentityServiceType.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.Fhir.Ingest.Config
     public enum ResourceIdentityServiceType
     {
         /// <summary>
-        /// Create the identity resources if not existed.
+        /// Create the identity resources if they do not exist.
         /// </summary>
         Create,
 
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Ingest.Config
         Lookup,
 
         /// <summary>
-        /// Look up the identity resource with Encounter info.
+        /// Look up the identity resource with the Encounter info.
         /// </summary>
         LookupWithEncounter,
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Config/ResourceIdentityServiceType.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Config/ResourceIdentityServiceType.cs
@@ -1,0 +1,28 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Ingest.Config
+{
+    /// <summary>
+    /// Resource Identity Service Type.
+    /// </summary>
+    public enum ResourceIdentityServiceType
+    {
+        /// <summary>
+        /// Create the identity resources if not existed.
+        /// </summary>
+        Create,
+
+        /// <summary>
+        /// Look up the identity resources.
+        /// </summary>
+        Lookup,
+
+        /// <summary>
+        /// Look up the identity resource with Encounter info.
+        /// </summary>
+        LookupWithEncounter,
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/ResourceIdentityServiceAttribute.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/ResourceIdentityServiceAttribute.cs
@@ -1,0 +1,24 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Ingest.Config;
+
+namespace Microsoft.Health.Fhir.Ingest.Host
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+    public sealed class ResourceIdentityServiceAttribute : Attribute
+    {
+        public ResourceIdentityServiceAttribute(ResourceIdentityServiceType serviceType, Type classType)
+        {
+            ServiceType = serviceType;
+            ClassType = classType;
+        }
+
+        public ResourceIdentityServiceType ServiceType { get; }
+
+        public Type ClassType { get; }
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/ResourceIdentityServiceAttribute.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/ResourceIdentityServiceAttribute.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Health.Fhir.Ingest.Config;
 
 namespace Microsoft.Health.Fhir.Ingest.Host
 {
@@ -13,6 +14,11 @@ namespace Microsoft.Health.Fhir.Ingest.Host
         public ResourceIdentityServiceAttribute(string type)
         {
             Type = type;
+        }
+
+        public ResourceIdentityServiceAttribute(ResourceIdentityServiceType type)
+            : this(type.ToString())
+        {
         }
 
         public string Type { get; }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/ResourceIdentityServiceAttribute.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/ResourceIdentityServiceAttribute.cs
@@ -8,17 +8,14 @@ using Microsoft.Health.Fhir.Ingest.Config;
 
 namespace Microsoft.Health.Fhir.Ingest.Host
 {
-    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public sealed class ResourceIdentityServiceAttribute : Attribute
     {
-        public ResourceIdentityServiceAttribute(ResourceIdentityServiceType serviceType, Type classType)
+        public ResourceIdentityServiceAttribute(ResourceIdentityServiceType type)
         {
-            ServiceType = serviceType;
-            ClassType = classType;
+            Type = type;
         }
 
-        public ResourceIdentityServiceType ServiceType { get; }
-
-        public Type ClassType { get; }
+        public ResourceIdentityServiceType Type { get; }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/ResourceIdentityServiceAttribute.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/ResourceIdentityServiceAttribute.cs
@@ -4,18 +4,17 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using Microsoft.Health.Fhir.Ingest.Config;
 
 namespace Microsoft.Health.Fhir.Ingest.Host
 {
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
     public sealed class ResourceIdentityServiceAttribute : Attribute
     {
-        public ResourceIdentityServiceAttribute(ResourceIdentityServiceType type)
+        public ResourceIdentityServiceAttribute(string type)
         {
             Type = type;
         }
 
-        public ResourceIdentityServiceType Type { get; }
+        public string Type { get; }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Host/MeasurementFhirImportExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Host/MeasurementFhirImportExtensions.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Runtime.CompilerServices;
 using EnsureThat;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
@@ -52,7 +51,6 @@ namespace Microsoft.Health.Fhir.Ingest.Host
             return builder;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static IResourceIdentityService ResolveResourceIdentityService(IServiceProvider serviceProvider)
         {
             EnsureArg.IsNotNull(serviceProvider, nameof(serviceProvider));

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
@@ -12,13 +12,11 @@ using Microsoft.Health.Extensions.Fhir.Service;
 using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;
-using Microsoft.Health.Fhir.Ingest.Service;
 using Model = Hl7.Fhir.Model;
-
-[assembly: ResourceIdentityService(ResourceIdentityServiceType.Create, typeof(R4DeviceAndPatientCreateIdentityService))]
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
+    [ResourceIdentityService(ResourceIdentityServiceType.Create)]
     public class R4DeviceAndPatientCreateIdentityService : R4DeviceAndPatientLookupIdentityService
     {
         public R4DeviceAndPatientCreateIdentityService(IFhirClient fhirClient)

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
@@ -9,14 +9,15 @@ using EnsureThat;
 using Hl7.Fhir.Rest;
 using Microsoft.Health.Extensions.Fhir;
 using Microsoft.Health.Extensions.Fhir.Service;
+using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;
 using Model = Hl7.Fhir.Model;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
-    [ResourceIdentityService("Create")]
-    [ResourceIdentityService("R4DeviceAndPatientCreateIdentityService")]
+    [ResourceIdentityService(ResourceIdentityServiceType.Create)]
+    [ResourceIdentityService(nameof(R4DeviceAndPatientCreateIdentityService))]
     public class R4DeviceAndPatientCreateIdentityService : R4DeviceAndPatientLookupIdentityService
     {
         public R4DeviceAndPatientCreateIdentityService(IFhirClient fhirClient)

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
@@ -9,14 +9,14 @@ using EnsureThat;
 using Hl7.Fhir.Rest;
 using Microsoft.Health.Extensions.Fhir;
 using Microsoft.Health.Extensions.Fhir.Service;
-using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;
 using Model = Hl7.Fhir.Model;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
-    [ResourceIdentityService(ResourceIdentityServiceType.Create)]
+    [ResourceIdentityService("Create")]
+    [ResourceIdentityService("R4DeviceAndPatientCreateIdentityService")]
     public class R4DeviceAndPatientCreateIdentityService : R4DeviceAndPatientLookupIdentityService
     {
         public R4DeviceAndPatientCreateIdentityService(IFhirClient fhirClient)

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
@@ -9,8 +9,13 @@ using EnsureThat;
 using Hl7.Fhir.Rest;
 using Microsoft.Health.Extensions.Fhir;
 using Microsoft.Health.Extensions.Fhir.Service;
+using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
+using Microsoft.Health.Fhir.Ingest.Host;
+using Microsoft.Health.Fhir.Ingest.Service;
 using Model = Hl7.Fhir.Model;
+
+[assembly: ResourceIdentityService(ResourceIdentityServiceType.Create, typeof(R4DeviceAndPatientCreateIdentityService))]
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
@@ -8,14 +8,14 @@ using EnsureThat;
 using Hl7.Fhir.Rest;
 using Microsoft.Health.Extensions.Fhir;
 using Microsoft.Health.Extensions.Fhir.Service;
-using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;
 using Model = Hl7.Fhir.Model;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
-    [ResourceIdentityService(ResourceIdentityServiceType.Lookup)]
+    [ResourceIdentityService("Lookup")]
+    [ResourceIdentityService("R4DeviceAndPatientLookupIdentityService")]
     public class R4DeviceAndPatientLookupIdentityService : DeviceAndPatientLookupIdentityService
     {
         private readonly IFhirClient _fhirClient;

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
@@ -8,14 +8,15 @@ using EnsureThat;
 using Hl7.Fhir.Rest;
 using Microsoft.Health.Extensions.Fhir;
 using Microsoft.Health.Extensions.Fhir.Service;
+using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;
 using Model = Hl7.Fhir.Model;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
-    [ResourceIdentityService("Lookup")]
-    [ResourceIdentityService("R4DeviceAndPatientLookupIdentityService")]
+    [ResourceIdentityService(ResourceIdentityServiceType.Lookup)]
+    [ResourceIdentityService(nameof(R4DeviceAndPatientLookupIdentityService))]
     public class R4DeviceAndPatientLookupIdentityService : DeviceAndPatientLookupIdentityService
     {
         private readonly IFhirClient _fhirClient;

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
@@ -8,8 +8,13 @@ using EnsureThat;
 using Hl7.Fhir.Rest;
 using Microsoft.Health.Extensions.Fhir;
 using Microsoft.Health.Extensions.Fhir.Service;
+using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
+using Microsoft.Health.Fhir.Ingest.Host;
+using Microsoft.Health.Fhir.Ingest.Service;
 using Model = Hl7.Fhir.Model;
+
+[assembly: ResourceIdentityService(ResourceIdentityServiceType.Lookup, typeof(R4DeviceAndPatientLookupIdentityService))]
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
@@ -11,13 +11,11 @@ using Microsoft.Health.Extensions.Fhir.Service;
 using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;
-using Microsoft.Health.Fhir.Ingest.Service;
 using Model = Hl7.Fhir.Model;
-
-[assembly: ResourceIdentityService(ResourceIdentityServiceType.Lookup, typeof(R4DeviceAndPatientLookupIdentityService))]
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
+    [ResourceIdentityService(ResourceIdentityServiceType.Lookup)]
     public class R4DeviceAndPatientLookupIdentityService : DeviceAndPatientLookupIdentityService
     {
         private readonly IFhirClient _fhirClient;

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientWithEncounterLookupIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientWithEncounterLookupIdentityService.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.Rest;
 using Microsoft.Health.Extensions.Fhir.Service;
-using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;
 using Model = Hl7.Fhir.Model;
@@ -19,7 +18,8 @@ namespace Microsoft.Health.Fhir.Ingest.Service
     /// Supports looking up device, patient, and encounter ids.  Ids are cached by the device identifier in the supplied measurement group.
     /// Assumption is one patient and encounter supported per device.
     /// </summary>
-    [ResourceIdentityService(ResourceIdentityServiceType.LookupWithEncounter)]
+    [ResourceIdentityService("LookupWithEncounter")]
+    [ResourceIdentityService("R4DeviceAndPatientWithEncounterLookupIdentityService")]
     public class R4DeviceAndPatientWithEncounterLookupIdentityService : R4DeviceAndPatientLookupIdentityService
     {
         public R4DeviceAndPatientWithEncounterLookupIdentityService(IFhirClient fhirClient)

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientWithEncounterLookupIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientWithEncounterLookupIdentityService.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.Rest;
 using Microsoft.Health.Extensions.Fhir.Service;
+using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;
 using Model = Hl7.Fhir.Model;
@@ -18,8 +19,8 @@ namespace Microsoft.Health.Fhir.Ingest.Service
     /// Supports looking up device, patient, and encounter ids.  Ids are cached by the device identifier in the supplied measurement group.
     /// Assumption is one patient and encounter supported per device.
     /// </summary>
-    [ResourceIdentityService("LookupWithEncounter")]
-    [ResourceIdentityService("R4DeviceAndPatientWithEncounterLookupIdentityService")]
+    [ResourceIdentityService(ResourceIdentityServiceType.LookupWithEncounter)]
+    [ResourceIdentityService(nameof(R4DeviceAndPatientWithEncounterLookupIdentityService))]
     public class R4DeviceAndPatientWithEncounterLookupIdentityService : R4DeviceAndPatientLookupIdentityService
     {
         public R4DeviceAndPatientWithEncounterLookupIdentityService(IFhirClient fhirClient)

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientWithEncounterLookupIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientWithEncounterLookupIdentityService.cs
@@ -11,10 +11,7 @@ using Microsoft.Health.Extensions.Fhir.Service;
 using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;
-using Microsoft.Health.Fhir.Ingest.Service;
 using Model = Hl7.Fhir.Model;
-
-[assembly: ResourceIdentityService(ResourceIdentityServiceType.LookupWithEncounter, typeof(R4DeviceAndPatientWithEncounterLookupIdentityService))]
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
@@ -22,6 +19,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
     /// Supports looking up device, patient, and encounter ids.  Ids are cached by the device identifier in the supplied measurement group.
     /// Assumption is one patient and encounter supported per device.
     /// </summary>
+    [ResourceIdentityService(ResourceIdentityServiceType.LookupWithEncounter)]
     public class R4DeviceAndPatientWithEncounterLookupIdentityService : R4DeviceAndPatientLookupIdentityService
     {
         public R4DeviceAndPatientWithEncounterLookupIdentityService(IFhirClient fhirClient)

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientWithEncounterLookupIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientWithEncounterLookupIdentityService.cs
@@ -8,8 +8,13 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.Rest;
 using Microsoft.Health.Extensions.Fhir.Service;
+using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
+using Microsoft.Health.Fhir.Ingest.Host;
+using Microsoft.Health.Fhir.Ingest.Service;
 using Model = Hl7.Fhir.Model;
+
+[assembly: ResourceIdentityService(ResourceIdentityServiceType.LookupWithEncounter, typeof(R4DeviceAndPatientWithEncounterLookupIdentityService))]
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/ResourceIdentityServiceFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/ResourceIdentityServiceFactoryTests.cs
@@ -11,10 +11,6 @@ using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;
 using Xunit;
 using Xunit.Abstractions;
-using static Microsoft.Health.Fhir.Ingest.Service.ResourceIdentityServiceFactoryTests;
-
-[assembly: ResourceIdentityService(ResourceIdentityServiceType.Lookup, typeof(TestLookUpResourceIdentityService))]
-[assembly: ResourceIdentityService(ResourceIdentityServiceType.Create, typeof(TestCreateResourceIdentityService))]
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
@@ -28,12 +24,12 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         }
 
         [Fact]
-        public void GivenSupportedConfigurationAndNoCtorParams_WhenLookUp_ThenObjectCreated_Test()
+        public void GivenSupportedConfigurationAndNoCtorParams_WhenLookup_ThenObjectCreated_Test()
         {
             var options = new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.Lookup };
             var srv = ResourceIdentityServiceFactory.Instance.Create(options);
             Assert.NotNull(srv);
-            var typedSrv = Assert.IsType<TestLookUpResourceIdentityService>(srv);
+            var typedSrv = Assert.IsType<TestLookupResourceIdentityService>(srv);
             Assert.Equal(options, typedSrv.Options);
         }
 
@@ -49,7 +45,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         }
 
         [Fact]
-        public void GivenNotSupportedConfigurationAndInvalidCtorParams_WhenLookUpWithEncounter_ThenNotSupportedException_Test()
+        public void GivenNotSupportedConfigurationAndInvalidCtorParams_WhenLookupWithEncounter_ThenNotSupportedException_Test()
         {
             var ex = Assert.Throws<NotSupportedException>(() => ResourceIdentityServiceFactory.Instance.Create(new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.LookupWithEncounter }));
             _output.WriteLine(ex.Message);
@@ -58,11 +54,12 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         [Fact]
         public void GivenSupportedConfigurationAndInvalidCtorParams_WhenCreate_ThenNotSupportedException_Test()
         {
-           var ex = Assert.Throws<NotSupportedException>(() => ResourceIdentityServiceFactory.Instance.Create(new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.Create }, 1));
-           _output.WriteLine(ex.Message);
+            var ex = Assert.Throws<NotSupportedException>(() => ResourceIdentityServiceFactory.Instance.Create(new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.Create }, 1));
+            _output.WriteLine(ex.Message);
         }
 
-        public class TestLookUpResourceIdentityService : IResourceIdentityService
+        [ResourceIdentityService(ResourceIdentityServiceType.Lookup)]
+        public class TestLookupResourceIdentityService : IResourceIdentityService
         {
             public ResourceIdentityOptions Options { get; private set; }
 
@@ -77,6 +74,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             }
         }
 
+        [ResourceIdentityService(ResourceIdentityServiceType.Create)]
         public class TestCreateResourceIdentityService : IResourceIdentityService
         {
             public TestCreateResourceIdentityService(string parameter)
@@ -86,6 +84,21 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
             public string Parameter { get; private set; }
 
+            public ResourceIdentityOptions Options { get; private set; }
+
+            public void Initialize(ResourceIdentityOptions options)
+            {
+                Options = options;
+            }
+
+            public Task<IDictionary<ResourceType, string>> ResolveResourceIdentitiesAsync(IMeasurementGroup input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class TestUnregisteredResourceIdentityService : IResourceIdentityService
+        {
             public ResourceIdentityOptions Options { get; private set; }
 
             public void Initialize(ResourceIdentityOptions options)

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/ResourceIdentityServiceFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/ResourceIdentityServiceFactoryTests.cs
@@ -8,8 +8,13 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
+using Microsoft.Health.Fhir.Ingest.Host;
 using Xunit;
 using Xunit.Abstractions;
+using static Microsoft.Health.Fhir.Ingest.Service.ResourceIdentityServiceFactoryTests;
+
+[assembly: ResourceIdentityService(ResourceIdentityServiceType.Lookup, typeof(TestLookUpResourceIdentityService))]
+[assembly: ResourceIdentityService(ResourceIdentityServiceType.Create, typeof(TestCreateResourceIdentityService))]
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
@@ -23,41 +28,41 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         }
 
         [Fact]
-        public void GivenValidConfigurationAndNoCtorParams_WhenCreate_ThenObjectCreated_Test()
+        public void GivenSupportedConfigurationAndNoCtorParams_WhenLookUp_ThenObjectCreated_Test()
         {
-            var options = new ResourceIdentityOptions { ResourceIdentityServiceType = nameof(Test1ResourceIdentityService) };
+            var options = new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.Lookup };
             var srv = ResourceIdentityServiceFactory.Instance.Create(options);
             Assert.NotNull(srv);
-            var typedSrv = Assert.IsType<Test1ResourceIdentityService>(srv);
+            var typedSrv = Assert.IsType<TestLookUpResourceIdentityService>(srv);
             Assert.Equal(options, typedSrv.Options);
         }
 
         [Fact]
-        public void GivenValidConfigurationAndCtorParams_WhenCreate_ThenObjectCreatedWithParam_Test()
+        public void GivenSupportedConfigurationAndValidCtorParams_WhenCreate_ThenObjectCreatedWithParam_Test()
         {
-            var options = new ResourceIdentityOptions { ResourceIdentityServiceType = nameof(Test2ResourceIdentityService) };
+            var options = new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.Create };
             var srv = ResourceIdentityServiceFactory.Instance.Create(options, "foo");
             Assert.NotNull(srv);
-            var typedSrv = Assert.IsType<Test2ResourceIdentityService>(srv);
+            var typedSrv = Assert.IsType<TestCreateResourceIdentityService>(srv);
             Assert.Equal("foo", typedSrv.Parameter);
             Assert.Equal(options, typedSrv.Options);
         }
 
         [Fact]
-        public void GivenInValidConfigurationAndCtorParams_WhenCreate_ThenNotSupportedException_Test()
+        public void GivenNotSupportedConfigurationAndInvalidCtorParams_WhenLookUpWithEncounter_ThenNotSupportedException_Test()
         {
-            var ex = Assert.Throws<NotSupportedException>(() => ResourceIdentityServiceFactory.Instance.Create(new ResourceIdentityOptions { ResourceIdentityServiceType = "type1" }));
+            var ex = Assert.Throws<NotSupportedException>(() => ResourceIdentityServiceFactory.Instance.Create(new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.LookupWithEncounter }));
             _output.WriteLine(ex.Message);
         }
 
         [Fact]
-        public void GivenValidConfigurationAndInvalidCtorParams_WhenCreate_ThenNotSupportedException_Test()
+        public void GivenSupportedConfigurationAndInvalidCtorParams_WhenCreate_ThenNotSupportedException_Test()
         {
-           var ex = Assert.Throws<NotSupportedException>(() => ResourceIdentityServiceFactory.Instance.Create(new ResourceIdentityOptions { ResourceIdentityServiceType = nameof(Test2ResourceIdentityService) }, 1));
+           var ex = Assert.Throws<NotSupportedException>(() => ResourceIdentityServiceFactory.Instance.Create(new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.Create }, 1));
            _output.WriteLine(ex.Message);
         }
 
-        public class Test1ResourceIdentityService : IResourceIdentityService
+        public class TestLookUpResourceIdentityService : IResourceIdentityService
         {
             public ResourceIdentityOptions Options { get; private set; }
 
@@ -72,9 +77,9 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             }
         }
 
-        public class Test2ResourceIdentityService : IResourceIdentityService
+        public class TestCreateResourceIdentityService : IResourceIdentityService
         {
-            public Test2ResourceIdentityService(string parameter)
+            public TestCreateResourceIdentityService(string parameter)
             {
                 Parameter = parameter;
             }

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/ResourceIdentityServiceFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/ResourceIdentityServiceFactoryTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         [Fact]
         public void GivenSupportedConfigurationAndNoCtorParams_WhenLookup_ThenObjectCreated_Test()
         {
-            var options = new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.Lookup };
+            var options = new ResourceIdentityOptions { ResourceIdentityServiceType = "Lookup" };
             var srv = ResourceIdentityServiceFactory.Instance.Create(options);
             Assert.NotNull(srv);
             var typedSrv = Assert.IsType<TestLookupResourceIdentityService>(srv);
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         [Fact]
         public void GivenSupportedConfigurationAndValidCtorParams_WhenCreate_ThenObjectCreatedWithParam_Test()
         {
-            var options = new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.Create };
+            var options = new ResourceIdentityOptions { ResourceIdentityServiceType = "Create" };
             var srv = ResourceIdentityServiceFactory.Instance.Create(options, "foo");
             Assert.NotNull(srv);
             var typedSrv = Assert.IsType<TestCreateResourceIdentityService>(srv);
@@ -45,20 +45,31 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         }
 
         [Fact]
+        public void GivenLegacySupportedConfigurationAndNoCtorParams_WhenLookup_ThenObjectCreated_Test()
+        {
+            var options = new ResourceIdentityOptions { ResourceIdentityServiceType = "R4DeviceAndPatientLookupIdentityService" };
+            var srv = ResourceIdentityServiceFactory.Instance.Create(options);
+            Assert.NotNull(srv);
+            var typedSrv = Assert.IsType<TestLookupResourceIdentityService>(srv);
+            Assert.Equal(options, typedSrv.Options);
+        }
+
+        [Fact]
         public void GivenNotSupportedConfigurationAndInvalidCtorParams_WhenLookupWithEncounter_ThenNotSupportedException_Test()
         {
-            var ex = Assert.Throws<NotSupportedException>(() => ResourceIdentityServiceFactory.Instance.Create(new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.LookupWithEncounter }));
+            var ex = Assert.Throws<NotSupportedException>(() => ResourceIdentityServiceFactory.Instance.Create(new ResourceIdentityOptions { ResourceIdentityServiceType = "LookupWithEncounter" }));
             _output.WriteLine(ex.Message);
         }
 
         [Fact]
         public void GivenSupportedConfigurationAndInvalidCtorParams_WhenCreate_ThenNotSupportedException_Test()
         {
-            var ex = Assert.Throws<NotSupportedException>(() => ResourceIdentityServiceFactory.Instance.Create(new ResourceIdentityOptions { ResourceIdentityServiceType = ResourceIdentityServiceType.Create }, 1));
+            var ex = Assert.Throws<NotSupportedException>(() => ResourceIdentityServiceFactory.Instance.Create(new ResourceIdentityOptions { ResourceIdentityServiceType = "Create" }, 1));
             _output.WriteLine(ex.Message);
         }
 
-        [ResourceIdentityService(ResourceIdentityServiceType.Lookup)]
+        [ResourceIdentityService("Lookup")]
+        [ResourceIdentityService("R4DeviceAndPatientLookupIdentityService")]
         public class TestLookupResourceIdentityService : IResourceIdentityService
         {
             public ResourceIdentityOptions Options { get; private set; }
@@ -74,7 +85,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             }
         }
 
-        [ResourceIdentityService(ResourceIdentityServiceType.Create)]
+        [ResourceIdentityService("Create")]
         public class TestCreateResourceIdentityService : IResourceIdentityService
         {
             public TestCreateResourceIdentityService(string parameter)


### PR DESCRIPTION
- Add the Assembly attribute to register the implementation classes.
- Use structured enum data type for ResourceIdentityServiceType.
- Update Unit Tests with new enum type.