### PR TITLE
Removal of false positive 'npm audit' warnings

### DIFF
--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/package.json
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/package.json
@@ -16,7 +16,6 @@
     "react-redux": "7.1.1",
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
-    "react-scripts": "4.0.1",
     "reactstrap": "8.1.1",
     "redux": "4.0.4",
     "redux-thunk": "2.3.0"
@@ -41,6 +40,7 @@
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.16.0",
     "nan": "^2.14.1",
+    "react-scripts": "4.0.1",
     "typescript": "4.1.3"
   },
   "scripts": {


### PR DESCRIPTION
Moved `react-scripts` in `package.json` from `dependencies` to `devDependencies` to remove `npm audit` warnings about vulnerabilities that are false positives, as detailed in https://github.com/facebook/create-react-app/issues/11092 and https://github.com/facebook/create-react-app/issues/11174.
The affected components (packages) mentioned in these warnings are development-only dependencies.