### PR TITLE
Handle event processing exceptions based on type.

### DIFF
--- a/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/ErrorType.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/ErrorType.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Health.Common.Telemetry
         public static string DeviceMessageError => nameof(DeviceMessageError);
 
         /// <summary>
+        /// A metric type for errors that occur when interacting with event hub resources.
+        /// </summary>
+        public static string EventHubError => nameof(EventHubError);
+
+        /// <summary>
         /// A metric type for errors that occur when loading or parsing the FHIR template json file.
         /// </summary>
         public static string FHIRTemplateError => nameof(FHIRTemplateError);

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubErrorCode.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubErrorCode.cs
@@ -1,0 +1,35 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Events.Telemetry
+{
+    public enum EventHubErrorCode
+    {
+        /// <summary>
+        /// Error code that categorizes exceptions of the type EventHubsException
+        /// </summary>
+        OperationError,
+
+        /// <summary>
+        /// Error code that indicates failures in initializing event hub partition
+        /// </summary>
+        EventHubPartitionInitFailed,
+
+        /// <summary>
+        /// Error code that categorizes exceptions of the type SocketException
+        /// </summary>
+        SocketError,
+
+        /// <summary>
+        /// Error code that categorizes authentication errors (eg: exceptions of the type UnauthorizedAccessException)
+        /// </summary>
+        AuthorizationError,
+
+        /// <summary>
+        /// Error code that categorizes all other generic Exceptions
+        /// </summary>
+        GeneralError,
+    }
+}

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionTelemetryProcessor.cs
@@ -12,29 +12,6 @@ using Microsoft.Health.Logging.Telemetry;
 
 namespace Microsoft.Health.Events.Telemetry.Exceptions
 {
-    public enum EventHubErrorCode
-    {
-        /// <summary>
-        /// Error code that categorizes exceptions of the type EventHubsException
-        /// </summary>
-        OperationErrors,
-
-        /// <summary>
-        /// Error code that indicates failures in initializing event hub partition
-        /// </summary>
-        EventHubPartitionInitFailed,
-
-        /// <summary>
-        /// Error code that categorizes exceptions of the type SocketException
-        /// </summary>
-        SocketErrors,
-
-        /// <summary>
-        /// Error code that categorizes all other generic Exceptions
-        /// </summary>
-        GeneralErrors,
-    }
-
     public static class EventHubExceptionTelemetryProcessor
     {
         public static void ProcessException(
@@ -59,11 +36,13 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
             switch (exception)
             {
                 case EventHubsException _:
-                    return $"{ErrorType.EventHubError}{EventHubErrorCode.OperationErrors}";
+                    return $"{ErrorType.EventHubError}{EventHubErrorCode.OperationError}";
                 case SocketException _:
-                    return $"{ErrorType.EventHubError}{EventHubErrorCode.SocketErrors}";
+                    return $"{ErrorType.EventHubError}{EventHubErrorCode.SocketError}";
+                case UnauthorizedAccessException _:
+                    return $"{ErrorType.EventHubError}{EventHubErrorCode.AuthorizationError}";
                 default:
-                    return $"{ErrorType.EventHubError}{EventHubErrorCode.GeneralErrors}";
+                    return $"{ErrorType.EventHubError}{EventHubErrorCode.GeneralError}";
             }
         }
     }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionTelemetryProcessor.cs
@@ -1,0 +1,70 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Net.Sockets;
+using Azure.Messaging.EventHubs;
+using EnsureThat;
+using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Logging.Telemetry;
+
+namespace Microsoft.Health.Events.Telemetry.Exceptions
+{
+    public enum EventHubErrorCode
+    {
+        /// <summary>
+        /// Error code that categorizes exceptions of the type EventHubsException
+        /// </summary>
+        OperationErrors,
+
+        /// <summary>
+        /// Error code that indicates failures in initializing event hub partition
+        /// </summary>
+        EventHubPartitionInitFailed,
+
+        /// <summary>
+        /// Error code that categorizes exceptions of the type SocketException
+        /// </summary>
+        SocketErrors,
+
+        /// <summary>
+        /// Error code that categorizes all other generic Exceptions
+        /// </summary>
+        GeneralErrors,
+    }
+
+    public static class EventHubExceptionTelemetryProcessor
+    {
+        public static void ProcessException(
+            Exception exception,
+            ITelemetryLogger logger,
+            bool shouldLogMetric = true,
+            string errorMetricName = null)
+        {
+            EnsureArg.IsNotNull(exception, nameof(exception));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+
+            logger.LogError(exception);
+
+            if (shouldLogMetric)
+            {
+                logger.LogMetric(EventMetrics.HandledException(errorMetricName ?? GetErrorMetricName(exception), ConnectorOperation.Setup), 1);
+            }
+        }
+
+        private static string GetErrorMetricName(Exception exception)
+        {
+            switch (exception)
+            {
+                case EventHubsException _:
+                    return $"{ErrorType.EventHubError}{EventHubErrorCode.OperationErrors}";
+                case SocketException _:
+                    return $"{ErrorType.EventHubError}{EventHubErrorCode.SocketErrors}";
+                default:
+                    return $"{ErrorType.EventHubError}{EventHubErrorCode.GeneralErrors}";
+            }
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Health.Events.Telemetry
                 {
                     { _nameDimension, exceptionName },
                     { _categoryDimension, Category.Errors },
-                    { _errorTypeDimension, ErrorType.GeneralError },
+                    { _errorTypeDimension, ErrorType.EventHubError },
                     { _errorSeverityDimension, ErrorSeverity.Critical },
                     { _operationDimension, connectorStage },
                 });

--- a/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Azure.Messaging.EventHubs;
 using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Events.Telemetry;
 using Microsoft.Health.Events.Telemetry.Exceptions;
 using Microsoft.Health.Logging.Telemetry;
 using NSubstitute;
@@ -12,9 +13,10 @@ namespace Microsoft.Health.Events.UnitTest
     public class EventHubExceptionTelemetryProcessorTests
     {
         [Theory]
-        [InlineData(typeof(EventHubsException), new object [] { false, "test" }, "EventHubErrorOperationErrors")]
-        [InlineData(typeof(SocketException), null, "EventHubErrorSocketErrors")]
-        [InlineData(typeof(Exception), null, "EventHubErrorGeneralErrors")]
+        [InlineData(typeof(EventHubsException), new object [] { false, "test" }, "EventHubErrorOperationError")]
+        [InlineData(typeof(SocketException), null, "EventHubErrorSocketError")]
+        [InlineData(typeof(UnauthorizedAccessException), null, "EventHubErrorAuthorizationError")]
+        [InlineData(typeof(Exception), null, "EventHubErrorGeneralError")]
         public void GivenExceptionTypes_WhenProcessExpection_ThenExceptionLoggedAndEventHubErrorMetricLogged_Test(Type exType, object[] param, string expectedErrorMetricName)
         {
             var logger = Substitute.For<ITelemetryLogger>();

--- a/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
@@ -1,0 +1,67 @@
+﻿using Azure.Messaging.EventHubs;
+using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Events.Telemetry.Exceptions;
+using Microsoft.Health.Logging.Telemetry;
+using NSubstitute;
+using System;
+using System.Net.Sockets;
+using Xunit;
+
+namespace Microsoft.Health.Events.UnitTest
+{
+    public class EventHubExceptionTelemetryProcessorTests
+    {
+        [Theory]
+        [InlineData(typeof(EventHubsException), new object [] { false, "test" }, "EventHubErrorOperationErrors")]
+        [InlineData(typeof(SocketException), null, "EventHubErrorSocketErrors")]
+        [InlineData(typeof(Exception), null, "EventHubErrorGeneralErrors")]
+        public void GivenExceptionTypes_WhenProcessExpection_ThenExceptionLoggedAndEventHubErrorMetricLogged_Test(Type exType, object[] param, string expectedErrorMetricName)
+        {
+            var logger = Substitute.For<ITelemetryLogger>();
+            Exception ex = Activator.CreateInstance(exType, param) as Exception;
+
+            EventHubExceptionTelemetryProcessor.ProcessException(ex, logger);
+
+            logger.Received(1).LogError(ex);
+            logger.Received(1).LogMetric(Arg.Is<Metric>(m =>
+                m.Name.Equals(expectedErrorMetricName) &&
+                ValidateEventHubErrorMetricProperties(m)),
+                1);
+        }
+
+        [Theory]
+        [InlineData(typeof(SocketException))]
+        public void GivenExceptionAndShouldNotLogMetric_WhenProcessExpection_ThenExceptionLoggedAndEventHubErrorMetricNotLogged_Test(System.Type exType)
+        {
+            var logger = Substitute.For<ITelemetryLogger>();
+            var ex = Activator.CreateInstance(exType) as Exception;
+
+            EventHubExceptionTelemetryProcessor.ProcessException(ex, logger, shouldLogMetric: false);
+
+            logger.Received(1).LogError(ex);
+            logger.DidNotReceiveWithAnyArgs().LogMetric(null, default);
+        }
+
+        [Theory]
+        [InlineData(typeof(Exception))]
+        public void GivenExceptionAndErrorMetricName_WhenProcessExpection_ThenExceptionLoggedAndErrorMetricNameLogged_Test(System.Type exType)
+        {
+            var logger = Substitute.For<ITelemetryLogger>();
+            var ex = Activator.CreateInstance(exType) as Exception;
+
+            EventHubExceptionTelemetryProcessor.ProcessException(ex, logger, errorMetricName: EventHubErrorCode.EventHubPartitionInitFailed.ToString());
+
+            logger.Received(1).LogError(ex);
+            logger.Received(1).LogMetric(Arg.Is<Metric>(m =>
+                m.Name.Equals(EventHubErrorCode.EventHubPartitionInitFailed.ToString()) &&
+                ValidateEventHubErrorMetricProperties(m)),
+                1);
+        }
+
+        private bool ValidateEventHubErrorMetricProperties(Metric metric)
+        {
+            return metric.Dimensions["Category"].Equals(Category.Errors) &&
+                metric.Dimensions["ErrorType"].Equals(ErrorType.EventHubError);
+        }
+    }
+}


### PR DESCRIPTION
Bug: Upon handling errors when processing events, the corresponding exception was always being cast to EventHubException even when the exception was not of that type causing an invalid cast exception in the error handling and as a result no errors/metrics were being logged.
Fix: Process the exception according to its type.