### PR TITLE
Fix High CPU usage in Event Processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,4 @@ ASALocalRun/
 .Trashes
 ehthumbs.db
 Thumbs.db
+src/console/local.appsettings.json

--- a/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
+++ b/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
@@ -29,6 +29,10 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
+    <None Update="local.appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
   </ItemGroup>
   
 </Project>

--- a/src/console/Program.cs
+++ b/src/console/Program.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Health.Fhir.Ingest.Console
         {
             IConfiguration config = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json", true, true)
+                .AddJsonFile("local.appsettings.json", true, true)
                 .AddEnvironmentVariables()
                 .Build();
 

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
                 Console.WriteLine($"Starting event hub processor at {DateTime.UtcNow}");
                 await processor.StartProcessingAsync(ct);
 
-                // Wait indefinitely until cancelation is requested
+                // Wait indefinitely until cancellation is requested
                 ct.WaitHandle.WaitOne();
 
                 await processor.StopProcessingAsync();

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
@@ -89,11 +89,10 @@ namespace Microsoft.Health.Events.EventHubProcessor
             try
             {
                 Console.WriteLine($"Starting event hub processor at {DateTime.UtcNow}");
-                await processor.StartProcessingAsync();
+                await processor.StartProcessingAsync(ct);
 
-                while (!ct.IsCancellationRequested)
-                {
-                }
+                // Wait indefinitely until cancelation is requested
+                ct.WaitHandle.WaitOne();
 
                 await processor.StopProcessingAsync();
             }


### PR DESCRIPTION
* Update core EventProcessor loop to wait indefinitely on cancellation token instead of spin in while loop to reduce CPU usage.
* Pass ct token into processor.StartProcessingAsync
* Add optional local.appsettings.json to config loading and add file to gitignore to facilitate local testing