### PR TITLE
Update audience in Managed Identity ARM template

### DIFF
--- a/deploy/templates/managed-identity-azuredeploy.json
+++ b/deploy/templates/managed-identity-azuredeploy.json
@@ -144,6 +144,13 @@
         "description": "Url of the FHIR server that IoMT will be written to."
       }
     },
+    "FhirServiceAudience": {
+      "type": "string",
+      "metadata": {
+        "description": "Audience representing the FHIR server."
+      },
+      "defaultValue": ""
+    },
     "ResourceIdentityServiceType": {
       "type": "string",
       "allowedValues": [
@@ -177,7 +184,8 @@
     "app_service_resource_id": "[resourceId('Microsoft.Web/sites', variables('app_service_name'))]",
     "deploy_source_code": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
     "sender_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '2b629674-e913-4c01-ae53-ef4638d8f975')]",
-    "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]"
+    "receiver_role": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]",
+    "fhir_service_audience": "[if(or(equals(parameters('FhirServiceAudience'), json('null')), equals(parameters('FhirServiceAudience'), '')), parameters('FhirServiceUrl'), parameters('FhirServiceAudience'))]"
   },
   "resources": [
     {
@@ -554,7 +562,7 @@
             "AzureWebJobsSecretStorageType": "Files",
             "FhirVersion": "[parameters('FhirVersion')]",
             "FhirService:Url": "[parameters('FhirServiceUrl')]",
-            "FhirService:Resource": "https://azurehealthcareapis.com",
+            "FhirService:Resource": "[variables('fhir_service_audience')]",
             "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(concat('Microsoft.Insights/components/', variables('app_insights_name'))).InstrumentationKey]",
             "Template:DeviceContent": "devicecontent.json",
             "Template:FhirMapping": "fhirmapping.json",


### PR DESCRIPTION
Add optional audience to managed identity template.  Update default if not set to FHIR service URL to match current default audience on the Azure API for FHIR.