### PR TITLE
Use Polly to perform retries on failed event processing

### DIFF
--- a/src/console/MeasurementCollectionToFhir/Processor.cs
+++ b/src/console/MeasurementCollectionToFhir/Processor.cs
@@ -58,7 +58,8 @@ namespace Microsoft.Health.Fhir.Ingest.Console.MeasurementCollectionToFhir
         {
             bool ExceptionRetryableFilter(Exception ee)
             {
-                logger.LogError(new Exception("Encountered retryable exception", ee));
+                logger.LogTrace($"Encountered retryable exception {ee.GetType()}");
+                logger.LogError(ee);
                 TrackExceptionMetric(ee, logger);
                 return true;
             }

--- a/src/console/MeasurementCollectionToFhir/Processor.cs
+++ b/src/console/MeasurementCollectionToFhir/Processor.cs
@@ -34,17 +34,16 @@ namespace Microsoft.Health.Fhir.Ingest.Console.MeasurementCollectionToFhir
             [MeasurementFhirImport] MeasurementFhirImportService measurementImportService,
             ITelemetryLogger logger)
         {
-            _templateDefinition = templateDefinition;
-            _templateManager = templateManager;
-            _measurementImportService = measurementImportService;
-            _logger = logger;
+            _templateDefinition = EnsureArg.IsNotNullOrWhiteSpace(templateDefinition, nameof(templateDefinition));
+            _templateManager = EnsureArg.IsNotNull(templateManager, nameof(templateManager));
+            _measurementImportService = EnsureArg.IsNotNull(measurementImportService, nameof(measurementImportService));
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
             _retryPolicy = CreateRetryPolicy(logger);
         }
 
         public async Task ConsumeAsync(IEnumerable<IEventMessage> events)
         {
             EnsureArg.IsNotNull(events);
-            EnsureArg.IsNotNull(_templateDefinition);
 
             await _retryPolicy.ExecuteAsync(async () => await ConsumeAsyncImpl(events, _templateManager.GetTemplateAsString(_templateDefinition)));
         }

--- a/src/console/MeasurementCollectionToFhir/Processor.cs
+++ b/src/console/MeasurementCollectionToFhir/Processor.cs
@@ -3,17 +3,20 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Events.EventConsumers;
 using Microsoft.Health.Events.Model;
 using Microsoft.Health.Fhir.Ingest.Console.Template;
 using Microsoft.Health.Fhir.Ingest.Host;
 using Microsoft.Health.Fhir.Ingest.Service;
 using Microsoft.Health.Logging.Telemetry;
+using Polly;
 
 namespace Microsoft.Health.Fhir.Ingest.Console.MeasurementCollectionToFhir
 {
@@ -23,6 +26,7 @@ namespace Microsoft.Health.Fhir.Ingest.Console.MeasurementCollectionToFhir
         private MeasurementFhirImportService _measurementImportService;
         private string _templateDefinition;
         private ITelemetryLogger _logger;
+        private AsyncPolicy _retryPolicy;
 
         public Processor(
             [Blob("template/%Template:FhirMapping%", FileAccess.Read)] string templateDefinition,
@@ -34,6 +38,7 @@ namespace Microsoft.Health.Fhir.Ingest.Console.MeasurementCollectionToFhir
             _templateManager = templateManager;
             _measurementImportService = measurementImportService;
             _logger = logger;
+            _retryPolicy = CreateRetryPolicy(logger);
         }
 
         public async Task ConsumeAsync(IEnumerable<IEventMessage> events)
@@ -41,8 +46,42 @@ namespace Microsoft.Health.Fhir.Ingest.Console.MeasurementCollectionToFhir
             EnsureArg.IsNotNull(events);
             EnsureArg.IsNotNull(_templateDefinition);
 
-            var templateContent = _templateManager.GetTemplateAsString(_templateDefinition);
+            await _retryPolicy.ExecuteAsync(async () => await ConsumeAsyncImpl(events, _templateManager.GetTemplateAsString(_templateDefinition)));
+        }
+
+        private async Task ConsumeAsyncImpl(IEnumerable<IEventMessage> events, string templateContent)
+        {
             await _measurementImportService.ProcessEventsAsync(events, templateContent, _logger).ConfigureAwait(false);
+        }
+
+        private static AsyncPolicy CreateRetryPolicy(ITelemetryLogger logger)
+        {
+            bool ExceptionRetryableFilter(Exception ee)
+            {
+                logger.LogError(new Exception("Encountered retryable exception", ee));
+                TrackExceptionMetric(ee, logger);
+                return true;
+            }
+
+            return Policy
+                .Handle<Exception>(ExceptionRetryableFilter)
+                .WaitAndRetryForeverAsync(retryCount => TimeSpan.FromSeconds(Math.Min(30, Math.Pow(2, retryCount))));
+        }
+
+        private static void TrackExceptionMetric(Exception exception, ITelemetryLogger logger)
+        {
+            var type = exception.GetType().ToString();
+            var ToMetric = new Metric(
+                type,
+                new Dictionary<string, object>
+                {
+                    { DimensionNames.Name, type },
+                    { DimensionNames.Category, Category.Errors },
+                    { DimensionNames.ErrorType, ErrorType.GeneralError },
+                    { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
+                    { DimensionNames.Operation, ConnectorOperation.FHIRConversion},
+                });
+            logger.LogMetric(ToMetric, 1);
         }
     }
 }

--- a/src/console/Normalize/Processor.cs
+++ b/src/console/Normalize/Processor.cs
@@ -129,7 +129,8 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
                         return false;
                 }
 
-                logger.LogError(new Exception("Encountered retryable exception", ee));
+                logger.LogTrace($"Encountered retryable exception {ee.GetType()}");
+                logger.LogError(ee);
                 TrackExceptionMetric(ee, logger);
                 return true;
             }

--- a/src/console/Normalize/Processor.cs
+++ b/src/console/Normalize/Processor.cs
@@ -58,14 +58,13 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
         public async Task ConsumeAsync(IEnumerable<IEventMessage> events)
         {
             EnsureArg.IsNotNull(events);
-            await _retryPolicy.ExecuteAsync(async () => await ConsumeAsyncImpl(events));
+            EnsureArg.IsNotNull(_templateDefinition);
+
+            await _retryPolicy.ExecuteAsync(async () => await ConsumeAsyncImpl(events, _templateManager.GetTemplateAsString(_templateDefinition)));
         }
 
-        private async Task ConsumeAsyncImpl(IEnumerable<IEventMessage> events)
+        private async Task ConsumeAsyncImpl(IEnumerable<IEventMessage> events, string templateContent)
         {
-            EnsureArg.IsNotNull(_templateDefinition);
-            var templateContent = _templateManager.GetTemplateAsString(_templateDefinition);
-
             var templateContext = CollectionContentTemplateFactory.Default.Create(templateContent);
             templateContext.EnsureValid();
             var template = templateContext.Template;

--- a/src/console/Normalize/Processor.cs
+++ b/src/console/Normalize/Processor.cs
@@ -1,7 +1,21 @@
-﻿using EnsureThat;
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Identity;
+using EnsureThat;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Events.EventConsumers;
 using Microsoft.Health.Events.Model;
 using Microsoft.Health.Fhir.Ingest.Console.Template;
@@ -10,10 +24,7 @@ using Microsoft.Health.Fhir.Ingest.Service;
 using Microsoft.Health.Fhir.Ingest.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Logging.Telemetry;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
+using Polly;
 using static Microsoft.Azure.EventHubs.EventData;
 
 namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
@@ -26,6 +37,7 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
         private IAsyncCollector<IMeasurement> _collector;
         private IOptions<NormalizationServiceOptions> _normalizationOptions;
         private IEventProcessingMeter _eventProcessingMeter = new EventProcessingMeter();
+        private AsyncPolicy _retryPolicy;
 
         public Processor(
             [Blob("template/%Template:DeviceContent%", FileAccess.Read)] string templateDefinition,
@@ -39,9 +51,17 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
             _collector = collector;
             _logger = logger;
             _normalizationOptions = options;
+            _retryPolicy = CreateRetryPolicy(logger);
         }
 
         public async Task ConsumeAsync(IEnumerable<IEventMessage> events)
+        {
+            EnsureArg.IsNotNull(events);
+            await _retryPolicy.ExecuteAsync(async () => await ConsumeAsyncImpl(events));
+            
+        }
+
+        private async Task ConsumeAsyncImpl(IEnumerable<IEventMessage> events)
         {
             EnsureArg.IsNotNull(_templateDefinition);
             var templateContent = _templateManager.GetTemplateAsString(_templateDefinition);
@@ -89,6 +109,45 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
                     IomtMetrics.DeviceIngressSizeBytes(),
                     eventStats.TotalEventsProcessedBytes);
             }
+        }
+
+        private static AsyncPolicy CreateRetryPolicy(ITelemetryLogger logger)
+        {
+            bool ExceptionRetryableFilter(Exception ee)
+            {
+                var type = ee.GetType().ToString();
+                var ToMetric = new Metric(
+                type,
+                new Dictionary<string, object>
+                {
+                        { DimensionNames.Name, type },
+                        { DimensionNames.Category, Category.Errors },
+                        { DimensionNames.ErrorType, ErrorType.DeviceMessageError },
+                        { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
+                        { DimensionNames.Operation, ConnectorOperation.Normalization},
+                });
+                logger.LogMetric(ToMetric, 1);
+
+                switch (ee)
+                {
+                    case AggregateException ae when ae.InnerExceptions.Any(ExceptionRetryableFilter):
+                    case OperationCanceledException _:
+                    case HttpRequestException _:
+                    case EventHubsException _:
+                    case AuthenticationFailedException _:
+                    case RequestFailedException _:
+                        break;
+                    default:
+                        return false;
+                }
+
+                logger.LogError(new Exception("Encountered retryable exception", ee));
+                return true;
+            }
+
+            return Policy
+                .Handle<Exception>(ExceptionRetryableFilter)
+                .WaitAndRetryForeverAsync(retryCount => TimeSpan.FromSeconds(Math.Min(30, Math.Pow(2, retryCount))));
         }
     }
 }

--- a/src/console/Normalize/Processor.cs
+++ b/src/console/Normalize/Processor.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Azure;
+using AzureMessagingEventHubs = Azure.Messaging.EventHubs;
 using Azure.Identity;
 using EnsureThat;
 using Microsoft.Azure.EventHubs;
@@ -119,7 +120,7 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
                     case AggregateException ae when ae.InnerExceptions.Any(ExceptionRetryableFilter):
                     case OperationCanceledException _:
                     case HttpRequestException _:
-                    case EventHubsException _:
+                    case AzureMessagingEventHubs.EventHubsException _:
                     case AuthenticationFailedException _:
                     case RequestFailedException _:
                         break;

--- a/src/console/Normalize/Processor.cs
+++ b/src/console/Normalize/Processor.cs
@@ -142,15 +142,15 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
         {
             var type = exception.GetType().ToString();
             var ToMetric = new Metric(
-            type,
-            new Dictionary<string, object>
-            {
-                { DimensionNames.Name, type },
-                { DimensionNames.Category, Category.Errors },
-                { DimensionNames.ErrorType, ErrorType.DeviceMessageError },
-                { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
-                { DimensionNames.Operation, ConnectorOperation.Normalization},
-            });
+                type,
+                new Dictionary<string, object>
+                {
+                    { DimensionNames.Name, type },
+                    { DimensionNames.Category, Category.Errors },
+                    { DimensionNames.ErrorType, ErrorType.DeviceMessageError },
+                    { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
+                    { DimensionNames.Operation, ConnectorOperation.Normalization},
+                });
             logger.LogMetric(ToMetric, 1);
         }
     }

--- a/src/console/Normalize/Processor.cs
+++ b/src/console/Normalize/Processor.cs
@@ -58,7 +58,6 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
         {
             EnsureArg.IsNotNull(events);
             await _retryPolicy.ExecuteAsync(async () => await ConsumeAsyncImpl(events));
-            
         }
 
         private async Task ConsumeAsyncImpl(IEnumerable<IEventMessage> events)

--- a/src/console/Normalize/Processor.cs
+++ b/src/console/Normalize/Processor.cs
@@ -47,18 +47,17 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
             ITelemetryLogger logger,
             IOptions<NormalizationServiceOptions> options)
         {
-            _templateDefinition = templateDefinition;
-            _templateManager = templateManager;
-            _collector = collector;
-            _logger = logger;
-            _normalizationOptions = options;
+            _templateDefinition = EnsureArg.IsNotNullOrWhiteSpace(templateDefinition, nameof(templateDefinition));
+            _templateManager = EnsureArg.IsNotNull(templateManager, nameof(templateManager));
+            _collector = EnsureArg.IsNotNull(collector, nameof(collector));
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+            _normalizationOptions = EnsureArg.IsNotNull(options, nameof(options));
             _retryPolicy = CreateRetryPolicy(logger);
         }
 
         public async Task ConsumeAsync(IEnumerable<IEventMessage> events)
         {
             EnsureArg.IsNotNull(events);
-            EnsureArg.IsNotNull(_templateDefinition);
 
             await _retryPolicy.ExecuteAsync(async () => await ConsumeAsyncImpl(events, _templateManager.GetTemplateAsString(_templateDefinition)));
         }

--- a/src/console/Startup.cs
+++ b/src/console/Startup.cs
@@ -3,13 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.	
 // -------------------------------------------------------------------------------------------------	
 
+using System;
+using System.Collections.Generic;
 using Azure.Messaging.EventHubs;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Common.Storage;
-using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Events.Common;
 using Microsoft.Health.Events.EventCheckpointing;
 using Microsoft.Health.Events.EventConsumers;
@@ -21,8 +22,6 @@ using Microsoft.Health.Fhir.Ingest.Console.Template;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Service;
 using Microsoft.Health.Logging.Telemetry;
-using System;
-using System.Collections.Generic;
 
 namespace Microsoft.Health.Fhir.Ingest.Console
 {
@@ -126,30 +125,7 @@ namespace Microsoft.Health.Fhir.Ingest.Console
         {
             var eventConsumers = serviceProvider.GetRequiredService<List<IEventConsumer>>();
             var logger = serviceProvider.GetRequiredService<ITelemetryLogger>();
-            var applicationType = GetConsoleApplicationType();
-
-            if (applicationType == _normalizationAppType)
-            {
-                Action<Exception> exceptionProcessor = exception =>
-                {
-                    var type = exception.GetType().ToString();
-                    var ToMetric = new Metric(
-                    type,
-                    new Dictionary<string, object>
-                    {
-                        { DimensionNames.Name, type },
-                        { DimensionNames.Category, Category.Errors },
-                        { DimensionNames.ErrorType, ErrorType.DeviceMessageError },
-                        { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
-                        { DimensionNames.Operation, ConnectorOperation.Normalization},
-                    });
-                    logger.LogMetric(ToMetric, 1);
-                };
-
-                return new EventConsumerService(eventConsumers, logger, exceptionTelemetryProcessor: exceptionProcessor);
-            }
-
-            return new EventConsumerService(eventConsumers, logger, false);
+            return new EventConsumerService(eventConsumers, logger);
         }
 
         public virtual IAsyncCollector<IMeasurement> ResolveEventCollector(IServiceProvider serviceProvider)

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
                 {
                     try
                     {
-                        await RetryPolicy.ExecuteAsync(async () => await TryOperationAsync(eventConsumer, events).ConfigureAwait(false));
+                        await RetryPolicy.ExecuteAsync(async () => await eventConsumer.ConsumeAsync(events).ConfigureAwait(false));
                     }
                     catch (Exception e)
                     {
@@ -61,11 +61,6 @@ namespace Microsoft.Health.Events.EventConsumers.Service
                     }
                 }
             }
-        }
-
-        private static async Task TryOperationAsync(IEventConsumer eventConsumer, IEnumerable<IEventMessage> events)
-        {
-            await eventConsumer.ConsumeAsync(events);
         }
 
         private static AsyncPolicy CreateRetryPolicy(ITelemetryLogger logger)

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
@@ -6,23 +6,38 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Messaging.EventHubs;
+using EnsureThat;
 using Microsoft.Health.Events.Model;
 using Microsoft.Health.Logging.Telemetry;
+using Polly;
 
 namespace Microsoft.Health.Events.EventConsumers.Service
 {
     public class EventConsumerService : IEventConsumerService
     {
         private readonly IEnumerable<IEventConsumer> _eventConsumers;
-        private const int _maximumBackoffMs = 32000;
         private ITelemetryLogger _logger;
 
         public EventConsumerService(IEnumerable<IEventConsumer> eventConsumers, ITelemetryLogger logger)
         {
-            _eventConsumers = eventConsumers;
-            _logger = logger;
+            _eventConsumers = EnsureArg.IsNotNull(eventConsumers, nameof(eventConsumers));
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+
+            RetryPolicy = CreateRetryPolicy(logger);
         }
+
+        public EventConsumerService(IEnumerable<IEventConsumer> eventConsumers, ITelemetryLogger logger, AsyncPolicy retryPolicy)
+        {
+            _eventConsumers = EnsureArg.IsNotNull(eventConsumers, nameof(eventConsumers));
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+            RetryPolicy = EnsureArg.IsNotNull(retryPolicy, nameof(retryPolicy));
+        }
+
+        public AsyncPolicy RetryPolicy { get;  }
 
         public Task ConsumeEvent(IEventMessage eventArg)
         {
@@ -35,37 +50,14 @@ namespace Microsoft.Health.Events.EventConsumers.Service
             {
                 foreach (IEventConsumer eventConsumer in _eventConsumers)
                 {
-                    await OperationWithRetryAsync(eventConsumer, events);
-                }
-            }
-        }
-
-        private async Task OperationWithRetryAsync(IEventConsumer eventConsumer, IEnumerable<IEventMessage> events)
-        {
-            int currentRetry = 0;
-            double backoffMs = 0;
-            Random random = new Random();
-            bool operationComplete = false;
-
-            while (!operationComplete)
-            {
-                try
-                {
-                    if (currentRetry > 0 && backoffMs < _maximumBackoffMs)
+                    try
                     {
-                        int randomMs = random.Next(0, 1000);
-                        backoffMs = Math.Pow(2000, currentRetry) + randomMs;
-                        await Task.Delay((int)backoffMs);
+                        await RetryPolicy.ExecuteAsync(async () => await TryOperationAsync(eventConsumer, events).ConfigureAwait(false));
                     }
-
-                    await TryOperationAsync(eventConsumer, events).ConfigureAwait(false);
-                    break;
-                }
-#pragma warning disable CA1031
-                catch (Exception e)
-#pragma warning restore CA1031
-                {
-                    _logger.LogError(e);
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e);
+                    }
                 }
             }
         }
@@ -73,6 +65,31 @@ namespace Microsoft.Health.Events.EventConsumers.Service
         private static async Task TryOperationAsync(IEventConsumer eventConsumer, IEnumerable<IEventMessage> events)
         {
             await eventConsumer.ConsumeAsync(events);
+        }
+
+        private static AsyncPolicy CreateRetryPolicy(ITelemetryLogger logger)
+        {
+            bool ExceptionRetryableFilter(Exception ee)
+            {
+                switch (ee)
+                {
+                    case AggregateException ae when ae.InnerExceptions.All(ExceptionRetryableFilter):
+                    case OperationCanceledException _:
+                    case HttpRequestException _:
+                    case EventHubsException _:
+                    case RequestFailedException _:
+                        break;
+                    default:
+                        return false;
+                }
+
+                logger.LogError(new Exception("Encountered retryable exception", ee));
+                return true;
+            }
+
+            return Policy
+                .Handle<Exception>(ExceptionRetryableFilter)
+                .WaitAndRetryForeverAsync(retryCount => TimeSpan.FromSeconds(Math.Min(30, Math.Pow(2, retryCount))));
         }
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Azure;
+using Azure.Identity;
 using Azure.Messaging.EventHubs;
 using EnsureThat;
 using Microsoft.Health.Events.Model;
@@ -77,6 +78,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
                     case OperationCanceledException _:
                     case HttpRequestException _:
                     case EventHubsException _:
+                    case AuthenticationFailedException _:
                     case RequestFailedException _:
                         break;
                     default:

--- a/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
+++ b/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
@@ -34,6 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageReference Include="Polly" Version="7.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Common\Microsoft.Health.Common.csproj" />

--- a/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
+++ b/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
@@ -34,7 +34,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
-    <PackageReference Include="Polly" Version="7.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Common\Microsoft.Health.Common.csproj" />

--- a/test/Microsoft.Health.Events.UnitTest/EventConsumerServiceTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventConsumerServiceTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Events.UnitTest
             var logger = Substitute.For<ITelemetryLogger>();
             var eventConsumer = Substitute.For<IEventConsumer>();
 
-            // fail to consume events 3 times in a row, then succeed
+            // fail to consume events 2 times in a row, then succeed
             eventConsumer.When(x => x.ConsumeAsync(initialBatch))
                 .Do(x => { if (retries < 2) { retries++; throw new HttpRequestException("failure"); } });
 

--- a/test/Microsoft.Health.Events.UnitTest/EventConsumerServiceTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventConsumerServiceTests.cs
@@ -1,4 +1,9 @@
-﻿using Microsoft.Health.Events.EventConsumers;
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Events.EventConsumers;
 using Microsoft.Health.Events.EventConsumers.Service;
 using Microsoft.Health.Events.Model;
 using Microsoft.Health.Logging.Telemetry;
@@ -6,6 +11,7 @@ using NSubstitute;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Net.Http;
 using Xunit;
 
 namespace Microsoft.Health.Events.UnitTest
@@ -13,7 +19,30 @@ namespace Microsoft.Health.Events.UnitTest
     public class EventConsumerServiceTests
     {
         [Fact]
-        public async void GivenEventConsumer_WhenEventConsumerThrowsException_ThenRetryEventConsumer_Test()
+        public async void GivenEventConsumer_WhenEventConsumerThrowsNonRetryableException_ThenEventConsumer_IsNotRetried_()
+        {
+            var retries = 0;
+            var initialBatch = new List<EventMessage>()
+            {
+                new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()))
+            };
+
+            var logger = Substitute.For<ITelemetryLogger>();
+            var eventConsumer = Substitute.For<IEventConsumer>();
+
+            eventConsumer.When(x => x.ConsumeAsync(initialBatch))
+                .Do(x => { if (retries < 3) { retries++;  throw new Exception("failure"); } });
+
+            var eventEventConsumers = new List<IEventConsumer>() { eventConsumer };
+            var eventConsumerService = new EventConsumerService(eventEventConsumers, logger);
+
+            await eventConsumerService.ConsumeEvents(initialBatch);
+            logger.Received(1).LogError(Arg.Is<Exception>(ex => ex.Message == "failure"));
+            await eventConsumer.Received(1).ConsumeAsync(initialBatch);
+        }
+
+        [Fact]
+        public async void GivenEventConsumer_WhenEventConsumerThrowsRetryableException_ThenRetryEventConsumer_Test()
         {
             var retries = 0;
             var initialBatch = new List<EventMessage>()
@@ -26,14 +55,15 @@ namespace Microsoft.Health.Events.UnitTest
 
             // fail to consume events 3 times in a row, then succeed
             eventConsumer.When(x => x.ConsumeAsync(initialBatch))
-                .Do(x => { if (retries < 3) { retries++;  throw new Exception("failure"); } });
+                .Do(x => { if (retries < 2) { retries++; throw new HttpRequestException("failure"); } });
 
             var eventEventConsumers = new List<IEventConsumer>() { eventConsumer };
             var eventConsumerService = new EventConsumerService(eventEventConsumers, logger);
 
-            // 3 retries followed by a successful call
+            // 2 retries followed by a successful call
             await eventConsumerService.ConsumeEvents(initialBatch);
-            await eventConsumer.Received(4).ConsumeAsync(initialBatch);
+            logger.Received(2).LogError(Arg.Is<Exception>(ex => ex.Message.StartsWith("Encountered retryable exception")));
+            await eventConsumer.Received(3).ConsumeAsync(initialBatch);
         }
     }
 }

--- a/test/Microsoft.Health.Events.UnitTest/EventConsumerServiceTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventConsumerServiceTests.cs
@@ -3,15 +3,15 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 using Microsoft.Health.Events.EventConsumers;
 using Microsoft.Health.Events.EventConsumers.Service;
 using Microsoft.Health.Events.Model;
 using Microsoft.Health.Logging.Telemetry;
 using NSubstitute;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Net.Http;
 using Xunit;
 
 namespace Microsoft.Health.Events.UnitTest
@@ -19,9 +19,8 @@ namespace Microsoft.Health.Events.UnitTest
     public class EventConsumerServiceTests
     {
         [Fact]
-        public async void GivenEventConsumer_WhenEventConsumerThrowsNonRetryableException_ThenEventConsumer_ThenIsNotRetried_()
+        public async void GivenEventConsumer_WhenEventConsumerThrowsException_ThenExceptionIsLogged_()
         {
-            var retries = 0;
             var initialBatch = new List<EventMessage>()
             {
                 new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()))
@@ -30,8 +29,7 @@ namespace Microsoft.Health.Events.UnitTest
             var logger = Substitute.For<ITelemetryLogger>();
             var eventConsumer = Substitute.For<IEventConsumer>();
 
-            eventConsumer.When(x => x.ConsumeAsync(initialBatch))
-                .Do(x => { if (retries < 3) { retries++;  throw new Exception("failure"); } });
+            eventConsumer.ConsumeAsync(Arg.Any<IEnumerable<IEventMessage>>()).ReturnsForAnyArgs(Task.FromException(new Exception("failure")));
 
             var eventEventConsumers = new List<IEventConsumer>() { eventConsumer };
             var eventConsumerService = new EventConsumerService(eventEventConsumers, logger);
@@ -39,60 +37,6 @@ namespace Microsoft.Health.Events.UnitTest
             await eventConsumerService.ConsumeEvents(initialBatch);
             logger.Received(1).LogError(Arg.Is<Exception>(ex => ex.Message == "failure"));
             await eventConsumer.Received(1).ConsumeAsync(initialBatch);
-        }
-
-        [Fact]
-        public async void GivenEventConsumer_And_ConfiguredToNotRetry_WhenEventConsumerThrowsRetryableException_ThenIsNotRetried()
-        {
-            var retries = 0;
-            var initialBatch = new List<EventMessage>()
-            {
-                new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()))
-            };
-
-            var logger = Substitute.For<ITelemetryLogger>();
-            var eventConsumer = Substitute.For<IEventConsumer>();
-            var exceptionProcessor = Substitute.For<Action<Exception>>();
-
-            // fail to consume events 2 times in a row, then succeed
-            eventConsumer.When(x => x.ConsumeAsync(initialBatch))
-                .Do(x => { if (retries < 2) { retries++; throw new HttpRequestException("failure"); } });
-
-            var eventEventConsumers = new List<IEventConsumer>() { eventConsumer };
-            var eventConsumerService = new EventConsumerService(eventEventConsumers, logger, false, exceptionProcessor);
-
-            // 2 retries followed by a successful call
-            await eventConsumerService.ConsumeEvents(initialBatch);
-            logger.Received(0).LogError(Arg.Is<Exception>(ex => ex.Message.StartsWith("Encountered retryable exception")));
-            await eventConsumer.Received(1).ConsumeAsync(initialBatch);
-            exceptionProcessor.Received(1).Invoke(Arg.Any<HttpRequestException>());
-        }
-
-        [Fact]
-        public async void GivenEventConsumer_WhenEventConsumerThrowsRetryableException_ThenRetryEventConsumer_Test()
-        {
-            var retries = 0;
-            var initialBatch = new List<EventMessage>()
-            {
-                new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()))
-            };
-
-            var logger = Substitute.For<ITelemetryLogger>();
-            var eventConsumer = Substitute.For<IEventConsumer>();
-            var exceptionProcessor = Substitute.For<Action<Exception>>();
-
-            // fail to consume events 2 times in a row, then succeed
-            eventConsumer.When(x => x.ConsumeAsync(initialBatch))
-                .Do(x => { if (retries < 2) { retries++; throw new HttpRequestException("failure"); } });
-
-            var eventEventConsumers = new List<IEventConsumer>() { eventConsumer };
-            var eventConsumerService = new EventConsumerService(eventEventConsumers, logger, true, exceptionProcessor);
-
-            // 2 retries followed by a successful call
-            await eventConsumerService.ConsumeEvents(initialBatch);
-            logger.Received(2).LogError(Arg.Is<Exception>(ex => ex.Message.StartsWith("Encountered retryable exception")));
-            await eventConsumer.Received(3).ConsumeAsync(initialBatch);
-            exceptionProcessor.Received(2).Invoke(Arg.Any<HttpRequestException>());
         }
     }
 }


### PR DESCRIPTION
Currently, when an event incurs an error the entire batch is retried forever. This PR utilizes `Polly` to perform the retry logic. Only a specific set of exceptions will be allowed to retry.