### PR TITLE
Create a new template factory for IoT Central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.vscode
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/CollectionContentTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/CollectionContentTemplateFactory.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         private CollectionContentTemplateFactory()
             : base(
                   new JsonPathContentTemplateFactory(),
-                  new IotJsonPathContentTemplateFactory())
+                  new IotJsonPathContentTemplateFactory(),
+                  new IotCentralJsonPathContentTemplateFactory())
         {
         }
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotCentralJsonPathContentTemplate.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotCentralJsonPathContentTemplate.cs
@@ -1,0 +1,24 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public class IotCentralJsonPathContentTemplate : JsonPathContentTemplate
+    {
+        [JsonIgnore]
+        public override string DeviceIdExpression
+        {
+            get => "$.deviceId"; set { }
+        }
+
+        [JsonIgnore]
+        public override string TimestampExpression
+        {
+            get => "$.enqueuedTime"; set { }
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotCentralJsonPathContentTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotCentralJsonPathContentTemplateFactory.cs
@@ -1,0 +1,32 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public class IotCentralJsonPathContentTemplateFactory : HandlerProxyTemplateFactory<TemplateContainer, IContentTemplate>
+    {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Exception message")]
+        public override IContentTemplate Create(TemplateContainer jsonTemplate)
+        {
+            EnsureArg.IsNotNull(jsonTemplate, nameof(jsonTemplate));
+
+            const string targetTypeName = "IotCentralJsonPathContent";
+            if (!jsonTemplate.MatchTemplateName(targetTypeName))
+            {
+                return null;
+            }
+
+            if (jsonTemplate.Template?.Type != JTokenType.Object)
+            {
+                throw new InvalidTemplateException($"Expected an object for the template property value for template type {targetTypeName}.");
+            }
+
+            return jsonTemplate.Template.ToValidTemplate<IotCentralJsonPathContentTemplate>();
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/IotCentralJsonPathContentTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/IotCentralJsonPathContentTemplateFactoryTests.cs
@@ -1,0 +1,135 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Tests.Common;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public class IotCentralJsonPathContentTemplateFactoryTests
+    {
+        [Theory]
+        [FileData(@"TestInput/data_IotCentralJsonPathContentTemplateValid.json")]
+        public void GivenValidTemplateJson_WhenFactoryCreate_ThenTemplateCreated_Test(string json)
+        {
+            var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
+
+            var factory = new IotCentralJsonPathContentTemplateFactory();
+
+            var template = factory.Create(templateContainer);
+            Assert.NotNull(template);
+
+            var jsonPathTemplate = template as IotCentralJsonPathContentTemplate;
+            Assert.NotNull(jsonPathTemplate);
+
+            Assert.Equal("telemetry", jsonPathTemplate.TypeName);
+            Assert.Equal("$..[?(@telemetry)]", jsonPathTemplate.TypeMatchExpression);
+            Assert.Equal("$.deviceId", jsonPathTemplate.DeviceIdExpression);
+            Assert.Equal("$.enqueuedTime", jsonPathTemplate.TimestampExpression);
+            Assert.Null(jsonPathTemplate.PatientIdExpression);
+            Assert.Collection(
+                jsonPathTemplate.Values,
+                v =>
+                {
+                    Assert.True(v.Required);
+                    Assert.Equal("activity", v.ValueName);
+                    Assert.Equal("$.template.Activity", v.ValueExpression);
+                },
+                v =>
+                {
+                    Assert.True(v.Required);
+                    Assert.Equal("bp_diastolic", v.ValueName);
+                    Assert.Equal("$.template.BloodPressure.Diastolic", v.ValueExpression);
+                });
+        }
+
+        [Theory]
+        [FileData(@"TestInput/data_IotCentralJsonPathContentTemplateValidWithOptional.json")]
+        public void GivenValidTemplateJsonWithOptionalExpressions_WhenFactoryCreate_ThenTemplateCreated_Test(string json)
+        {
+            var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
+
+            var factory = new IotCentralJsonPathContentTemplateFactory();
+
+            var template = factory.Create(templateContainer);
+            Assert.NotNull(template);
+
+            var jsonPathTemplate = template as IotCentralJsonPathContentTemplate;
+            Assert.NotNull(jsonPathTemplate);
+
+            Assert.Equal("telemetry", jsonPathTemplate.TypeName);
+            Assert.Equal("$..[?(@telemetry)]", jsonPathTemplate.TypeMatchExpression);
+            Assert.Equal("$.deviceId", jsonPathTemplate.DeviceIdExpression);
+            Assert.Equal("$.enqueuedTime", jsonPathTemplate.TimestampExpression);
+            Assert.Equal("$.messageProperties.patientId", jsonPathTemplate.PatientIdExpression);
+            Assert.Collection(
+                jsonPathTemplate.Values,
+                v =>
+                {
+                    Assert.True(v.Required);
+                    Assert.Equal("activity", v.ValueName);
+                    Assert.Equal("$.template.Activity", v.ValueExpression);
+                },
+                v =>
+                {
+                    Assert.True(v.Required);
+                    Assert.Equal("bp_diastolic", v.ValueName);
+                    Assert.Equal("$.template.BloodPressure.Diastolic", v.ValueExpression);
+                });
+        }
+
+        [Theory]
+        [FileData(@"TestInput/data_IotCentralJsonPathContentTemplateInvalidMissingTypeMetadata.json")]
+        public void GivenInvalidTemplateJsonMissingTypeMetadata_WhenFactoryCreate_ThenTemplateErrorReturned_Test(string json)
+        {
+            var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
+            var factory = new IotCentralJsonPathContentTemplateFactory();
+
+            var ex = Assert.Throws<InvalidTemplateException>(() => factory.Create(templateContainer));
+            Assert.NotNull(ex);
+            Assert.Contains("TypeName", ex.Message);
+            Assert.Contains("TypeMatchExpression", ex.Message);
+        }
+
+        [Theory]
+        [FileData(@"TestInput/data_IotCentralJsonPathContentTemplateInvalidMissingValueField.json")]
+        public void GivenInvalidTemplateJsonMissingValueField_WhenFactoryCreate_ThenTemplateErrorReturned_Test(string json)
+        {
+            var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
+            var factory = new IotCentralJsonPathContentTemplateFactory();
+
+            var ex = Assert.Throws<InvalidTemplateException>(() => factory.Create(templateContainer));
+            Assert.NotNull(ex);
+            Assert.Contains("ValueName", ex.Message);
+        }
+
+        [Fact]
+        public void GivenInvalidTemplateTargetType_WhenFactoryCreate_ThenNullReturned_Test()
+        {
+            var templateContainer = new TemplateContainer();
+
+            var factory = new IotCentralJsonPathContentTemplateFactory();
+
+            var template = factory.Create(templateContainer);
+            Assert.Null(template);
+        }
+
+        [Fact]
+        public void GivenInvalidTemplateBody_WhenFactoryCreate_ThenInvalidTemplateExceptionThrown_Test()
+        {
+            var templateContainer = new TemplateContainer
+            {
+                TemplateType = "IotCentralJsonPathContent",
+                Template = null,
+            };
+
+            var factory = new IotCentralJsonPathContentTemplateFactory();
+
+            var ex = Assert.Throws<InvalidTemplateException>(() => factory.Create(templateContainer));
+            Assert.NotNull(ex);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/IotCentralJsonPathContentTemplateTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/IotCentralJsonPathContentTemplateTests.cs
@@ -1,0 +1,68 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Health.Tests.Common;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public class IotCentralJsonPathContentTemplateTests
+    {
+        private static readonly IContentTemplate TelemetryTemplate = new IotCentralJsonPathContentTemplate
+        {
+            TypeName = "telemetry",
+            TypeMatchExpression = "$..[?(@telemetry)]",
+            Values = new List<JsonPathValueExpression>
+            {
+                new JsonPathValueExpression { ValueName = "activity", ValueExpression = "$.telemetry.Activity", Required = true },
+                new JsonPathValueExpression { ValueName = "bp_diastolic", ValueExpression = "$.telemetry.BloodPressure.Diastolic", Required = true },
+                new JsonPathValueExpression { ValueName = "bp_systolic", ValueExpression = "$.telemetry.BloodPressure.Systolic", Required = true },
+                new JsonPathValueExpression { ValueName = "respitoryrate", ValueExpression = "$.telemetry.RespiratoryRate", Required = true },
+            },
+        };
+
+        [Theory]
+        [FileData(@"TestInput/data_IotCentralPayloadExample.json")]
+        public void GivenTelemetryTemplate_WhenGetMeasurements_ThenAllMeasurementReturned_Test(string eventJson)
+        {
+            var token = JsonConvert.DeserializeObject<JToken>(eventJson);
+            var result = TelemetryTemplate.GetMeasurements(token).ToArray();
+
+            Assert.NotNull(result);
+            Assert.Collection(result, m =>
+            {
+                Assert.Equal("telemetry", m.Type);
+                Assert.Equal(token["enqueuedTime"], m.OccurrenceTimeUtc);
+                Assert.Equal(token["deviceId"], m.DeviceId);
+                Assert.Collection(
+                    m.Properties,
+                    p =>
+                    {
+                        Assert.Equal("activity", p.Name);
+                        Assert.Equal("running", p.Value);
+                    },
+                    p =>
+                    {
+                        Assert.Equal("bp_diastolic", p.Name);
+                        Assert.Equal("7", p.Value);
+                    },
+                    p =>
+                    {
+                        Assert.Equal("bp_systolic", p.Name);
+                        Assert.Equal("71", p.Value);
+                    },
+                    p =>
+                    {
+                        Assert.Equal("respitoryrate", p.Name);
+                        Assert.Equal("13", p.Value);
+                    });
+            });
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/Microsoft.Health.Fhir.Ingest.Template.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/Microsoft.Health.Fhir.Ingest.Template.UnitTests.csproj
@@ -43,106 +43,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="TestInput\data_CodeValueFhirTemplate_CodeableConceptAndStringComponent.json">
+    <None Update="TestInput\*.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="TestInput\data_CodeValueFhirTemplate_CodeableConceptData.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CodeValueFhirTemplate_Components.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CodeValueFhirTemplate_Quantity.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CodeValueFhirTemplateInvalid_MissingFields.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CodeValueFhirTemplate_SampledData.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CodeValueFhirTemplate_String.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionContentTemplateEmpty.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionContentTemplateEmptyWithType.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionContentTemplateMultipleMocks.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionFhirTemplateEmpty.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionFhirTemplateEmptyWithType.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionFhirTemplateInvalid.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionFhirTemplateMixedValidity.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionContentTemplateMixed.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionContentTemplateInvalid.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionContentTemplateMixedValidity.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionFhirTemplateMixed.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionFhirTemplateValid.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_CollectionFhirTemplateMultipleMocks.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_IotHubPayloadExample.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_IotHubPayloadExampleMissingCreateTime.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_IotHubPayloadMultiValueExample.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_IotJsonPathContentTemplateValid.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_IotJsonPathContentTemplateInvalidMissingTypeMetadata.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_IotJsonPathContentTemplateInvalidMissingValueField.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_IotJsonPathContentTemplateValidWithOptional.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_JsonPathContentTemplateInvalidMissingExpression.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_JsonPathContentTemplateValid.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_JsonPathContentTemplateValidWithOptional.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_InvalidJson.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_InvalidTemplateType.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_InvalidCollectionContentTemplateWithNoTemplateArray.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestInput\data_InvalidCollectionFhirTemplateWithNoTemplateArray.json">
+    <None Update="TestInput\*.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_IotCentralJsonPathContentTemplateInvalidMissingTypeMetadata.json
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_IotCentralJsonPathContentTemplateInvalidMissingTypeMetadata.json
@@ -1,0 +1,12 @@
+{
+  "templateType": "IotCentralJsonPathContent",
+  "template": {
+    "values": [
+      {
+        "required": "true",
+        "valueExpression": "$.Body.heartrate",
+        "valueName": "hr"
+      }
+    ]
+  }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_IotCentralJsonPathContentTemplateInvalidMissingValueField.json
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_IotCentralJsonPathContentTemplateInvalidMissingValueField.json
@@ -1,0 +1,13 @@
+{
+  "templateType": "IotCentralJsonPathContent",
+  "template": {
+    "typeName": "heartrate",
+    "typeMatchExpression": "$..[?(@Body.heartrate)]",
+    "values": [
+      {
+        "required": "true",
+        "valueExpression": "$.Body.heartrate"
+      }
+    ]
+  }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_IotCentralJsonPathContentTemplateValid.json
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_IotCentralJsonPathContentTemplateValid.json
@@ -1,0 +1,19 @@
+{
+  "templateType": "IotCentralJsonPathContent",
+  "template": {
+    "typeName": "telemetry",
+    "typeMatchExpression": "$..[?(@telemetry)]",
+    "values": [
+      {
+        "required": "true",
+        "valueExpression": "$.template.Activity",
+        "valueName": "activity"
+      },
+      {
+        "required": "true",
+        "valueExpression": "$.template.BloodPressure.Diastolic",
+        "valueName": "bp_diastolic"
+      }
+    ]
+  }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_IotCentralJsonPathContentTemplateValidWithOptional.json
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_IotCentralJsonPathContentTemplateValidWithOptional.json
@@ -1,0 +1,20 @@
+{
+  "templateType": "IotCentralJsonPathContent",
+  "template": {
+    "typeName": "telemetry",
+    "typeMatchExpression": "$..[?(@telemetry)]",
+    "patientIdExpression": "$.messageProperties.patientId",
+    "values": [
+      {
+        "required": "true",
+        "valueExpression": "$.template.Activity",
+        "valueName": "activity"
+      },
+      {
+        "required": "true",
+        "valueExpression": "$.template.BloodPressure.Diastolic",
+        "valueName": "bp_diastolic"
+      }
+    ]
+  }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_IotCentralPayloadExample.json
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_IotCentralPayloadExample.json
@@ -1,0 +1,22 @@
+{
+  "applicationId": "1dffa667-9bee-4f16-b243-25ad4151475e",
+  "messageSource": "telemetry",
+  "deviceId": "1vzb5ghlsg1",
+  "schema": "default@v1",
+  "templateId": "urn:qugj6vbw5:___qbj_27r",
+  "enqueuedTime": "2020-08-05T22:26:55.455Z",
+  "telemetry": {
+      "Activity": "running",
+      "BloodPressure": {
+          "Diastolic": 7,
+          "Systolic": 71
+      },
+      "RespiratoryRate": 13
+  },
+  "enrichments": {
+    "userSpecifiedKey": "sampleValue"
+  },
+  "messageProperties": {
+    "messageProp": "value"
+  }
+}


### PR DESCRIPTION
IoT Central has an updated [telemetry format](https://github.com/microsoft/iomt-fhir/pull/new/personal/rogordon01/addIotCentralTemplateFactory) for exporting device data. This PR creates a new template factory in order to normalize events of this type.