### PR TITLE
Remove extra "foreach" when creating EventData object

### DIFF
--- a/src/console/Normalize/Processor.cs
+++ b/src/console/Normalize/Processor.cs
@@ -75,11 +75,6 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
                         eventData.SystemProperties.TryAdd(entry.Key, entry.Value);
                     }
 
-                    foreach (KeyValuePair<string, object> entry in x.Properties)
-                    {
-                        eventData.Properties[entry.Key] = entry.Value;
-                    }
-
                     return eventData;
                 });
 


### PR DESCRIPTION
There is an extra `foreach `statement that ends up copying Properties into the eventData object twice. The extra `foreach` should be removed.

```
foreach (KeyValuePair<string, object> entry in x.Properties)
{
	eventData.Properties[entry.Key] = entry.Value;
}

foreach (KeyValuePair<string, object> entry in x.SystemProperties)
{
	eventData.SystemProperties.TryAdd(entry.Key, entry.Value);
}

foreach (KeyValuePair<string, object> entry in x.Properties)
{
	eventData.Properties[entry.Key] = entry.Value;
}
```