### PR TITLE
Personal/duburson/remove sa prototype

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# CA1812: EventHubsScaleMonitor.BlobPartitionLease is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).
+dotnet_diagnostic.CA1812.severity = none

--- a/Microsoft.Health.Fhir.Ingest.sln
+++ b/Microsoft.Health.Fhir.Ingest.sln
@@ -73,9 +73,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "healthkitOnFhir", "healthki
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Template", "src\lib\Microsoft.Health.Fhir.Ingest.Template\Microsoft.Health.Fhir.Ingest.Template.csproj", "{85D653A7-0E63-4751-8904-728156807A14}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.Ingest.Schema", "src\lib\Microsoft.Health.Fhir.Ingest.Schema\Microsoft.Health.Fhir.Ingest.Schema.csproj", "{A85AB6BC-698C-460F-81D4-9D1D2BD14B71}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Schema", "src\lib\Microsoft.Health.Fhir.Ingest.Schema\Microsoft.Health.Fhir.Ingest.Schema.csproj", "{A85AB6BC-698C-460F-81D4-9D1D2BD14B71}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.Ingest.Template.UnitTests", "test\Microsoft.Health.Fhir.Ingest.Template.UnitTests\Microsoft.Health.Fhir.Ingest.Template.UnitTests.csproj", "{EE072537-807D-4FE2-BFEB-424B64DCD7F9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Template.UnitTests", "test\Microsoft.Health.Fhir.Ingest.Template.UnitTests\Microsoft.Health.Fhir.Ingest.Template.UnitTests.csproj", "{EE072537-807D-4FE2-BFEB-424B64DCD7F9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{10EFAC3D-8282-4CD6-AD35-61880CA0BB06}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/IomtConnectorFunctions.cs
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/IomtConnectorFunctions.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Health.Common.EventHubs;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.8" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.14" />

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="3.0.6" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.8" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.14" />

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/host.json
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/host.json
@@ -16,6 +16,7 @@
   "extensions": {
     "eventHubs": {
       "batchCheckpointFrequency": 1,
+      "eventQueueSize": 1,
       "eventProcessorOptions": {
         "maxBatchSize": 1024,
         "prefetchCount": 2048

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/host.json
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/host.json
@@ -16,7 +16,7 @@
   "extensions": {
     "eventHubs": {
       "batchCheckpointFrequency": 1,
-      "eventQueueSize": 1,
+      "eventQueueSize": 1000,
       "eventProcessorOptions": {
         "maxBatchSize": 1024,
         "prefetchCount": 2048

--- a/src/lib/Microsoft.Health.Common/EventHub/Config/EventHubExtensionConfigProvider.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Config/EventHubExtensionConfigProvider.cs
@@ -1,0 +1,163 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Processor;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Configuration;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Common.EventHubs
+{
+    [Extension("EventHubs", configurationSection: "EventHubs")]
+    public class EventHubExtensionConfigProvider : IExtensionConfigProvider
+    {
+#pragma warning disable CA1051 // Do not declare visible instance fields
+#pragma warning disable SA1401 // Fields should be private
+        public IConfiguration _config;
+#pragma warning restore SA1401 // Fields should be private
+#pragma warning restore CA1051 // Do not declare visible instance fields
+        private readonly IOptions<EventHubOptions> _options;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly IConverterManager _converterManager;
+        private readonly INameResolver _nameResolver;
+        private readonly IWebJobsExtensionConfiguration<EventHubExtensionConfigProvider> _configuration;
+
+        public EventHubExtensionConfigProvider(IConfiguration config, IOptions<EventHubOptions> options, ILoggerFactory loggerFactory,
+#pragma warning disable SA1117 // Parameters should be on same line or separate lines
+            IConverterManager converterManager, INameResolver nameResolver, IWebJobsExtensionConfiguration<EventHubExtensionConfigProvider> configuration)
+#pragma warning restore SA1117 // Parameters should be on same line or separate lines
+        {
+            _config = config;
+            _options = options;
+            _loggerFactory = loggerFactory;
+            _converterManager = converterManager;
+            _nameResolver = nameResolver;
+            _configuration = configuration;
+        }
+
+        internal Action<ExceptionReceivedEventArgs> ExceptionHandler { get; set; }
+
+        private void ExceptionReceivedHandler(ExceptionReceivedEventArgs args)
+        {
+            ExceptionHandler?.Invoke(args);
+        }
+
+        public void Initialize(ExtensionConfigContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            _options.Value.EventProcessorOptions.SetExceptionHandler(ExceptionReceivedHandler);
+            _configuration.ConfigurationSection.Bind(_options);
+
+            context
+                .AddConverter<string, EventData>(ConvertString2EventData)
+                .AddConverter<EventData, string>(ConvertEventData2String)
+                .AddConverter<byte[], EventData>(ConvertBytes2EventData)
+                .AddConverter<EventData, byte[]>(ConvertEventData2Bytes)
+                .AddOpenConverter<OpenType.Poco, EventData>(ConvertPocoToEventData);
+
+            // register our trigger binding provider
+            var triggerBindingProvider = new EventHubTriggerAttributeBindingProvider(_config, _nameResolver, _converterManager, _options, _loggerFactory);
+            context.AddBindingRule<EventHubTriggerAttribute>()
+                .BindToTrigger(triggerBindingProvider);
+
+            // register our binding provider
+            context.AddBindingRule<EventHubAttribute>()
+                .BindToCollector(BuildFromAttribute);
+
+            context.AddBindingRule<EventHubAttribute>()
+                .BindToInput(attribute =>
+            {
+                return _options.Value.GetEventHubClient(attribute.EventHubName, attribute.Connection);
+            });
+
+            ExceptionHandler = e =>
+            {
+                LogExceptionReceivedEvent(e, _loggerFactory);
+            };
+        }
+
+        internal static void LogExceptionReceivedEvent(ExceptionReceivedEventArgs e, ILoggerFactory loggerFactory)
+        {
+            try
+            {
+                var logger = loggerFactory?.CreateLogger(LogCategories.Executor);
+                string message = $"EventProcessorHost error (Action={e.Action}, HostName={e.Hostname}, PartitionId={e.PartitionId})";
+
+                var logLevel = GetLogLevel(e.Exception);
+                logger?.Log(logLevel, 0, message, e.Exception, (s, ex) => message);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                // best effort logging
+            }
+        }
+
+        private static LogLevel GetLogLevel(Exception ex)
+        {
+            if (ex is ReceiverDisconnectedException ||
+                ex is LeaseLostException)
+            {
+                // For EventProcessorHost these exceptions can happen as part
+                // of normal partition balancing across instances, so we want to
+                // trace them, but not treat them as errors.
+                return LogLevel.Information;
+            }
+
+            var ehex = ex as EventHubsException;
+            if (!(ex is OperationCanceledException) && (ehex == null || !ehex.IsTransient))
+            {
+                // any non-transient exceptions or unknown exception types
+                // we want to log as errors
+                return LogLevel.Error;
+            }
+            else
+            {
+                // transient messaging errors we log as info so we have a record
+                // of them, but we don't treat them as actual errors
+                return LogLevel.Information;
+            }
+        }
+
+        private IAsyncCollector<EventData> BuildFromAttribute(EventHubAttribute attribute)
+        {
+            EventHubClient client = _options.Value.GetEventHubClient(attribute.EventHubName, attribute.Connection);
+            return new EventHubAsyncCollector(client);
+        }
+
+        private static string ConvertEventData2String(EventData x)
+            => Encoding.UTF8.GetString(ConvertEventData2Bytes(x));
+
+        private static EventData ConvertBytes2EventData(byte[] input)
+            => new EventData(input);
+
+        private static byte[] ConvertEventData2Bytes(EventData input)
+            => input.Body.Array;
+
+        private static EventData ConvertString2EventData(string input)
+            => ConvertBytes2EventData(Encoding.UTF8.GetBytes(input));
+
+        private static Task<object> ConvertPocoToEventData(object arg, Attribute attrResolved, ValueBindingContext context)
+        {
+            return Task.FromResult<object>(ConvertString2EventData(JsonConvert.SerializeObject(arg)));
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/Config/EventHubOptions.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Config/EventHubOptions.cs
@@ -1,0 +1,431 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Processor;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Hosting;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Health.Common.EventHubs
+{
+    public class EventHubOptions : IOptionsFormatter
+    {
+        // Event Hub Names are case-insensitive.
+        // The same path can have multiple connection strings with different permissions (sending and receiving),
+        // so we track senders and receivers separately and infer which one to use based on the EventHub (sender) vs. EventHubTrigger (receiver) attribute.
+        // Connection strings may also encapsulate different endpoints.
+
+        // The client cache must be thread safe because clients are accessed/added on the function
+        private readonly ConcurrentDictionary<string, EventHubClient> _clients = new ConcurrentDictionary<string, EventHubClient>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, ReceiverCreds> _receiverCreds = new Dictionary<string, ReceiverCreds>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, EventProcessorHost> _explicitlyProvidedHosts = new Dictionary<string, EventProcessorHost>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Name of the blob container that the EventHostProcessor instances uses to coordinate load balancing listening on an event hub.
+        /// Each event hub gets its own blob prefix within the container.
+        /// </summary>
+        public const string LeaseContainerName = "azure-webjobs-eventhub";
+        private int _batchCheckpointFrequency = 1;
+
+        public EventHubOptions()
+        {
+            EventProcessorOptions = EventProcessorOptions.DefaultOptions;
+            PartitionManagerOptions = new PartitionManagerOptions();
+        }
+
+        /// <summary>
+        /// Gets or sets the number of batches to process before creating an EventHub cursor checkpoint. Default 1.
+        /// </summary>
+        public int BatchCheckpointFrequency
+        {
+            get
+            {
+                return _batchCheckpointFrequency;
+            }
+
+            set
+            {
+                if (value <= 0)
+                {
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+                    throw new InvalidOperationException(message: "Batch checkpoint frequency must be larger than 0.");
+#pragma warning restore CA1303 // Do not pass literals as localized parameters
+                }
+
+                _batchCheckpointFrequency = value;
+            }
+        }
+
+        public EventProcessorOptions EventProcessorOptions { get; }
+
+        public PartitionManagerOptions PartitionManagerOptions { get; }
+
+        /// <summary>
+        /// Add an existing client for sending messages to an event hub.  Infer the eventHub name from client.path
+        /// </summary>
+        /// <param name="client">client</param>
+        public void AddEventHubClient(EventHubClient client)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            string eventHubName = client.EventHubName;
+            AddEventHubClient(eventHubName, client);
+        }
+
+        /// <summary>
+        /// Add an existing client for sending messages to an event hub.  Infer the eventHub name from client.path
+        /// </summary>
+        /// <param name="eventHubName">name of the event hub</param>
+        /// <param name="client">client</param>
+        public void AddEventHubClient(string eventHubName, EventHubClient client)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException(nameof(eventHubName));
+            }
+
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            _clients[eventHubName] = client;
+        }
+
+        /// <summary>
+        /// Add a connection for sending messages to an event hub. Connect via the connection string.
+        /// </summary>
+        /// <param name="eventHubName">name of the event hub. </param>
+        /// <param name="sendConnectionString">connection string for sending messages. If this includes an EntityPath, it takes precedence over the eventHubName parameter.</param>
+        public void AddSender(string eventHubName, string sendConnectionString)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException(nameof(eventHubName));
+            }
+
+            if (sendConnectionString == null)
+            {
+                throw new ArgumentNullException(nameof(sendConnectionString));
+            }
+
+            EventHubsConnectionStringBuilder sb = new EventHubsConnectionStringBuilder(sendConnectionString);
+            if (string.IsNullOrWhiteSpace(sb.EntityPath))
+            {
+                sb.EntityPath = eventHubName;
+            }
+
+            var client = EventHubClient.CreateFromConnectionString(sb.ToString());
+            AddEventHubClient(eventHubName, client);
+        }
+
+        /// <summary>
+        /// Add a connection for listening on events from an event hub.
+        /// </summary>
+        /// <param name="eventHubName">Name of the event hub</param>
+        /// <param name="listener">initialized listener object</param>
+        /// <remarks>The EventProcessorHost type is from the ServiceBus SDK.
+        /// Allow callers to bind to EventHubConfiguration without needing to have a direct assembly reference to the ServiceBus SDK.
+        /// The compiler needs to resolve all types in all overloads, so give methods that use the ServiceBus SDK types unique non-overloaded names
+        /// to avoid eager compiler resolution.
+        /// </remarks>
+        public void AddEventProcessorHost(string eventHubName, EventProcessorHost listener)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException(nameof(eventHubName));
+            }
+
+            if (listener == null)
+            {
+                throw new ArgumentNullException(nameof(listener));
+            }
+
+            _explicitlyProvidedHosts[eventHubName] = listener;
+        }
+
+        /// <summary>
+        /// Add a connection for listening on events from an event hub. Connect via the connection string and use the SDK's built-in storage account.
+        /// </summary>
+        /// <param name="eventHubName">name of the event hub</param>
+        /// <param name="receiverConnectionString">connection string for receiving messages. This can encapsulate other service bus properties like the namespace and endpoints.</param>
+        public void AddReceiver(string eventHubName, string receiverConnectionString)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException(nameof(eventHubName));
+            }
+
+            if (receiverConnectionString == null)
+            {
+                throw new ArgumentNullException(nameof(receiverConnectionString));
+            }
+
+            _receiverCreds[eventHubName] = new ReceiverCreds
+            {
+                EventHubConnectionString = receiverConnectionString,
+            };
+        }
+
+        /// <summary>
+        /// Add a connection for listening on events from an event hub. Connect via the connection string and use the supplied storage account
+        /// </summary>
+        /// <param name="eventHubName">name of the event hub</param>
+        /// <param name="receiverConnectionString">connection string for receiving messages</param>
+        /// <param name="storageConnectionString">storage connection string that the EventProcessorHost client will use to coordinate multiple listener instances. </param>
+        public void AddReceiver(string eventHubName, string receiverConnectionString, string storageConnectionString)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException(nameof(eventHubName));
+            }
+
+            if (receiverConnectionString == null)
+            {
+                throw new ArgumentNullException(nameof(receiverConnectionString));
+            }
+
+            if (storageConnectionString == null)
+            {
+                throw new ArgumentNullException(nameof(storageConnectionString));
+            }
+
+            _receiverCreds[eventHubName] = new ReceiverCreds
+            {
+                EventHubConnectionString = receiverConnectionString,
+                StorageConnectionString = storageConnectionString,
+            };
+        }
+
+        internal EventHubClient GetEventHubClient(string eventHubName, string connection)
+        {
+            EventHubClient client;
+
+            if (string.IsNullOrEmpty(eventHubName))
+            {
+                EventHubsConnectionStringBuilder builder = new EventHubsConnectionStringBuilder(connection);
+                eventHubName = builder.EntityPath;
+            }
+
+            if (_clients.TryGetValue(eventHubName, out client))
+            {
+                return client;
+            }
+            else if (!string.IsNullOrWhiteSpace(connection))
+            {
+                return _clients.GetOrAdd(eventHubName, key =>
+                {
+                    AddSender(key, connection);
+                    return _clients[key];
+                });
+            }
+
+            throw new InvalidOperationException("No event hub sender named " + eventHubName);
+        }
+
+        // Lookup a listener for receiving events given the name provided in the [EventHubTrigger] attribute.
+        internal EventProcessorHost GetEventProcessorHost(IConfiguration config, string eventHubName, string consumerGroup)
+        {
+            ReceiverCreds creds;
+            if (_receiverCreds.TryGetValue(eventHubName, out creds))
+            {
+                // Common case. Create a new EventProcessorHost instance to listen.
+                string eventProcessorHostName = Guid.NewGuid().ToString();
+
+                if (consumerGroup == null)
+                {
+                    consumerGroup = PartitionReceiver.DefaultConsumerGroupName;
+                }
+
+                var storageConnectionString = creds.StorageConnectionString;
+                if (storageConnectionString == null)
+                {
+                    string defaultStorageString = config.GetWebJobsConnectionString(ConnectionStringNames.Storage);
+                    storageConnectionString = defaultStorageString;
+                }
+
+                // If the connection string provides a hub name, that takes precedence.
+                // Note that connection strings *can't* specify a consumerGroup, so must always be passed in.
+                string actualPath = eventHubName;
+                EventHubsConnectionStringBuilder sb = new EventHubsConnectionStringBuilder(creds.EventHubConnectionString);
+                if (sb.EntityPath != null)
+                {
+                    actualPath = sb.EntityPath;
+                    sb.EntityPath = null; // need to remove to use with EventProcessorHost
+                }
+
+                var @namespace = GetEventHubNamespace(sb);
+                var blobPrefix = GetBlobPrefix(actualPath, @namespace);
+
+                // Use blob prefix support available in EPH starting in 2.2.6
+                EventProcessorHost host = new EventProcessorHost(
+                    hostName: eventProcessorHostName,
+                    eventHubPath: actualPath,
+                    consumerGroupName: consumerGroup,
+                    eventHubConnectionString: sb.ToString(),
+                    storageConnectionString: storageConnectionString,
+                    leaseContainerName: LeaseContainerName,
+                    storageBlobPrefix: blobPrefix);
+
+                host.PartitionManagerOptions = PartitionManagerOptions;
+
+                return host;
+            }
+            else
+            {
+                // Rare case: a power-user caller specifically provided an event processor host to use.
+                EventProcessorHost host;
+                if (_explicitlyProvidedHosts.TryGetValue(eventHubName, out host))
+                {
+                    return host;
+                }
+            }
+
+            throw new InvalidOperationException("No event hub receiver named " + eventHubName);
+        }
+
+        private static string EscapeStorageCharacter(char character)
+        {
+            var ordinalValue = (ushort)character;
+            if (ordinalValue < 0x100)
+            {
+                return string.Format(CultureInfo.InvariantCulture, ":{0:X2}", ordinalValue);
+            }
+            else
+            {
+                return string.Format(CultureInfo.InvariantCulture, "::{0:X4}", ordinalValue);
+            }
+        }
+
+        // Escape a blob path.
+        // For diagnostics, we want human-readble strings that resemble the input.
+        // Inputs are most commonly alphanumeric with a fex extra chars (dash, underscore, dot).
+        // Escape character is a ':', which is also escaped.
+        // Blob names are case sensitive; whereas input is case insensitive, so normalize to lower.
+        private static string EscapeBlobPath(string path)
+        {
+            StringBuilder sb = new StringBuilder(path.Length);
+            foreach (char c in path)
+            {
+                if (c >= 'a' && c <= 'z')
+                {
+                    sb.Append(c);
+                }
+                else if (c == '-' || c == '_' || c == '.')
+                {
+                    // Potentially common carahcters.
+                    sb.Append(c);
+                }
+                else if (c >= 'A' && c <= 'Z')
+                {
+                    sb.Append((char)(c - 'A' + 'a')); // ToLower
+                }
+                else if (c >= '0' && c <= '9')
+                {
+                    sb.Append(c);
+                }
+                else
+                {
+                    sb.Append(EscapeStorageCharacter(c));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        internal static string GetEventHubNamespace(EventHubsConnectionStringBuilder connectionString)
+        {
+            // EventHubs only have 1 endpoint.
+            var url = connectionString.Endpoint;
+            var @namespace = url.Host;
+            return @namespace;
+        }
+
+        /// <summary>
+        /// Get the blob prefix used with EventProcessorHost for a given event hub.
+        /// </summary>
+        /// <param name="eventHubName">the event hub path</param>
+        /// <param name="serviceBusNamespace">the event hub's service bus namespace.</param>
+        /// <returns>a blob prefix path that can be passed to EventProcessorHost.</returns>
+        /// <remarks>
+        /// An event hub is defined by it's path and namespace. The namespace is extracted from the connection string.
+        /// This must be an injective one-to-one function because:
+        /// 1. multiple machines listening on the same event hub must use the same blob prefix. This means it must be deterministic.
+        /// 2. different event hubs must not resolve to the same path.
+        /// </remarks>
+        public static string GetBlobPrefix(string eventHubName, string serviceBusNamespace)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException(nameof(eventHubName));
+            }
+
+            if (serviceBusNamespace == null)
+            {
+                throw new ArgumentNullException(nameof(serviceBusNamespace));
+            }
+
+            string key = EscapeBlobPath(serviceBusNamespace) + "/" + EscapeBlobPath(eventHubName) + "/";
+            return key;
+        }
+
+        public string Format()
+        {
+            JObject eventProcessorOptions = null;
+            if (EventProcessorOptions != null)
+            {
+                eventProcessorOptions = new JObject
+                {
+                    { nameof(EventProcessorOptions.EnableReceiverRuntimeMetric), EventProcessorOptions.EnableReceiverRuntimeMetric },
+                    { nameof(EventProcessorOptions.InvokeProcessorAfterReceiveTimeout), EventProcessorOptions.InvokeProcessorAfterReceiveTimeout },
+                    { nameof(EventProcessorOptions.MaxBatchSize), EventProcessorOptions.MaxBatchSize },
+                    { nameof(EventProcessorOptions.PrefetchCount), EventProcessorOptions.PrefetchCount },
+                    { nameof(EventProcessorOptions.ReceiveTimeout), EventProcessorOptions.ReceiveTimeout },
+                };
+            }
+
+            JObject partitionManagerOptions = null;
+            if (PartitionManagerOptions != null)
+            {
+                partitionManagerOptions = new JObject
+                {
+                    { nameof(PartitionManagerOptions.LeaseDuration), PartitionManagerOptions.LeaseDuration },
+                    { nameof(PartitionManagerOptions.RenewInterval), PartitionManagerOptions.RenewInterval },
+                };
+            }
+
+            JObject options = new JObject
+            {
+                { nameof(BatchCheckpointFrequency), BatchCheckpointFrequency },
+                { nameof(EventProcessorOptions), eventProcessorOptions },
+                { nameof(PartitionManagerOptions), partitionManagerOptions },
+            };
+
+            return options.ToString(Formatting.Indented);
+        }
+
+        // Hold credentials for a given eventHub name.
+        // Multiple consumer groups (and multiple listeners) on the same hub can share the same credentials.
+        private class ReceiverCreds
+        {
+            // Required.
+            public string EventHubConnectionString { get; set; }
+
+            // Optional. If not found, use the stroage from JobHostConfiguration
+            public string StorageConnectionString { get; set; }
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/Config/EventHubOptions.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Config/EventHubOptions.cs
@@ -66,6 +66,8 @@ namespace Microsoft.Health.Common.EventHubs
             }
         }
 
+        public int EventQueueSize { get; set; } = 1;
+
         public EventProcessorOptions EventProcessorOptions { get; }
 
         public PartitionManagerOptions PartitionManagerOptions { get; }

--- a/src/lib/Microsoft.Health.Common/EventHub/Config/EventHubWebJobsBuilderExtensions.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Config/EventHubWebJobsBuilderExtensions.cs
@@ -1,0 +1,50 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Common.EventHubs;
+
+namespace Microsoft.Extensions.Hosting
+{
+    public static class EventHubWebJobsBuilderExtensions
+    {
+        public static IWebJobsBuilder AddEventHubs(this IWebJobsBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.AddEventHubs(p => { });
+
+            return builder;
+        }
+
+        public static IWebJobsBuilder AddEventHubs(this IWebJobsBuilder builder, Action<EventHubOptions> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            builder.AddExtension<EventHubExtensionConfigProvider>()
+                .BindOptions<EventHubOptions>();
+
+            builder.Services.Configure<EventHubOptions>(options =>
+            {
+                configure(options);
+            });
+
+            return builder;
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/EventHubAttribute.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/EventHubAttribute.cs
@@ -1,0 +1,39 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Azure.WebJobs.Description;
+
+namespace Microsoft.Health.Common.EventHubs
+{
+    /// <summary>
+    /// Setup an 'output' binding to an EventHub. This can be any output type compatible with an IAsyncCollector.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
+    [Binding]
+    public sealed class EventHubAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventHubAttribute"/> class.
+        /// </summary>
+        /// <param name="eventHubName">Name of the event hub as resolved against the <see cref="EventHubConfiguration"/> </param>
+        public EventHubAttribute(string eventHubName)
+        {
+            EventHubName = eventHubName;
+        }
+
+        /// <summary>
+        /// The name of the event hub. This is resolved against the <see cref="EventHubConfiguration"/>
+        /// </summary>
+        [AutoResolve]
+        public string EventHubName { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the optional connection string name that contains the Event Hub connection string. If missing, tries to use a registered event hub sender.
+        /// </summary>
+        [ConnectionString]
+        public string Connection { get; set; }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/EventHubTriggerAttribute.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/EventHubTriggerAttribute.cs
@@ -1,0 +1,42 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Azure.WebJobs.Description;
+
+namespace Microsoft.Health.Common.EventHubs
+{
+    /// <summary>
+    /// Setup an 'trigger' on a parameter to listen on events from an event hub.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Binding]
+    public sealed class EventHubTriggerAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventHubTriggerAttribute"/> class.
+        /// </summary>
+        /// <param name="eventHubName">Event hub to listen on for messages. </param>
+        public EventHubTriggerAttribute(string eventHubName)
+        {
+            EventHubName = eventHubName;
+        }
+
+        /// <summary>
+        /// Name of the event hub.
+        /// </summary>
+        public string EventHubName { get; private set; }
+
+        /// <summary>
+        /// Optional Name of the consumer group. If missing, then use the default name, "$Default"
+        /// </summary>
+        public string ConsumerGroup { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional app setting name that contains the Event Hub connection string. If missing, tries to use a registered event hub receiver.
+        /// </summary>
+        public string Connection { get; set; }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/EventHubsWebJobsStartup.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/EventHubsWebJobsStartup.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Health.Common.EventHubs;
+
+[assembly: WebJobsStartup(typeof(EventHubsWebJobsStartup))]
+
+namespace Microsoft.Health.Common.EventHubs
+{
+    public class EventHubsWebJobsStartup : IWebJobsStartup
+    {
+        public void Configure(IWebJobsBuilder builder)
+        {
+            builder.AddEventHubs();
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/Extensions/SystemPropertiesCollectionExtensions.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Extensions/SystemPropertiesCollectionExtensions.cs
@@ -1,0 +1,25 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using static Microsoft.Azure.EventHubs.EventData;
+
+namespace Microsoft.Health.Common.EventHubs
+{
+    internal static class SystemPropertiesCollectionExtensions
+    {
+        internal static IDictionary<string, object> ToDictionary(this SystemPropertiesCollection collection)
+        {
+            IDictionary<string, object> modifiedDictionary = new Dictionary<string, object>(collection);
+
+            // Following is needed to maintain structure of bindingdata: https://github.com/Azure/azure-webjobs-sdk/pull/1849
+            modifiedDictionary["SequenceNumber"] = collection.SequenceNumber;
+            modifiedDictionary["Offset"] = collection.Offset;
+            modifiedDictionary["PartitionKey"] = collection.PartitionKey;
+            modifiedDictionary["EnqueuedTimeUtc"] = collection.EnqueuedTimeUtc;
+            return modifiedDictionary;
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/Listeners/EventHubListener.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Listeners/EventHubListener.cs
@@ -1,0 +1,401 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Processor;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Common.EventHubs.Listeners;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Common.EventHubs
+{
+    internal sealed class EventHubListener : IListener, IEventProcessorFactory, IScaleMonitorProvider
+    {
+        private static readonly Dictionary<string, object> EmptyScope = new Dictionary<string, object>();
+        private readonly string _functionId;
+        private readonly string _eventHubName;
+        private readonly string _consumerGroup;
+        private readonly string _connectionString;
+        private readonly string _storageConnectionString;
+        private readonly ITriggeredFunctionExecutor _executor;
+        private readonly EventProcessorHost _eventProcessorHost;
+        private readonly bool _singleDispatch;
+        private readonly EventHubOptions _options;
+        private readonly ILogger _logger;
+        private bool _started;
+
+        private Lazy<EventHubsScaleMonitor> _scaleMonitor;
+
+        public EventHubListener(
+            string functionId,
+            string eventHubName,
+            string consumerGroup,
+            string connectionString,
+            string storageConnectionString,
+            ITriggeredFunctionExecutor executor,
+            EventProcessorHost eventProcessorHost,
+            bool singleDispatch,
+            EventHubOptions options,
+            ILogger logger,
+            CloudBlobContainer blobContainer = null)
+        {
+            _functionId = functionId;
+            _eventHubName = eventHubName;
+            _consumerGroup = consumerGroup;
+            _connectionString = connectionString;
+            _storageConnectionString = storageConnectionString;
+            _executor = executor;
+            _eventProcessorHost = eventProcessorHost;
+            _singleDispatch = singleDispatch;
+            _options = options;
+            _logger = logger;
+            _scaleMonitor = new Lazy<EventHubsScaleMonitor>(() => new EventHubsScaleMonitor(_functionId, _eventHubName, _consumerGroup, _connectionString, _storageConnectionString, _logger, blobContainer));
+        }
+
+        void IListener.Cancel()
+        {
+            StopAsync(CancellationToken.None).Wait();
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            await _eventProcessorHost.RegisterEventProcessorFactoryAsync(this, _options.EventProcessorOptions);
+            _started = true;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            if (_started)
+            {
+                await _eventProcessorHost.UnregisterEventProcessorAsync();
+            }
+
+            _started = false;
+        }
+
+        IEventProcessor IEventProcessorFactory.CreateEventProcessor(PartitionContext context)
+        {
+            return new EventProcessor(_options, _executor, _logger, _singleDispatch);
+        }
+
+        public IScaleMonitor GetMonitor()
+        {
+            return _scaleMonitor.Value;
+        }
+
+        /// <summary>
+        /// Wrapper for un-mockable checkpoint APIs to aid in unit testing
+        /// </summary>
+#pragma warning disable SA1201 // Elements should appear in the correct order
+        internal interface ICheckpointer
+#pragma warning restore SA1201 // Elements should appear in the correct order
+        {
+            Task CheckpointAsync(PartitionContext context);
+        }
+
+        // We get a new instance each time Start() is called.
+        // We'll get a listener per partition - so they can potentialy run in parallel even on a single machine.
+        internal class EventProcessor : IEventProcessor, IDisposable, ICheckpointer
+        {
+            private readonly ITriggeredFunctionExecutor _executor;
+            private readonly bool _singleDispatch;
+            private readonly ILogger _logger;
+            private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+            private readonly ICheckpointer _checkpointer;
+            private readonly int _batchCheckpointFrequency;
+            private int _batchCounter = 0;
+            private bool _disposed = false;
+
+            public EventProcessor(EventHubOptions options, ITriggeredFunctionExecutor executor, ILogger logger, bool singleDispatch, ICheckpointer checkpointer = null)
+            {
+                _checkpointer = checkpointer ?? this;
+                _executor = executor;
+                _singleDispatch = singleDispatch;
+                _batchCheckpointFrequency = options.BatchCheckpointFrequency;
+                _logger = logger;
+            }
+
+            public Task CloseAsync(PartitionContext context, CloseReason reason)
+            {
+                // signal cancellation for any in progress executions
+                _cts.Cancel();
+
+                _logger.LogDebug(GetOperationDetails(context, $"CloseAsync, {reason.ToString()}"));
+                return Task.CompletedTask;
+            }
+
+            public Task OpenAsync(PartitionContext context)
+            {
+                _logger.LogDebug(GetOperationDetails(context, "OpenAsync"));
+                return Task.CompletedTask;
+            }
+
+            public Task ProcessErrorAsync(PartitionContext context, Exception error)
+            {
+                string errorDetails = $"Partition Id: '{context.PartitionId}', Owner: '{context.Owner}', EventHubPath: '{context.EventHubPath}'";
+
+                if (error is ReceiverDisconnectedException ||
+                    error is LeaseLostException)
+                {
+                    // For EventProcessorHost these exceptions can happen as part
+                    // of normal partition balancing across instances, so we want to
+                    // trace them, but not treat them as errors.
+                    _logger.LogInformation($"An Event Hub exception of type '{error.GetType().Name}' was thrown from {errorDetails}. This exception type is typically a result of Event Hub processor rebalancing and can be safely ignored.");
+                }
+                else
+                {
+                    _logger.LogError(error, $"Error processing event from {errorDetails}");
+                }
+
+                return Task.CompletedTask;
+            }
+
+            public async Task ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages)
+            {
+                var triggerInput = new EventHubTriggerInput
+                {
+                    Events = messages.ToArray(),
+                    PartitionContext = context,
+                };
+
+                TriggeredFunctionData input = null;
+                if (_singleDispatch)
+                {
+                    // Single dispatch
+                    int eventCount = triggerInput.Events.Length;
+                    List<Task> invocationTasks = new List<Task>();
+                    for (int i = 0; i < eventCount; i++)
+                    {
+                        if (_cts.IsCancellationRequested)
+                        {
+                            break;
+                        }
+
+                        EventHubTriggerInput eventHubTriggerInput = triggerInput.GetSingleEventTriggerInput(i);
+                        input = new TriggeredFunctionData
+                        {
+                            TriggerValue = eventHubTriggerInput,
+                            TriggerDetails = eventHubTriggerInput.GetTriggerDetails(context),
+                        };
+
+                        Task task = TryExecuteWithLoggingAsync(input, triggerInput.Events[i]);
+                        invocationTasks.Add(task);
+                    }
+
+                    // Drain the whole batch before taking more work
+                    if (invocationTasks.Count > 0)
+                    {
+                        await Task.WhenAll(invocationTasks);
+                    }
+                }
+                else
+                {
+                    // Batch dispatch
+                    input = new TriggeredFunctionData
+                    {
+                        TriggerValue = triggerInput,
+                        TriggerDetails = triggerInput.GetTriggerDetails(context),
+                    };
+
+                    using (_logger.BeginScope(GetLinksScope(triggerInput.Events)))
+                    {
+                        await _executor.TryExecuteAsync(input, _cts.Token);
+                    }
+                }
+
+                // Dispose all messages to help with memory pressure. If this is missed, the finalizer thread will still get them.
+                bool hasEvents = false;
+                foreach (var message in messages)
+                {
+                    hasEvents = true;
+                    message.Dispose();
+                }
+
+                // Checkpoint if we processed any events.
+                // Don't checkpoint if no events. This can reset the sequence counter to 0.
+                // Note: we intentionally checkpoint the batch regardless of function
+                // success/failure. EventHub doesn't support any sort "poison event" model,
+                // so that is the responsibility of the user's function currently. E.g.
+                // the function should have try/catch handling around all event processing
+                // code, and capture/log/persist failed events, since they won't be retried.
+                if (hasEvents)
+                {
+                    await CheckpointAsync(context);
+                }
+            }
+
+            private async Task TryExecuteWithLoggingAsync(TriggeredFunctionData input, EventData message)
+            {
+                using (_logger.BeginScope(GetLinksScope(message)))
+                {
+                    await _executor.TryExecuteAsync(input, _cts.Token);
+                }
+            }
+
+            private async Task CheckpointAsync(PartitionContext context)
+            {
+                bool checkpointed = false;
+                if (_batchCheckpointFrequency == 1)
+                {
+                    await _checkpointer.CheckpointAsync(context);
+                    checkpointed = true;
+                }
+                else
+                {
+                    // only checkpoint every N batches
+                    if (++_batchCounter >= _batchCheckpointFrequency)
+                    {
+                        _batchCounter = 0;
+                        await _checkpointer.CheckpointAsync(context);
+                        checkpointed = true;
+                    }
+                }
+
+                if (checkpointed)
+                {
+                    _logger.LogDebug(GetOperationDetails(context, "CheckpointAsync"));
+                }
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!_disposed)
+                {
+                    if (disposing)
+                    {
+                        _cts.Dispose();
+                    }
+
+                    _disposed = true;
+                }
+            }
+
+            public void Dispose()
+            {
+                Dispose(true);
+            }
+
+            async Task ICheckpointer.CheckpointAsync(PartitionContext context)
+            {
+                await context.CheckpointAsync();
+            }
+
+            private static Dictionary<string, object> GetLinksScope(EventData message)
+            {
+                if (TryGetLinkedActivity(message, out var link))
+                {
+                    return new Dictionary<string, object> { ["Links"] = new[] { link } };
+                }
+
+                return EmptyScope;
+            }
+
+            private Dictionary<string, object> GetLinksScope(EventData[] messages)
+            {
+                List<Activity> links = null;
+
+                foreach (var message in messages)
+                {
+                    if (TryGetLinkedActivity(message, out var link))
+                    {
+                        if (links == null)
+                        {
+                            links = new List<Activity>(messages.Length);
+                        }
+
+                        links.Add(link);
+                    }
+                }
+
+                if (links != null)
+                {
+                    return new Dictionary<string, object> { ["Links"] = links };
+                }
+
+                return EmptyScope;
+            }
+
+            private static bool TryGetLinkedActivity(EventData message, out Activity link)
+            {
+                link = null;
+
+                if (((message.SystemProperties != null && message.SystemProperties.TryGetValue("Diagnostic-Id", out var diagnosticIdObj)) || message.Properties.TryGetValue("Diagnostic-Id", out diagnosticIdObj))
+                    && diagnosticIdObj is string diagnosticIdString)
+                {
+                    link = new Activity("Microsoft.Azure.EventHubs.Process");
+                    link.SetParentId(diagnosticIdString);
+                    return true;
+                }
+
+                return false;
+            }
+
+            private static string GetOperationDetails(PartitionContext context, string operation)
+            {
+                StringWriter sw = new StringWriter();
+                using (JsonTextWriter writer = new JsonTextWriter(sw) { Formatting = Formatting.None })
+                {
+                    writer.WriteStartObject();
+                    WritePropertyIfNotNull(writer, "operation", operation);
+                    writer.WritePropertyName("partitionContext");
+                    writer.WriteStartObject();
+                    WritePropertyIfNotNull(writer, "partitionId", context.PartitionId);
+                    WritePropertyIfNotNull(writer, "owner", context.Owner);
+                    WritePropertyIfNotNull(writer, "eventHubPath", context.EventHubPath);
+                    writer.WriteEndObject();
+
+                    // Log partition lease
+                    if (context.Lease != null)
+                    {
+                        writer.WritePropertyName("lease");
+                        writer.WriteStartObject();
+                        WritePropertyIfNotNull(writer, "offset", context.Lease.Offset);
+                        WritePropertyIfNotNull(writer, "sequenceNumber", context.Lease.SequenceNumber.ToString());
+                        writer.WriteEndObject();
+                    }
+
+                    // Log RuntimeInformation if EnableReceiverRuntimeMetric is enabled
+                    if (context.RuntimeInformation != null)
+                    {
+                        writer.WritePropertyName("runtimeInformation");
+                        writer.WriteStartObject();
+                        WritePropertyIfNotNull(writer, "lastEnqueuedOffset", context.RuntimeInformation.LastEnqueuedOffset);
+                        WritePropertyIfNotNull(writer, "lastSequenceNumber", context.RuntimeInformation.LastSequenceNumber.ToString());
+                        WritePropertyIfNotNull(writer, "lastEnqueuedTimeUtc", context.RuntimeInformation.LastEnqueuedTimeUtc.ToString("o"));
+                        writer.WriteEndObject();
+                    }
+
+                    writer.WriteEndObject();
+                }
+
+                return sw.ToString();
+            }
+
+            private static void WritePropertyIfNotNull(JsonTextWriter writer, string propertyName, string propertyValue)
+            {
+                if (propertyValue != null)
+                {
+                    writer.WritePropertyName(propertyName);
+                    writer.WriteValue(propertyValue);
+                }
+            }
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/Listeners/EventHubsScaleMonitor.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Listeners/EventHubsScaleMonitor.cs
@@ -1,0 +1,419 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Common.EventHubs.Listeners
+{
+    internal class EventHubsScaleMonitor : IScaleMonitor<EventHubsTriggerMetrics>
+    {
+        private const string EventHubContainerName = "azure-webjobs-eventhub";
+        private const int PartitionLogIntervalInMinutes = 5;
+
+        private readonly string _functionId;
+        private readonly string _eventHubName;
+        private readonly string _consumerGroup;
+        private readonly string _connectionString;
+        private readonly string _storageConnectionString;
+        private readonly Lazy<EventHubClient> _client;
+        private readonly ScaleMonitorDescriptor _scaleMonitorDescriptor;
+        private readonly ILogger _logger;
+
+        private EventHubsConnectionStringBuilder _connectionStringBuilder;
+        private CloudBlobContainer _blobContainer;
+        private DateTime _nextPartitionLogTime;
+        private DateTime _nextPartitionWarningTime;
+
+        public EventHubsScaleMonitor(
+            string functionId,
+            string eventHubName,
+            string consumerGroup,
+            string connectionString,
+            string storageConnectionString,
+            ILogger logger,
+            CloudBlobContainer blobContainer = null)
+        {
+            _functionId = functionId;
+            _eventHubName = eventHubName;
+            _consumerGroup = consumerGroup;
+            _connectionString = connectionString;
+            _storageConnectionString = storageConnectionString;
+            _logger = logger;
+#pragma warning disable CA1304 // Specify CultureInfo
+            _scaleMonitorDescriptor = new ScaleMonitorDescriptor($"{_functionId}-EventHubTrigger-{_eventHubName}-{_consumerGroup}".ToLower());
+#pragma warning restore CA1304 // Specify CultureInfo
+            _nextPartitionLogTime = DateTime.UtcNow;
+            _nextPartitionWarningTime = DateTime.UtcNow;
+            _blobContainer = blobContainer;
+            _client = new Lazy<EventHubClient>(() => EventHubClient.CreateFromConnectionString(ConnectionStringBuilder.ToString()));
+        }
+
+        public ScaleMonitorDescriptor Descriptor
+        {
+            get
+            {
+                return _scaleMonitorDescriptor;
+            }
+        }
+
+        private CloudBlobContainer BlobContainer
+        {
+            get
+            {
+                if (_blobContainer == null)
+                {
+                    CloudStorageAccount cloudStorageAccount = CloudStorageAccount.Parse(_storageConnectionString);
+                    CloudBlobClient blobClient = cloudStorageAccount.CreateCloudBlobClient();
+                    _blobContainer = blobClient.GetContainerReference(EventHubContainerName);
+                }
+
+                return _blobContainer;
+            }
+        }
+
+        private EventHubsConnectionStringBuilder ConnectionStringBuilder
+        {
+            get
+            {
+                if (_connectionStringBuilder == null)
+                {
+                    _connectionStringBuilder = new EventHubsConnectionStringBuilder(_connectionString);
+                    if (!string.IsNullOrEmpty(_eventHubName))
+                    {
+                        _connectionStringBuilder.EntityPath = _eventHubName;
+                    }
+                }
+
+                return _connectionStringBuilder;
+            }
+        }
+
+        async Task<ScaleMetrics> IScaleMonitor.GetMetricsAsync()
+        {
+            return await GetMetricsAsync();
+        }
+
+        public async Task<EventHubsTriggerMetrics> GetMetricsAsync()
+        {
+            EventHubsTriggerMetrics metrics = new EventHubsTriggerMetrics();
+            EventHubRuntimeInformation runtimeInfo = null;
+
+            try
+            {
+                runtimeInfo = await _client.Value.GetRuntimeInformationAsync();
+            }
+            catch (NotSupportedException e)
+            {
+                _logger.LogWarning($"EventHubs Trigger does not support NotificationHubs. Error: {e.Message}");
+                return metrics;
+            }
+            catch (MessagingEntityNotFoundException)
+            {
+                _logger.LogWarning($"EventHub '{_eventHubName}' was not found.");
+                return metrics;
+            }
+            catch (TimeoutException e)
+            {
+                _logger.LogWarning($"Encountered a timeout while checking EventHub '{_eventHubName}'. Error: {e.Message}");
+                return metrics;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                _logger.LogWarning($"Encountered an exception while checking EventHub '{_eventHubName}'. Error: {e.Message}");
+                return metrics;
+            }
+
+            // Get the PartitionRuntimeInformation for all partitions
+            _logger.LogInformation($"Querying partition information for {runtimeInfo.PartitionCount} partitions.");
+            var tasks = new Task<EventHubPartitionRuntimeInformation>[runtimeInfo.PartitionCount];
+
+            for (int i = 0; i < runtimeInfo.PartitionCount; i++)
+            {
+                tasks[i] = _client.Value.GetPartitionRuntimeInformationAsync(i.ToString());
+            }
+
+            await Task.WhenAll(tasks);
+
+            return await CreateTriggerMetrics(tasks.Select(t => t.Result).ToList());
+        }
+
+        internal async Task<EventHubsTriggerMetrics> CreateTriggerMetrics(List<EventHubPartitionRuntimeInformation> partitionRuntimeInfo, bool alwaysLog = false)
+        {
+            long totalUnprocessedEventCount = 0;
+            bool logPartitionInfo = alwaysLog ? true : DateTime.UtcNow >= _nextPartitionLogTime;
+            bool logPartitionWarning = alwaysLog ? true : DateTime.UtcNow >= _nextPartitionWarningTime;
+
+            // For each partition, get the last enqueued sequence number.
+            // If the last enqueued sequence number does not equal the SequenceNumber from the lease info in storage,
+            // accumulate new event counts across partitions to derive total new event counts.
+            List<string> partitionErrors = new List<string>();
+            for (int i = 0; i < partitionRuntimeInfo.Count; i++)
+            {
+                long partitionUnprocessedEventCount = 0;
+
+                Tuple<BlobPartitionLease, string> partitionLeaseFile = await GetPartitionLeaseFileAsync(i);
+                BlobPartitionLease partitionLeaseInfo = partitionLeaseFile.Item1;
+                string errorMsg = partitionLeaseFile.Item2;
+
+                if (partitionRuntimeInfo[i] == null || partitionLeaseInfo == null)
+                {
+                    partitionErrors.Add(errorMsg);
+                }
+                else
+                {
+                    // Check for the unprocessed messages when there are messages on the event hub parition
+                    // In that case, LastEnqueuedSequenceNumber will be >= 0
+                    if ((partitionRuntimeInfo[i].LastEnqueuedSequenceNumber != -1 && partitionRuntimeInfo[i].LastEnqueuedSequenceNumber != partitionLeaseInfo.SequenceNumber)
+                        || (partitionLeaseInfo.Offset == null && partitionRuntimeInfo[i].LastEnqueuedSequenceNumber >= 0))
+                    {
+                        partitionUnprocessedEventCount = GetUnprocessedEventCount(partitionRuntimeInfo[i], partitionLeaseInfo);
+                        totalUnprocessedEventCount += partitionUnprocessedEventCount;
+                    }
+                }
+            }
+
+            // Only log if not all partitions are failing or it's time to log
+            if (partitionErrors.Count > 0 && (partitionErrors.Count != partitionRuntimeInfo.Count || logPartitionWarning))
+            {
+                _logger.LogWarning($"Function '{_functionId}': Unable to deserialize partition or lease info with the " +
+                    $"following errors: {string.Join(" ", partitionErrors)}");
+                _nextPartitionWarningTime = DateTime.UtcNow.AddMinutes(PartitionLogIntervalInMinutes);
+            }
+
+            if (totalUnprocessedEventCount > 0 && logPartitionInfo)
+            {
+                _logger.LogInformation($"Function '{_functionId}', Total new events: {totalUnprocessedEventCount}");
+                _nextPartitionLogTime = DateTime.UtcNow.AddMinutes(PartitionLogIntervalInMinutes);
+            }
+
+            return new EventHubsTriggerMetrics
+            {
+                Timestamp = DateTime.UtcNow,
+                PartitionCount = partitionRuntimeInfo.Count,
+                EventCount = totalUnprocessedEventCount,
+            };
+        }
+
+        private async Task<Tuple<BlobPartitionLease, string>> GetPartitionLeaseFileAsync(int partitionId)
+        {
+            BlobPartitionLease blobPartitionLease = null;
+            string prefix = $"{EventHubOptions.GetBlobPrefix(_eventHubName, EventHubOptions.GetEventHubNamespace(ConnectionStringBuilder))}{_consumerGroup}/{partitionId}";
+            string errorMsg = null;
+
+            try
+            {
+                CloudBlockBlob blockBlob = BlobContainer.GetBlockBlobReference(prefix);
+
+                if (blockBlob != null)
+                {
+                    var result = await blockBlob.DownloadTextAsync();
+                    if (!string.IsNullOrEmpty(result))
+                    {
+                        blobPartitionLease = JsonConvert.DeserializeObject<BlobPartitionLease>(result);
+                    }
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                var storageException = e as StorageException;
+                if (storageException?.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                {
+                    errorMsg = $"Lease file data could not be found for blob on Partition: '{partitionId}', " +
+                        $"EventHub: '{_eventHubName}', '{_consumerGroup}'. Error: {e.Message}";
+                }
+                else if (e is JsonSerializationException)
+                {
+                    errorMsg = $"Could not deserialize blob lease info for blob on Partition: '{partitionId}', " +
+                    $"EventHub: '{_eventHubName}', Consumer Group: '{_consumerGroup}'. Error: {e.Message}";
+                }
+                else
+                {
+                    errorMsg = $"Encountered exception while checking for last checkpointed sequence number for blob " +
+                    $"on Partition: '{partitionId}', EventHub: '{_eventHubName}', Consumer Group: '{_consumerGroup}'. Error: {e.Message}";
+                }
+            }
+
+            return new Tuple<BlobPartitionLease, string>(blobPartitionLease, errorMsg);
+        }
+
+        // Get the number of unprocessed events by deriving the delta between the server side info and the partition lease info,
+        private static long GetUnprocessedEventCount(EventHubPartitionRuntimeInformation partitionInfo, BlobPartitionLease partitionLeaseInfo)
+        {
+            long partitionLeaseInfoSequenceNumber = partitionLeaseInfo.SequenceNumber ?? 0;
+
+            // This handles two scenarios:
+            //   1. If the partition has received its first message, Offset will be null and LastEnqueuedSequenceNumber will be 0
+            //   2. If there are no instances set to process messages, Offset will be null and LastEnqueuedSequenceNumber will be >= 0
+            if (partitionLeaseInfo.Offset == null && partitionInfo.LastEnqueuedSequenceNumber >= 0)
+            {
+                return partitionInfo.LastEnqueuedSequenceNumber + 1;
+            }
+
+            if (partitionInfo.LastEnqueuedSequenceNumber > partitionLeaseInfoSequenceNumber)
+            {
+                return partitionInfo.LastEnqueuedSequenceNumber - partitionLeaseInfoSequenceNumber;
+            }
+
+            // Partition is a circular buffer, so it is possible that
+            // LastEnqueuedSequenceNumber < SequenceNumber
+            long count = 0;
+            unchecked
+            {
+                count = long.MaxValue - partitionInfo.LastEnqueuedSequenceNumber + partitionLeaseInfoSequenceNumber;
+            }
+
+            // It's possible for checkpointing to be ahead of the partition's LastEnqueuedSequenceNumber,
+            // especially if checkpointing is happening often and load is very low.
+            // If count is negative, we need to know that this read is invalid, so return 0.
+            // e.g., (9223372036854775807 - 10) + 11 = -9223372036854775808
+            return (count < 0) ? 0 : count;
+        }
+
+        ScaleStatus IScaleMonitor.GetScaleStatus(ScaleStatusContext context)
+        {
+            return GetScaleStatusCore(context.WorkerCount, context.Metrics?.Cast<EventHubsTriggerMetrics>().ToArray());
+        }
+
+        public ScaleStatus GetScaleStatus(ScaleStatusContext<EventHubsTriggerMetrics> context)
+        {
+            return GetScaleStatusCore(context.WorkerCount, context.Metrics?.ToArray());
+        }
+
+        private ScaleStatus GetScaleStatusCore(int workerCount, EventHubsTriggerMetrics[] metrics)
+        {
+            ScaleStatus status = new ScaleStatus
+            {
+                Vote = ScaleVote.None,
+            };
+
+            const int NumberOfSamplesToConsider = 5;
+
+            // Unable to determine the correct vote with no metrics.
+            if (metrics == null || metrics.Length == 0)
+            {
+                return status;
+            }
+
+            // We shouldn't assign more workers than there are partitions
+            // This check is first, because it is independent of load or number of samples.
+            int partitionCount = metrics.Last().PartitionCount;
+            if (partitionCount > 0 && partitionCount < workerCount)
+            {
+                status.Vote = ScaleVote.ScaleIn;
+                _logger.LogInformation($"WorkerCount ({workerCount}) > PartitionCount ({partitionCount}).");
+                _logger.LogInformation($"Number of instances ({workerCount}) is too high relative to number " +
+                                       $"of partitions ({partitionCount}) for EventHubs entity ({_eventHubName}, {_consumerGroup}).");
+                return status;
+            }
+
+            // At least 5 samples are required to make a scale decision for the rest of the checks.
+            if (metrics.Length < NumberOfSamplesToConsider)
+            {
+                return status;
+            }
+
+            // Maintain a minimum ratio of 1 worker per 1,000 unprocessed events.
+            long latestEventCount = metrics.Last().EventCount;
+            if (latestEventCount > workerCount * 1000)
+            {
+                status.Vote = ScaleVote.ScaleOut;
+                _logger.LogInformation($"EventCount ({latestEventCount}) > WorkerCount ({workerCount}) * 1,000.");
+                _logger.LogInformation($"Event count ({latestEventCount}) for EventHubs entity ({_eventHubName}, {_consumerGroup}) " +
+                                       $"is too high relative to the number of instances ({workerCount}).");
+                return status;
+            }
+
+            // Check to see if the EventHub has been empty for a while. Only if all metrics samples are empty do we scale down.
+            bool isIdle = metrics.All(m => m.EventCount == 0);
+            if (isIdle)
+            {
+                status.Vote = ScaleVote.ScaleIn;
+                _logger.LogInformation($"'{_eventHubName}' is idle.");
+                return status;
+            }
+
+            // Samples are in chronological order. Check for a continuous increase in unprocessed event count.
+            // If detected, this results in an automatic scale out for the site container.
+            if (metrics[0].EventCount > 0)
+            {
+                bool eventCountIncreasing =
+                IsTrueForLastN(
+                    metrics,
+                    NumberOfSamplesToConsider,
+                    (prev, next) => prev.EventCount < next.EventCount);
+                if (eventCountIncreasing)
+                {
+                    status.Vote = ScaleVote.ScaleOut;
+                    _logger.LogInformation($"Event count is increasing for '{_eventHubName}'.");
+                    return status;
+                }
+            }
+
+            bool eventCountDecreasing =
+                IsTrueForLastN(
+                    metrics,
+                    NumberOfSamplesToConsider,
+                    (prev, next) => prev.EventCount > next.EventCount);
+            if (eventCountDecreasing)
+            {
+                status.Vote = ScaleVote.ScaleIn;
+                _logger.LogInformation($"Event count is decreasing for '{_eventHubName}'.");
+                return status;
+            }
+
+            _logger.LogInformation($"EventHubs entity '{_eventHubName}' is steady.");
+
+            return status;
+        }
+
+        private static bool IsTrueForLastN(IList<EventHubsTriggerMetrics> samples, int count, Func<EventHubsTriggerMetrics, EventHubsTriggerMetrics, bool> predicate)
+        {
+            // Walks through the list from left to right starting at len(samples) - count.
+            for (int i = samples.Count - count; i < samples.Count - 1; i++)
+            {
+                if (!predicate(samples[i], samples[i + 1]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // The BlobPartitionLease class used for reading blob lease data for a partition from storage.
+        // Sample blob lease entry in storage:
+        // {"PartitionId":"0","Owner":"681d365b-de1b-4288-9733-76294e17daf0","Token":"2d0c4276-827d-4ca4-a345-729caeca3b82","Epoch":386,"Offset":"8591964920","SequenceNumber":960180}
+#pragma warning disable CA1812
+        private class BlobPartitionLease
+#pragma warning restore CA1812
+        {
+            public string PartitionId { get; set; }
+
+            public string Owner { get; set; }
+
+            public string Token { get; set; }
+
+            public long? Epoch { get; set; }
+
+            public string Offset { get; set; }
+
+            public long? SequenceNumber { get; set; }
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/Listeners/EventHubsTriggerMetrics.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Listeners/EventHubsTriggerMetrics.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Azure.WebJobs.Host.Scale;
+
+namespace Microsoft.Health.Common.EventHubs.Listeners
+{
+    public class EventHubsTriggerMetrics : ScaleMetrics
+    {
+        /// <summary>
+        /// The total number of unprocessed events across all partitions.
+        /// </summary>
+        public long EventCount { get; set; }
+
+        /// <summary>
+        /// The number of partitions.
+        /// </summary>
+        public int PartitionCount { get; set; }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/Triggers/EventHubAsyncCollector.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Triggers/EventHubAsyncCollector.cs
@@ -1,0 +1,192 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.WebJobs;
+
+namespace Microsoft.Health.Common.EventHubs
+{
+    /// <summary>
+    /// Core object to send events to EventHub.
+    /// Any user parameter that sends EventHub events will eventually get bound to this object.
+    /// This will queue events and send in batches, also keeping under the 256kb event hub limit per batch.
+    /// </summary>
+    internal class EventHubAsyncCollector : IAsyncCollector<EventData>
+    {
+        private readonly EventHubClient _client;
+
+        private readonly Dictionary<string, PartitionCollector> _partitions = new Dictionary<string, PartitionCollector>();
+
+        private const int BatchSize = 100;
+
+        // Suggested to use 240k instead of 256k to leave padding room for headers.
+        private const int MaxByteSize = 240 * 1024;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventHubAsyncCollector"/> class.
+        /// </summary>
+        /// <param name="client">Client</param>
+        public EventHubAsyncCollector(EventHubClient client)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            _client = client;
+        }
+
+        /// <summary>
+        /// Add an event.
+        /// </summary>
+        /// <param name="item">The event to add</param>
+        /// <param name="cancellationToken">a cancellation token. </param>
+        /// <returns>Task</returns>
+        public async Task AddAsync(EventData item, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            string key = item.SystemProperties?.PartitionKey ?? string.Empty;
+
+            PartitionCollector partition;
+            lock (_partitions)
+            {
+                if (!_partitions.TryGetValue(key, out partition))
+                {
+                    partition = new PartitionCollector(this);
+                    _partitions[key] = partition;
+                }
+            }
+
+            await partition.AddAsync(item, cancellationToken);
+        }
+
+        /// <summary>
+        /// synchronously flush events that have been queued up via AddAsync.
+        /// </summary>
+        /// <param name="cancellationToken">a cancellation token</param>
+        public async Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            while (true)
+            {
+                PartitionCollector partition;
+                lock (_partitions)
+                {
+                    if (_partitions.Count == 0)
+                    {
+                        return;
+                    }
+
+                    var kv = _partitions.First();
+                    partition = kv.Value;
+                    _partitions.Remove(kv.Key);
+                }
+
+                await partition.FlushAsync(cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Send the batch of events. All items in the batch will have the same partition key.
+        /// </summary>
+        /// <param name="batch">the set of events to send</param>
+        protected virtual async Task SendBatchAsync(IEnumerable<EventData> batch)
+        {
+            await _client.SendAsync(batch);
+        }
+
+        // A per-partition sender
+        private class PartitionCollector : IAsyncCollector<EventData>
+        {
+            private readonly EventHubAsyncCollector _parent;
+
+            private List<EventData> _list = new List<EventData>();
+
+            // total size of bytes in _list that we'll be sending in this batch.
+            private int _currentByteSize = 0;
+
+            public PartitionCollector(EventHubAsyncCollector parent)
+            {
+                _parent = parent;
+            }
+
+            /// <summary>
+            /// Add an event.
+            /// </summary>
+            /// <param name="item">The event to add</param>
+            /// <param name="cancellationToken">a cancellation token. </param>
+            /// <returns>Task</returns>
+            public async Task AddAsync(EventData item, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                if (item == null)
+                {
+                    throw new ArgumentNullException(nameof(item));
+                }
+
+                while (true)
+                {
+                    lock (_list)
+                    {
+                        var size = item.Body.Count;
+
+                        if (size > MaxByteSize)
+                        {
+                            // Single event is too large to add.
+                            string msg = string.Format("Event is too large. Event is approximately {0}b and max size is {1}b", size, MaxByteSize);
+                            throw new InvalidOperationException(msg);
+                        }
+
+                        bool flush = (_currentByteSize + size > MaxByteSize) || (_list.Count >= BatchSize);
+                        if (!flush)
+                        {
+                            _list.Add(item);
+                            _currentByteSize += size;
+                            return;
+                        }
+
+                        // We should flush.
+                        // Release the lock, flush, and then loop around and try again.
+                    }
+
+                    await FlushAsync(cancellationToken);
+                }
+            }
+
+            /// <summary>
+            /// synchronously flush events that have been queued up via AddAsync.
+            /// </summary>
+            /// <param name="cancellationToken">a cancellation token</param>
+            public async Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+            {
+                EventData[] batch = null;
+                lock (_list)
+                {
+                    batch = _list.ToArray();
+                    _list.Clear();
+                    _currentByteSize = 0;
+                }
+
+                if (batch.Length > 0)
+                {
+                    await _parent.SendBatchAsync(batch);
+
+                    // Dispose all messages to help with memory pressure. If this is missed, the finalizer thread will still get them.
+                    foreach (var msg in batch)
+                    {
+                        msg.Dispose();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/Triggers/EventHubTriggerAttributeBindingProvider.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Triggers/EventHubTriggerAttributeBindingProvider.cs
@@ -1,0 +1,102 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Health.Common.EventHubs
+{
+    internal class EventHubTriggerAttributeBindingProvider : ITriggerBindingProvider
+    {
+        private readonly INameResolver _nameResolver;
+        private readonly ILogger _logger;
+        private readonly IConfiguration _config;
+        private readonly IOptions<EventHubOptions> _options;
+        private readonly IConverterManager _converterManager;
+
+        public EventHubTriggerAttributeBindingProvider(
+            IConfiguration configuration,
+            INameResolver nameResolver,
+            IConverterManager converterManager,
+            IOptions<EventHubOptions> options,
+            ILoggerFactory loggerFactory)
+        {
+            _config = configuration;
+            _nameResolver = nameResolver;
+            _converterManager = converterManager;
+            _options = options;
+            _logger = loggerFactory?.CreateLogger(LogCategories.CreateTriggerCategory("EventHub"));
+        }
+
+#pragma warning disable SA1404 // Code analysis suppression should have justification
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+#pragma warning restore SA1404 // Code analysis suppression should have justification
+        public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            ParameterInfo parameter = context.Parameter;
+            EventHubTriggerAttribute attribute = parameter.GetCustomAttribute<EventHubTriggerAttribute>(inherit: false);
+
+            if (attribute == null)
+            {
+                return Task.FromResult<ITriggerBinding>(null);
+            }
+
+            string resolvedEventHubName = _nameResolver.ResolveWholeString(attribute.EventHubName);
+
+            string consumerGroup = attribute.ConsumerGroup ?? PartitionReceiver.DefaultConsumerGroupName;
+            string resolvedConsumerGroup = _nameResolver.ResolveWholeString(consumerGroup);
+
+            string connectionString = null;
+            if (!string.IsNullOrWhiteSpace(attribute.Connection))
+            {
+                attribute.Connection = _nameResolver.ResolveWholeString(attribute.Connection);
+                connectionString = _config.GetConnectionStringOrSetting(attribute.Connection);
+                _options.Value.AddReceiver(resolvedEventHubName, connectionString);
+            }
+
+            var eventHostListener = _options.Value.GetEventProcessorHost(_config, resolvedEventHubName, resolvedConsumerGroup);
+
+            string storageConnectionString = _config.GetWebJobsConnectionString(ConnectionStringNames.Storage);
+
+            Func<ListenerFactoryContext, bool, Task<IListener>> createListener =
+             (factoryContext, singleDispatch) =>
+             {
+                 IListener listener = new EventHubListener(
+                                                factoryContext.Descriptor.Id,
+                                                resolvedEventHubName,
+                                                resolvedConsumerGroup,
+                                                connectionString,
+                                                storageConnectionString,
+                                                factoryContext.Executor,
+                                                eventHostListener,
+                                                singleDispatch,
+                                                _options.Value,
+                                                _logger);
+                 return Task.FromResult(listener);
+             };
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            ITriggerBinding binding = BindingFactory.GetTriggerBinding(new EventHubTriggerBindingStrategy(), parameter, _converterManager, createListener);
+#pragma warning restore CS0618 // Type or member is obsolete
+            return Task.FromResult<ITriggerBinding>(binding);
+        }
+    } // end class
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/Triggers/EventHubTriggerBindingStrategy.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Triggers/EventHubTriggerBindingStrategy.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Processor;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+
+namespace Microsoft.Health.Common.EventHubs
+{
+    // Binding strategy for an event hub triggers.
+#pragma warning disable CS0618 // Type or member is obsolete
+    internal class EventHubTriggerBindingStrategy : ITriggerBindingStrategy<EventData, EventHubTriggerInput>
+#pragma warning restore CS0618 // Type or member is obsolete
+    {
+#pragma warning disable SA1404 // Code analysis suppression should have justification
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+#pragma warning restore SA1404 // Code analysis suppression should have justification
+        public EventHubTriggerInput ConvertFromString(string input)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(input);
+            EventData eventData = new EventData(bytes);
+
+            // Return a single event. Doesn't support multiple dispatch
+            return EventHubTriggerInput.New(eventData);
+        }
+
+        // Single instance: Core --> EventData
+        public EventData BindSingle(EventHubTriggerInput value, ValueBindingContext context)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            return value.GetSingleEventData();
+        }
+
+        public EventData[] BindMultiple(EventHubTriggerInput value, ValueBindingContext context)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            return value.Events;
+        }
+
+        public Dictionary<string, Type> GetBindingContract(bool isSingleDispatch = true)
+        {
+            var contract = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+            contract.Add("PartitionContext", typeof(PartitionContext));
+
+            AddBindingContractMember(contract, "PartitionKey", typeof(string), isSingleDispatch);
+            AddBindingContractMember(contract, "Offset", typeof(string), isSingleDispatch);
+            AddBindingContractMember(contract, "SequenceNumber", typeof(long), isSingleDispatch);
+            AddBindingContractMember(contract, "EnqueuedTimeUtc", typeof(DateTime), isSingleDispatch);
+            AddBindingContractMember(contract, "Properties", typeof(IDictionary<string, object>), isSingleDispatch);
+            AddBindingContractMember(contract, "SystemProperties", typeof(IDictionary<string, object>), isSingleDispatch);
+
+            return contract;
+        }
+
+        private static void AddBindingContractMember(Dictionary<string, Type> contract, string name, Type type, bool isSingleDispatch)
+        {
+            if (!isSingleDispatch)
+            {
+                name += "Array";
+            }
+
+            contract.Add(name, isSingleDispatch ? type : type.MakeArrayType());
+        }
+
+        public Dictionary<string, object> GetBindingData(EventHubTriggerInput value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            SafeAddValue(() => bindingData.Add(nameof(value.PartitionContext), value.PartitionContext));
+
+            if (value.IsSingleDispatch)
+            {
+                AddBindingData(bindingData, value.GetSingleEventData());
+            }
+            else
+            {
+                AddBindingData(bindingData, value.Events);
+            }
+
+            return bindingData;
+        }
+
+        internal static void AddBindingData(Dictionary<string, object> bindingData, EventData[] events)
+        {
+            int length = events.Length;
+            var partitionKeys = new string[length];
+            var offsets = new string[length];
+            var sequenceNumbers = new long[length];
+            var enqueuedTimesUtc = new DateTime[length];
+            var properties = new IDictionary<string, object>[length];
+            var systemProperties = new IDictionary<string, object>[length];
+
+            SafeAddValue(() => bindingData.Add("PartitionKeyArray", partitionKeys));
+            SafeAddValue(() => bindingData.Add("OffsetArray", offsets));
+            SafeAddValue(() => bindingData.Add("SequenceNumberArray", sequenceNumbers));
+            SafeAddValue(() => bindingData.Add("EnqueuedTimeUtcArray", enqueuedTimesUtc));
+            SafeAddValue(() => bindingData.Add("PropertiesArray", properties));
+            SafeAddValue(() => bindingData.Add("SystemPropertiesArray", systemProperties));
+
+            for (int i = 0; i < events.Length; i++)
+            {
+                partitionKeys[i] = events[i].SystemProperties?.PartitionKey;
+                offsets[i] = events[i].SystemProperties?.Offset;
+                sequenceNumbers[i] = events[i].SystemProperties?.SequenceNumber ?? 0;
+                enqueuedTimesUtc[i] = events[i].SystemProperties?.EnqueuedTimeUtc ?? DateTime.MinValue;
+                properties[i] = events[i].Properties;
+                systemProperties[i] = events[i].SystemProperties?.ToDictionary();
+            }
+        }
+
+        private static void AddBindingData(Dictionary<string, object> bindingData, EventData eventData)
+        {
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.PartitionKey), eventData.SystemProperties?.PartitionKey));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.Offset), eventData.SystemProperties?.Offset));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.SequenceNumber), eventData.SystemProperties?.SequenceNumber ?? 0));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.EnqueuedTimeUtc), eventData.SystemProperties?.EnqueuedTimeUtc ?? DateTime.MinValue));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.Properties), eventData.Properties));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties), eventData.SystemProperties?.ToDictionary()));
+        }
+
+        private static void SafeAddValue(Action addValue)
+        {
+            try
+            {
+                addValue();
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                // some message propery getters can throw, based on the
+                // state of the message
+            }
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/EventHub/Triggers/EventHubTriggerInput.cs
+++ b/src/lib/Microsoft.Health.Common/EventHub/Triggers/EventHubTriggerInput.cs
@@ -1,0 +1,93 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Processor;
+
+namespace Microsoft.Health.Common.EventHubs
+{
+    // The core object we get when an EventHub is triggered.
+    // This gets converted to the user type (EventData, string, poco, etc)
+    internal sealed class EventHubTriggerInput
+    {
+        // If != -1, then only process a single event in this batch.
+        private int _selector = -1;
+
+        internal EventData[] Events { get; set; }
+
+        internal PartitionContext PartitionContext { get; set; }
+
+        public bool IsSingleDispatch
+        {
+            get
+            {
+                return _selector != -1;
+            }
+        }
+
+        public static EventHubTriggerInput New(EventData eventData)
+        {
+            return new EventHubTriggerInput
+            {
+                PartitionContext = null,
+                Events = new EventData[]
+                {
+                      eventData,
+                },
+                _selector = 0,
+            };
+        }
+
+        public EventHubTriggerInput GetSingleEventTriggerInput(int idx)
+        {
+            return new EventHubTriggerInput
+            {
+                Events = Events,
+                PartitionContext = PartitionContext,
+                _selector = idx,
+            };
+        }
+
+        public EventData GetSingleEventData()
+        {
+            return Events[_selector];
+        }
+
+        public Dictionary<string, string> GetTriggerDetails(PartitionContext context)
+        {
+            if (Events.Length == 0)
+            {
+                return new Dictionary<string, string>();
+            }
+
+            string offset, enqueueTimeUtc, sequenceNumber;
+            if (IsSingleDispatch)
+            {
+                offset = Events[0].SystemProperties?.Offset;
+                enqueueTimeUtc = Events[0].SystemProperties?.EnqueuedTimeUtc.ToString("o");
+                sequenceNumber = Events[0].SystemProperties?.SequenceNumber.ToString();
+            }
+            else
+            {
+                EventData first = Events[0];
+                EventData last = Events[Events.Length - 1];
+
+                offset = $"{first.SystemProperties?.Offset}-{last.SystemProperties?.Offset}";
+                enqueueTimeUtc = $"{first.SystemProperties?.EnqueuedTimeUtc.ToString("o")}-{last.SystemProperties?.EnqueuedTimeUtc.ToString("o")}";
+                sequenceNumber = $"{first.SystemProperties?.SequenceNumber}-{last.SystemProperties?.SequenceNumber}";
+            }
+
+            return new Dictionary<string, string>()
+            {
+                { "PartionId", context.PartitionId },
+                { "Offset", offset },
+                { "EnqueueTimeUtc", enqueueTimeUtc },
+                { "SequenceNumber", sequenceNumber },
+                { "Count", Events.Length.ToString() },
+            };
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
+++ b/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
@@ -14,6 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Data/SampledDataProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Data/SampledDataProcessor.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Ingest.Data
             {
                 string value = null;
 
-                while (i < values.Length && values[i].Time >= currentDateTime && values[i].Time < nextDateTime)
+                while (i < values.Length && values[i].Time.ToUniversalTime() >= currentDateTime && values[i].Time.ToUniversalTime() < nextDateTime)
                 {
                     value = values[i].Value;
                     i++;

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.0" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
@@ -43,6 +43,9 @@
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Common\Microsoft.Health.Common.csproj" />


### PR DESCRIPTION
### Create a Prototype for processing IoMT events without Streaming Analytics

Leverages source code for [Azure Function Event Hub extensions](https://github.com/Azure/azure-functions-eventhubs-extension).

A majority of the changes are in the EventHubListner.cs  & MeasurementFhirImportService.cs classes.

Additional improvements include:
* Switching to latest [Azure.Messaging.EventHubs SDK](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/MigrationGuide.md).  Newer SDK has expanded options for controlling the identity used to connect to the Event Hub.
* Ensure the time period is standardize to common period. For example if the timed flush is 1 minute it should be at the top of every minute, not an arbitrary starting point when processing starts.  This will ensure repeatability and consistency across partitions
* Events should be matched to the time period for repeatability.  For example if you have 2,000 events and a 1 minute flush time, events should be read until they are past the 1 minute period (based on event enqueued time) and a batch is issued.  This ensure repeatability in down stream processing if the pipeline is reseeded.
* Ensure retries on failures.  Right now an unhandled error will be ignored and not retried.  This needs to be updated to keep retrying like with Stream Analytics.

Additional Ideas:
* Memory consumption may be high using this model.  It might be beneficial to introduce some compression.
* Deserialize events directly into measurement groups/measurements and flush them to the function.  This would make consumption in the functions easier and give us additional opportunities to reduce memory to just the objects we need but has additional challenges.  Watermarking progress on the EventHub is done based on the sequence number and partition.  If we went this route we would need to correlate the correct event data with the measurements so the watermark can be saved correctly.  Going this route also reduces the utility of the trigger we create for other applications.
* Use the Event Hub trigger to just track watermark changes and use additional methods like durable functions to process the events when we hit out batch size or timed flush.  PHI isn't an issue because we are just transmitting the event metadata.  In prior testing the spin up time for an Event Hub processor is pretty long ( a couple seconds) and not really suited for this.  Would need to see if there is a lighter weight alternative to make this feasible.  If so it would be a good option and reduce concerns about memory usage since we would only load messages when it is time to process them based on the watermarks.
