### PR TITLE
Data Mapper: JSON validation of Device Data Sample

### DIFF
--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/package.json
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/package.json
@@ -8,6 +8,7 @@
     "connected-react-router": "6.5.2",
     "history": "4.10.1",
     "jquery": "^3.5.1",
+    "jsonlint-mod": "^1.7.6",
     "lodash": "^4.14.165",
     "react": "16.11.0",
     "react-dom": "16.11.0",

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/package.json
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "axe-core": "4.1.1",
     "bootstrap": "^4.3.1",
+    "codemirror": "^5.62.2",
     "connected-react-router": "6.5.2",
     "history": "4.10.1",
     "jquery": "^3.5.1",
@@ -21,6 +22,7 @@
     "redux-thunk": "2.3.0"
   },
   "devDependencies": {
+    "@types/codemirror": "^5.60.2",
     "@types/history": "4.7.3",
     "@types/jest": "24.0.19",
     "@types/lodash": "^4.14.165",

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/Constants.ts
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/Constants.ts
@@ -64,4 +64,6 @@ export const Text = {
 
     LabelUntitled: "Untitled",
     LabelMappingList: "Mapping Templates",
+
+    LabelTestResultFail: "Fail"
 }

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Forms.Tutorials.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Forms.Tutorials.tsx
@@ -14,7 +14,7 @@ export const DeviceEditFormTutorial = (props: {}) => {
                     <span className="h6">Tutorial</span>
                 </CardTitle>
                 <p>
-                    Device Maping is used to normalize the data input from your devices.
+                    Device Mapping is used to normalize the data input from your devices.
                 </p>
                 Note: <br />
                 <ul>

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Test.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Test.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react';
 import { Input, Col, Row } from 'reactstrap';
+import * as JsonLint from 'jsonlint-mod';
 
 import { Mapping } from '../../store/Mapping';
 import TestService from '../../services/TestService';
@@ -12,6 +13,9 @@ import { PlayCircleIcon } from '../Icons';
 import * as Utility from './Utility';
 
 const MappingTestWidget = (props: { data: Mapping }) => {
+    const [dataSampleResult, setDataSampleResult] = React.useState('');
+    const [dataSampleValid, setDataSampleValid] = React.useState(true);
+
     const [normTestResult, setNormTestResult] = React.useState('Normalization test result output...');
     const [normTestResultBadge, setNormTestResultBadge] = React.useState('');
     const [normTestInProgress, setNormTestInProgress] = React.useState(false);
@@ -22,6 +26,19 @@ const MappingTestWidget = (props: { data: Mapping }) => {
 
     const dataSampleRef = React.useRef<HTMLInputElement>() as React.RefObject<HTMLInputElement>;
     const identityResolutionTypeRef = React.useRef<HTMLInputElement>() as React.RefObject<HTMLInputElement>;
+
+    const handleDataSampleChange = () => {
+        const dataSample = dataSampleRef.current?.value;
+        try {
+            JsonLint.parse(dataSample);
+            setDataSampleResult('Valid JSON');
+            setDataSampleValid(true);
+        }
+        catch (err) {
+            setDataSampleResult(err.toString());
+            setDataSampleValid(false);
+        }
+    }
 
     const startNormalizationTest = () => {
         setNormTestInProgress(true);
@@ -105,7 +122,11 @@ const MappingTestWidget = (props: { data: Mapping }) => {
                             <Input
                                 type="textarea" name="devicedatasample" id="devicedatasample" rows={10}
                                 placeholder="Paste your device data sample here..." innerRef={dataSampleRef}
+                                onChange={handleDataSampleChange}
                             />
+                            <pre className={`iomt-cm-data-result overflow-auto p-2 ${dataSampleValid ? "text-success" : "text-danger"}`}>
+                                {dataSampleResult}
+                            </pre>
                         </div>
                     </Col>
                     <Col sm={4}>

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Test.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Test.tsx
@@ -15,6 +15,7 @@ import 'codemirror/mode/javascript/javascript.js';
 
 import { Mapping } from '../../store/Mapping';
 import TestService from '../../services/TestService';
+import * as Constants from '../Constants';
 import { PlayCircleIcon } from '../Icons';
 import * as Utility from './Utility';
 
@@ -104,7 +105,7 @@ const MappingTestWidget = (props: { data: Mapping }) => {
                 setNormTestInProgress(false);
             })
             .catch(err => {
-                setNormTestResultBadge("Failed");
+                setNormTestResultBadge(Constants.Text.LabelTestResultFail);
                 setNormTestResult(err);
                 setNormTestInProgress(false);
             })
@@ -124,6 +125,7 @@ const MappingTestWidget = (props: { data: Mapping }) => {
             }
         }
         catch (err) {
+            setFhirTestResultBadge(Constants.Text.LabelTestResultFail);
             setFhirTestResult(`${err.message}. Did you already get successful normalization result?`);
             return;
         }
@@ -148,7 +150,7 @@ const MappingTestWidget = (props: { data: Mapping }) => {
                 setFhirTestInProgress(false);
             })
             .catch(err => {
-                setFhirTestResultBadge("Failed!");
+                setFhirTestResultBadge(Constants.Text.LabelTestResultFail);
                 setFhirTestResult(err);
                 setFhirTestInProgress(false);
             })

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Test.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Test.tsx
@@ -77,7 +77,7 @@ const MappingTestWidget = (props: { data: Mapping }) => {
     }
 
     const highlightDataSampleErrorLine = (line: number | null) => {
-        if (line === dataSampleErrorLine) {
+        if (line === dataSampleErrorLine || !codeEditor) {
             return;
         }
         if (typeof line === 'number') {
@@ -168,7 +168,8 @@ const MappingTestWidget = (props: { data: Mapping }) => {
                             <div className="pt-2 pb-3">
                                 <span className="h6">Device Data Sample</span>
                             </div>
-                            <textarea className="border overflow-auto p-2" ref={dataSampleRef}>
+                            <textarea className="border overflow-auto p-2" ref={dataSampleRef}
+                                onChange={e => { handleDataSampleChange(e.target.value) }}>
                             </textarea>
                             <pre className={`iomt-cm-data-result overflow-auto p-2 ${dataSampleValid ? "text-success" : "text-danger"}`}>
                                 {dataSampleResult}

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Test.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Test.tsx
@@ -31,27 +31,30 @@ const MappingTestWidget = (props: { data: Mapping }) => {
     const [fhirTestResultBadge, setFhirTestResultBadge] = React.useState('');
     const [fhirTestInProgress, setFhirTestInProgress] = React.useState(false);
 
+    const dataSampleRef = React.useRef<HTMLTextAreaElement>() as React.RefObject<HTMLTextAreaElement>;
     const identityResolutionTypeRef = React.useRef<HTMLInputElement>() as React.RefObject<HTMLInputElement>;
 
     var codeEditor: CodeMirror.EditorFromTextArea;
     var dataSampleErrorLine: number | null = null;
 
     React.useEffect(() => {
-        codeEditor = CodeMirror.fromTextArea(
-            (document.getElementById('devicedatasample') as HTMLTextAreaElement),
-            {
-                mode: "javascript",
-                lineNumbers: true,
-                matchBrackets: true,
-                placeholder: 'Paste your device data sample here...'
-            }
-        );
+        if (dataSampleRef.current) {
+            codeEditor = CodeMirror.fromTextArea(
+                dataSampleRef.current,
+                {
+                    mode: "javascript",
+                    lineNumbers: true,
+                    matchBrackets: true,
+                    placeholder: 'Paste your device data sample here...'
+                }
+            );
 
-        codeEditor.on('change', () => handleDataSampleChange(codeEditor.getValue()));
+            codeEditor.on('change', () => handleDataSampleChange(codeEditor.getValue()));
 
-        return () => {
-            codeEditor.toTextArea();
-        };
+            return () => {
+                codeEditor.toTextArea();
+            };
+        }
     }, []);
 
     const handleDataSampleChange = (newDataSample: string) => {
@@ -163,9 +166,8 @@ const MappingTestWidget = (props: { data: Mapping }) => {
                             <div className="pt-2 pb-3">
                                 <span className="h6">Device Data Sample</span>
                             </div>
-                            <Input
-                                type="textarea" name="devicedatasample" id="devicedatasample"
-                            />
+                            <textarea className="border overflow-auto p-2" ref={dataSampleRef}>
+                            </textarea>
                             <pre className={`iomt-cm-data-result overflow-auto p-2 ${dataSampleValid ? "text-success" : "text-danger"}`}>
                                 {dataSampleResult}
                             </pre>

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.css
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.css
@@ -1,4 +1,9 @@
-﻿
+﻿.CodeMirror {
+    height: 200px;
+    border: 1px solid #dee2e6 !important;
+    font-size: 87.5%;
+}
+
 .iomt-cm-test-area {
     width: calc(100vw - 30px);
     height: 380px;
@@ -10,6 +15,10 @@
 
 .iomt-cm-test {
     background-color: #f8f9fa;
+}
+
+.iomt-cm-data-error {
+    background-color: #ffc7ce;
 }
 
 .iomt-cm-data-result {

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.css
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.css
@@ -5,11 +5,17 @@
 }
 
 .iomt-cm-test-area textarea {
-    height: 280px;
+    height: 200px;
 }
 
 .iomt-cm-test {
     background-color: #f8f9fa;
+}
+
+.iomt-cm-data-result {
+    height: 70px;
+    margin-top: 10px;
+    overflow-y: scroll;
 }
 
 .iomt-cm-test-result {

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.css
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.css
@@ -10,6 +10,7 @@
 }
 
 .iomt-cm-test-area textarea {
+    width: 100%;
     height: 200px;
 }
 

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/jsonlint-mod.d.ts
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/jsonlint-mod.d.ts
@@ -1,0 +1,1 @@
+declare module "jsonlint-mod"

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Controllers/Apis/Utility.cs
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Controllers/Apis/Utility.cs
@@ -4,7 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Microsoft.Health.Tools.DataMapper.Controllers.Apis
 {
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Tools.DataMapper.Controllers.Apis
         {
             try
             {
-                JContainer.Parse(jsonContent);
+                JsonDocument.Parse(jsonContent);
                 message = null;
                 return true;
             }


### PR DESCRIPTION
Updated the IoMT Connector Data Mapper as follows:
- Replaced Newtonsoft.Json with System.Text.Json to validate JSON syntax when testing normalization and FHIR transformation. System.Text.Json is used because it follows RFC 8259 specification, which, for example, does not allow trailing commas.
- Use JSON Lint to validate JSON syntax as device data sample is input, and display validation result. JSON Lint is used because it considers trailing commas as invalid and it provides an error message with the line number of the error.
- Use CodeMirror as the editor for device data sample to improve the experience of entering the JSON and of finding JSON validation errors.
- Corrected spelling in Device Mapping tutorial.