### PR TITLE
Align Blood Pressure typeNames

### DIFF
--- a/sample/templates/sandbox/devicecontent.json
+++ b/sample/templates/sandbox/devicecontent.json
@@ -64,7 +64,7 @@
     {
       "templateType": "IotCentralJsonPathContent",
       "template": {
-        "typeName": "bp",
+        "typeName": "bloodpressure",
         "typeMatchExpression": "$..[?(@telemetry.BloodPressure.Systolic && @telemetry.BloodPressure.Diastolic)]",
         "patientIdExpression": "$.deviceId",
         "values": [

--- a/sample/templates/sandbox/legacy/devicecontent.json
+++ b/sample/templates/sandbox/legacy/devicecontent.json
@@ -64,7 +64,7 @@
     {
       "templateType": "IotJsonPathContent",
       "template": {
-        "typeName": "bp",
+        "typeName": "bloodpressure",
         "typeMatchExpression": "$..[?(@Body.Systolic && @Body.Diastolic)]",
         "patientIdExpression": "$.SystemProperties.iothub-connection-device-id",
         "values": [

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CodeValueFhirTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CodeValueFhirTemplateFactoryTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             var codeValueTemplate = template as CodeValueFhirTemplate;
             Assert.NotNull(codeValueTemplate);
 
-            Assert.Equal("bp", codeValueTemplate.TypeName);
+            Assert.Equal("bloodpressure", codeValueTemplate.TypeName);
             Assert.Equal(ObservationPeriodInterval.Hourly, codeValueTemplate.PeriodInterval);
             Assert.Null(codeValueTemplate.Value);
 
@@ -154,7 +154,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             var codeValueTemplate = template as CodeValueFhirTemplate;
             Assert.NotNull(codeValueTemplate);
 
-            Assert.Equal("bp", codeValueTemplate.TypeName);
+            Assert.Equal("bloodpressure", codeValueTemplate.TypeName);
             Assert.Equal(ObservationPeriodInterval.Hourly, codeValueTemplate.PeriodInterval);
             Assert.Null(codeValueTemplate.Value);
 

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CollectionFhirTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CollectionFhirTemplateFactoryTests.cs
@@ -61,10 +61,10 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             Assert.NotNull(templateContext);
             Assert.False(templateContext.IsValid(out _));
 
-            var codeValueTemplate = templateContext.Template.GetTemplate("bp") as CodeValueFhirTemplate;
+            var codeValueTemplate = templateContext.Template.GetTemplate("bloodpressure") as CodeValueFhirTemplate;
             Assert.NotNull(codeValueTemplate);
 
-            Assert.Equal("bp", codeValueTemplate.TypeName);
+            Assert.Equal("bloodpressure", codeValueTemplate.TypeName);
             Assert.Equal(ObservationPeriodInterval.Hourly, codeValueTemplate.PeriodInterval);
         }
 

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/NormalizationTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/NormalizationTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             Assert.NotEmpty(measurements);
             Assert.Equal(6, measurements.Length);
             Assert.Equal(2, measurements.Count(m => string.Equals(m.Type, "heartrate")));
-            Assert.Equal(2, measurements.Count(m => string.Equals(m.Type, "bp")));
+            Assert.Equal(2, measurements.Count(m => string.Equals(m.Type, "bloodpressure")));
             Assert.Equal(2, measurements.Count(m => string.Equals(m.Type, "respiratoryrate")));
 
             var heartrateMeasurement = measurements.First(m => string.Equals(m.Type, "heartrate"));
@@ -154,7 +154,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             Assert.Equal("hr", heartrateMeasurement.Properties[0].Name);
             Assert.Equal("75", heartrateMeasurement.Properties[0].Value);
 
-            var bpMeasurement = measurements.First(m => string.Equals(m.Type, "bp"));
+            var bpMeasurement = measurements.First(m => string.Equals(m.Type, "bloodpressure"));
             Assert.Equal(2, bpMeasurement.Properties.Count());
             Assert.Equal("systolic", bpMeasurement.Properties[0].Name);
             Assert.Equal("62", bpMeasurement.Properties[0].Value);

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CodeValueFhirTemplate_Components.json
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CodeValueFhirTemplate_Components.json
@@ -9,7 +9,7 @@
       }
     ],
     "periodInterval": 60,
-    "typeName": "bp",
+    "typeName": "bloodpressure",
     "components": [
       {
         "codes": [

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CodeValueFhirTemplate_Quantity.json
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CodeValueFhirTemplate_Quantity.json
@@ -9,7 +9,7 @@
       }
     ],
     "periodInterval": 60,
-    "typeName": "bp",
+    "typeName": "bloodpressure",
     "components": [
       {
         "codes": [

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CollectionContentTemplateMultipleIotCentralJsonPath.json
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CollectionContentTemplateMultipleIotCentralJsonPath.json
@@ -34,7 +34,7 @@
     {
       "templateType": "IotCentralJsonPathContent",
       "template": {
-        "typeName": "bp",
+        "typeName": "bloodpressure",
         "typeMatchExpression": "$..[?(@telemetry.BloodPressure.Systolic && @telemetry.BloodPressure.Diastolic)]",
         "patientIdExpression": "$.deviceId",
         "values": [

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CollectionFhirTemplateMixedValidity.json
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CollectionFhirTemplateMixedValidity.json
@@ -12,7 +12,7 @@
           }
         ],
         "periodInterval": 60,
-        "typeName": "bp"
+        "typeName": "bloodpressure"
       }
     },
     {


### PR DESCRIPTION
'typeName' attribute was misaligned between the sandbox devicecontent.json and fhirmapping.json (bp vs bloddpressure).
As a result, bloodpressure data wasn't propagated to the fhir server.
Replaced the usage of 'bp' in favor or 'bloodpressure', in production code, as well as in tests for the sake of conformity.