### PR TITLE
Clear Event Hub Device Watermarks when source event hub changed

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/ICheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/ICheckpointClient.cs
@@ -15,5 +15,7 @@ namespace Microsoft.Health.Events.EventCheckpointing
         Task PublishCheckpointAsync(string partitionId);
 
         Task<Checkpoint> GetCheckpointForPartitionAsync(string partitionId);
+
+        Task ResetCheckpointsAsync();
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
@@ -179,6 +179,8 @@ namespace Microsoft.Health.Events.EventCheckpointing
         {
             try
             {
+                _log.LogTrace($"Entering {nameof(ResetCheckpointsAsync)}...");
+
                 foreach (BlobItem blob in _storageClient.GetBlobs(states: BlobStates.All, prefix: _blobCheckpointPrefix, cancellationToken: CancellationToken.None))
                 {
                     if (!blob.Name.Contains(_blobPath, StringComparison.OrdinalIgnoreCase))
@@ -196,6 +198,8 @@ namespace Microsoft.Health.Events.EventCheckpointing
                         }
                     }
                 }
+
+                _log.LogTrace($"Exiting {nameof(ResetCheckpointsAsync)}.");
             }
 #pragma warning disable CA1031
             catch (Exception ex)

--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointOptions.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointOptions.cs
@@ -9,6 +9,14 @@ namespace Microsoft.Health.Events.EventCheckpointing
     {
         public const string Settings = "Checkpoint";
 
+        /// <summary>
+        /// Configurable prefix for the blob path where the checkpoints will be stored.
+        /// The provided prefix will be appended to the app type so as to have the checkpoints indiviidually maintained per app type.
+        /// The entire blob path will comprise of this blob prefix and the event hub details(event hub namespace FQDN and event hub name)
+        /// appended to it, to ensure that the checkpoints are appropriately managed if the source event hub changes.
+        /// For example, for the Normalization app if the provided BlobPrefix is "devicedata", the complete blob path for
+        /// the respective checkpoints will be - Normalization/devicedata/checkpoint/*eventHubNamespaceFQDN*/*eventHubName*/
+        /// </summary>
         public string BlobPrefix { get; set; }
 
         public string CheckpointBatchCount { get; set; }

--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointOptions.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.Events.EventCheckpointing
 
         /// <summary>
         /// Configurable prefix for the blob path where the checkpoints will be stored.
-        /// The provided prefix will be appended to the app type so as to have the checkpoints indiviidually maintained per app type.
+        /// The provided prefix will be appended to the app type so as to have the checkpoints individually maintained per app type.
         /// The entire blob path will comprise of this blob prefix and the event hub details(event hub namespace FQDN and event hub name)
         /// appended to it, to ensure that the checkpoints are appropriately managed if the source event hub changes.
         /// For example, for the Normalization app if the provided BlobPrefix is "devicedata", the complete blob path for

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
@@ -36,6 +36,9 @@ namespace Microsoft.Health.Events.EventHubProcessor
         {
             EnsureArg.IsNotNull(processor);
 
+            // Reset previous checkpoints corresponding to an older source event hub (i.e. applicable if the source event hub changes)
+            await _checkpointClient.ResetCheckpointsAsync();
+
             // Processes two types of events
             // 1) Event hub events
             // 2) Maximum wait events. These are generated when we have not received an event hub

--- a/test/Microsoft.Health.Events.UnitTest/StorageCheckpointTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/StorageCheckpointTests.cs
@@ -1,0 +1,174 @@
+﻿using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Health.Events.Common;
+using Microsoft.Health.Events.EventCheckpointing;
+using Microsoft.Health.Logging.Telemetry;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Health.Events.UnitTest
+{
+    public class StorageCheckpointTests
+    {
+        private readonly BlobContainerClient _blobContainerClient;
+        private readonly EventHubClientOptions _eventHubClientOptions;
+        private readonly ITelemetryLogger _logger;
+        private readonly StorageCheckpointOptions _storageCheckpointOptions;
+
+        private readonly string _blobCheckpointPrefix;
+        private readonly string _blobPath;
+        private readonly string _eventHubName;
+        private readonly string _eventHubNamespaceFQDN;
+
+        public StorageCheckpointTests()
+        {
+            _blobContainerClient = Substitute.For<BlobContainerClient>();
+
+            _storageCheckpointOptions = new StorageCheckpointOptions()
+            {
+                BlobPrefix = "Normalization",
+                CheckpointBatchCount = "5"
+            };
+
+            _eventHubClientOptions = new EventHubClientOptions();
+            _eventHubNamespaceFQDN = "test.servicebus.windows.net";
+            _eventHubName = "devicedata";
+
+            // Blob path corresponds to current event hub name
+            _blobCheckpointPrefix = $"{_storageCheckpointOptions.BlobPrefix}/checkpoint/";
+            _blobPath = $"{_blobCheckpointPrefix}{_eventHubNamespaceFQDN}/{_eventHubName}/";
+
+            IReadOnlyList<BlobItem> mockBlobItems = new List<BlobItem>()
+            {
+                BlobsModelFactory.BlobItem(name: $"{_blobPath}1"),
+                BlobsModelFactory.BlobItem(name: $"{_blobPath}10"),
+                BlobsModelFactory.BlobItem(name: $"{_blobPath}20")
+            };
+
+            var mockPageBlobItems = Page<BlobItem>.FromValues(mockBlobItems, "continuationToken", Substitute.For<Response>());
+            var mockPageableBlobItems = Pageable<BlobItem>.FromPages(new[] { mockPageBlobItems });
+
+            _blobContainerClient.GetBlobs(states: BlobStates.All, prefix: _blobCheckpointPrefix, cancellationToken: CancellationToken.None)
+                .Returns(mockPageableBlobItems);
+
+            _logger = Substitute.For<ITelemetryLogger>();
+        }
+
+        [Fact]
+        public void GivenNullParameters_WhenStorageCheckpointClientCreated_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new StorageCheckpointClient(null, _storageCheckpointOptions, _eventHubClientOptions, _logger));
+            Assert.Throws<ArgumentNullException>(() => new StorageCheckpointClient(_blobContainerClient, null, _eventHubClientOptions, _logger));
+            Assert.Throws<ArgumentNullException>(() => new StorageCheckpointClient(_blobContainerClient, _storageCheckpointOptions, null, _logger));
+        }
+
+        [Fact]
+        public async Task GivenUnchangedEventHubOptions_WhenResetCheckpointsAsyncCalled_ThenNoCheckpointsAreDeleted()
+        {
+            _eventHubClientOptions.EventHubNamespaceFQDN = _eventHubNamespaceFQDN;
+            _eventHubClientOptions.EventHubName = _eventHubName;
+
+            var storageClient = new StorageCheckpointClient(_blobContainerClient, _storageCheckpointOptions, _eventHubClientOptions, _logger);
+            await storageClient.ResetCheckpointsAsync();
+
+            // Given that the source event hub didn't change, verify that no checkpoint deletions occured.
+            _blobContainerClient.Received(1).GetBlobs(states: BlobStates.All, prefix: _blobCheckpointPrefix, cancellationToken: CancellationToken.None);
+            await _blobContainerClient.ReceivedWithAnyArgs(0).DeleteBlobAsync(null);
+        }
+
+        [Fact]
+        public async Task GivenUpdatedEventHubNamespace_WhenResetCheckpointsAsyncCalled_ThenPreviousCheckpointsAreDeleted()
+        {
+            _eventHubClientOptions.EventHubNamespaceFQDN = "newtest.servicebus.windows.net";
+            _eventHubClientOptions.EventHubName = _eventHubName;
+
+            var storageClient = new StorageCheckpointClient(_blobContainerClient, _storageCheckpointOptions, _eventHubClientOptions, _logger);
+            await storageClient.ResetCheckpointsAsync();
+
+            // Given that the event hub namespace changed and is therefore a new source, verify that the checkpoints corresponding to the old source will be deleted.
+            _blobContainerClient.Received(1).GetBlobs(states: BlobStates.All, prefix: _blobCheckpointPrefix, cancellationToken: CancellationToken.None);
+            await _blobContainerClient.ReceivedWithAnyArgs(3).DeleteBlobAsync(null);
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{_blobPath}1");
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{_blobPath}10");
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{_blobPath}20");
+        }
+
+        [Fact]
+        public async Task GivenUpdatedEventHubName_WhenResetCheckpointsAsyncCalled_ThenPreviousCheckpointsAreDeleted()
+        {
+            _eventHubClientOptions.EventHubNamespaceFQDN = _eventHubNamespaceFQDN;
+            _eventHubClientOptions.EventHubName = "newdevicedata";
+
+            var storageClient = new StorageCheckpointClient(_blobContainerClient, _storageCheckpointOptions, _eventHubClientOptions, _logger);
+            await storageClient.ResetCheckpointsAsync();
+
+            // Given that the event hub changed and is therefore a new source, verify that the checkpoints corresponding to the old source will be deleted.
+            _blobContainerClient.Received(1).GetBlobs(states: BlobStates.All, prefix: _blobCheckpointPrefix, cancellationToken: CancellationToken.None);
+            await _blobContainerClient.ReceivedWithAnyArgs(3).DeleteBlobAsync(null);
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{_blobPath}1");
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{_blobPath}10");
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{_blobPath}20");
+        }
+
+        [Fact]
+        public async Task GivenUpdatedEventHubNamespaceAndEventHubName_WhenResetCheckpointsAsyncCalled_ThenPreviousCheckpointsAreDeleted()
+        {
+            _eventHubClientOptions.EventHubNamespaceFQDN = "newtest.servicebus.windows.net";
+            _eventHubClientOptions.EventHubName = "newdevicedata";
+
+            var storageClient = new StorageCheckpointClient(_blobContainerClient, _storageCheckpointOptions, _eventHubClientOptions, _logger);
+            await storageClient.ResetCheckpointsAsync();
+
+            // Given that the event hub namespace and the event hub name changed and is therefore a new source, verify that the checkpoints corresponding to the old source will be deleted.
+            _blobContainerClient.Received(1).GetBlobs(states: BlobStates.All, prefix: _blobCheckpointPrefix, cancellationToken: CancellationToken.None);
+            await _blobContainerClient.ReceivedWithAnyArgs(3).DeleteBlobAsync(null);
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{_blobPath}1");
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{_blobPath}10");
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{_blobPath}20");
+        }
+
+        [Fact]
+        public async Task GivenDifferentAppType_WhenResetCheckpointsAsyncCalled_ThenCheckpointsOfOtherAppsAreNotDeleted()
+        {
+            _eventHubClientOptions.EventHubNamespaceFQDN = _eventHubNamespaceFQDN;
+            _eventHubClientOptions.EventHubName = "newdevicedata";
+            _storageCheckpointOptions.BlobPrefix = "MeasurementToFhir";
+            var fhirconvBlobCheckpointPrefix = $"{_storageCheckpointOptions.BlobPrefix }/checkpoint/";
+            var fhirconvBlobPath = $"{fhirconvBlobCheckpointPrefix}{_eventHubNamespaceFQDN}/{_eventHubName}/";
+
+            IReadOnlyList<BlobItem> mockBlobItems = new List<BlobItem>()
+            {
+                BlobsModelFactory.BlobItem(name: $"{fhirconvBlobPath}1"),
+                BlobsModelFactory.BlobItem(name: $"{fhirconvBlobPath}10"),
+                BlobsModelFactory.BlobItem(name: $"{fhirconvBlobPath}20")
+            };
+
+            var mockPageBlobItems = Page<BlobItem>.FromValues(mockBlobItems, "continuationToken", Substitute.For<Response>());
+            var mockPageableBlobItems = Pageable<BlobItem>.FromPages(new[] { mockPageBlobItems });
+
+            _blobContainerClient.GetBlobs(states: BlobStates.All, prefix: fhirconvBlobCheckpointPrefix, cancellationToken: CancellationToken.None)
+                .Returns(mockPageableBlobItems);
+
+            var storageClient = new StorageCheckpointClient(_blobContainerClient, _storageCheckpointOptions, _eventHubClientOptions, _logger);
+            await storageClient.ResetCheckpointsAsync();
+
+            // Given that we are processing events for a different app type and the source changed, verify that the previous checkpoints corresponding to this app are deleted.
+            _blobContainerClient.Received(1).GetBlobs(states: BlobStates.All, prefix: fhirconvBlobCheckpointPrefix, cancellationToken: CancellationToken.None);
+            await _blobContainerClient.ReceivedWithAnyArgs(3).DeleteBlobAsync(null);
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{fhirconvBlobPath}1");
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{fhirconvBlobPath}10");
+            await _blobContainerClient.Received(1).DeleteBlobAsync($"{fhirconvBlobPath}20");
+
+            // Given that we are processing events for a different app type, verify that the checkpoints corresponding to the other apps are not deleted.
+            _blobContainerClient.Received(0).GetBlobs(states: BlobStates.All, prefix: _blobCheckpointPrefix, cancellationToken: CancellationToken.None);
+            await _blobContainerClient.Received(0).DeleteBlobAsync($"{_blobPath}1");
+            await _blobContainerClient.Received(0).DeleteBlobAsync($"{_blobPath}10");
+            await _blobContainerClient.Received(0).DeleteBlobAsync($"{_blobPath}20");
+        }
+    }
+}


### PR DESCRIPTION
Description -
When customer changes their source of events (source event hub) the IoT Connector watermark should be reset and process all data available from the earliest available point in the event hub.

Changes - 
* Append event hub name to the checkpoint blob path
* Delete checkpoints corresponding to an older source event hub
* Note - This change is applicable to the event hubs for both the app types (i.e. watermarks will be handled in the same fashion for input event hub or the normalization event hub, but they are independently maintained.)

Testing - 
* Manual testing by running the Fhir.Ingest console app and verifying the various scenarios
    - Change event hub namespace
    - Change event hub within the same event hub namespace
    - Same event hub
* Added UTs for reset checkpoints

PENDING - 
Once this change takes effect, the checkpoints in the older path will not be honored, which will trigger reprocessing of the data. To avoid this, we can copy over the older checkpoints to the new location. Dustin is helping gauge how many active Gen2 connectors we have and the size of data ingested, to assess the impact and take the call accordingly. Will not be closing this PR until then, but putting this out now for first pass of review.
