### PR TITLE
Validate patient id is a relative reference

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.Rest;

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientLookupIdentityService.cs
@@ -43,15 +43,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         {
             EnsureArg.IsNotNull(device, nameof(device));
 
-            var patientId = device.Patient?.GetId<Model.Patient>() ?? throw new FhirResourceNotFoundException(ResourceType.Patient);
-
-            // only allow unreserved URI characters
-            if (!Regex.IsMatch(patientId, @"^[A-Za-z0-9_.\-~]+$"))
-            {
-                throw new NotSupportedException("Unsupported characters found in patient id");
-            }
-
-            return patientId;
+            return device.Patient?.GetId<Model.Patient>() ?? throw new FhirResourceNotFoundException(ResourceType.Patient);
         }
 
         protected async override Task<(string DeviceId, string PatientId)> LookUpDeviceAndPatientIdAsync(string value, string system = null)

--- a/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/ModelExtensionsTests.cs
+++ b/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/ModelExtensionsTests.cs
@@ -1,0 +1,39 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Xunit;
+using Model = Hl7.Fhir.Model;
+
+namespace Microsoft.Health.Extensions.Fhir.R4.UnitTests
+{
+    public class ModelExtensionsTests
+    {
+        [Fact]
+        public void GivenDeviceWithValidPatientReference_GetId_ThenReferenceIdentifierIsReturned_Test()
+        {
+            var device = new Model.Device
+            {
+                Id = "1",
+                Patient = new Model.ResourceReference("Patient/123"),
+            };
+
+            var patientIdentifier = device.Patient?.GetId<Model.Patient>();
+            Assert.Equal("123", patientIdentifier);
+        }
+
+        [Fact]
+        public void GivenDeviceWithInvalidPatientReference_GetId_ThenNullIsReturned_Test()
+        {
+            var device = new Model.Device
+            {
+                Id = "1",
+                Patient = new Model.ResourceReference("Not a reference in the form of: ResourceName/Identifier"),
+            };
+
+            var patientReference = device.Patient?.GetId<Model.Patient>();
+            Assert.Null(patientReference);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4DeviceAndPatientLookupIdentityServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4DeviceAndPatientLookupIdentityServiceTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Threading.Tasks;
 using Hl7.Fhir.Rest;
 using Microsoft.Health.Extensions.Fhir.Service;
@@ -110,7 +109,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             var device = new Model.Device
             {
                 Id = "1",
-                Patient = new Model.ResourceReference("Patient/&containsURIrestrictedchars"),
+                Patient = new Model.ResourceReference("Not a reference in the form of: /ResourceName/Identifier"),
             };
 
             var mg = Substitute.For<IMeasurementGroup>();
@@ -121,7 +120,8 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
             using (var idSrv = new R4DeviceAndPatientLookupIdentityService(fhirClient, resourceService))
             {
-                var ex = await Assert.ThrowsAsync<NotSupportedException>(async () => await idSrv.ResolveResourceIdentitiesAsync(mg));
+                var ex = await Assert.ThrowsAsync<FhirResourceNotFoundException>(async () => await idSrv.ResolveResourceIdentitiesAsync(mg));
+                Assert.Equal(ResourceType.Patient, ex.FhirResourceType);
             }
 
             await resourceService.Received(1).GetResourceByIdentityAsync<Model.Device>(fhirClient, "deviceId", null);


### PR DESCRIPTION
Validates that the relative reference patient identifier does not contain any URI restricted characters.

If the patient identifier contains restricted URI characters, then we log a `NotSupportedException`. We want to to this validation up front because the subsequent calls to FHIR will fail and we want to make it clear that the failure occurred due to certain characters contained in the identifier.

