### PR TITLE
Corrected secret name in ARM templates

### DIFF
--- a/deploy/templates/consumption-azuredeploy.json
+++ b/deploy/templates/consumption-azuredeploy.json
@@ -765,7 +765,7 @@
     {
       "type": "Microsoft.KeyVault/vaults/secrets",
       "apiVersion": "2016-10-01",
-      "name": "[concat(variables('storage_account_name'), '/blob-storage-cs')]",
+      "name": "[concat(variables('key_vault_name'), '/blob-storage-cs')]",
       "location": "[parameters('ResourceLocation')]",
       "dependsOn": [
         "[resourceId('Microsoft.KeyVault/vaults', variables('key_vault_name'))]",

--- a/deploy/templates/default-azuredeploy.json
+++ b/deploy/templates/default-azuredeploy.json
@@ -779,7 +779,7 @@
     {
       "type": "Microsoft.KeyVault/vaults/secrets",
       "apiVersion": "2016-10-01",
-      "name": "[concat(variables('storage_account_name'), '/blob-storage-cs')]",
+      "name": "[concat(variables('key_vault_name'), '/blob-storage-cs')]",
       "location": "[parameters('ResourceLocation')]",
       "dependsOn": [
         "[resourceId('Microsoft.KeyVault/vaults', variables('key_vault_name'))]",

--- a/deploy/templates/managed-identity-azuredeploy.json
+++ b/deploy/templates/managed-identity-azuredeploy.json
@@ -756,7 +756,7 @@
     {
       "type": "Microsoft.KeyVault/vaults/secrets",
       "apiVersion": "2016-10-01",
-      "name": "[concat(variables('storage_account_name'), '/blob-storage-cs')]",
+      "name": "[concat(variables('key_vault_name'), '/blob-storage-cs')]",
       "location": "[parameters('ResourceLocation')]",
       "dependsOn": [
         "[resourceId('Microsoft.KeyVault/vaults', variables('key_vault_name'))]",

--- a/deploy/templates/premium-azuredeploy.json
+++ b/deploy/templates/premium-azuredeploy.json
@@ -765,7 +765,7 @@
     {
       "type": "Microsoft.KeyVault/vaults/secrets",
       "apiVersion": "2016-10-01",
-      "name": "[concat(variables('storage_account_name'), '/blob-storage-cs')]",
+      "name": "[concat(variables('key_vault_name'), '/blob-storage-cs')]",
       "location": "[parameters('ResourceLocation')]",
       "dependsOn": [
         "[resourceId('Microsoft.KeyVault/vaults', variables('key_vault_name'))]",


### PR DESCRIPTION
Corrected a secret name in the ARM templates to use key_vault_name instead of storage_account_name (this bug is only apparent if you further modify the ARM templates to use different values for key_vault_name and storage_account_name).