### PR TITLE
Data Mapper: Editing type name

### DIFF
--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/package.json
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/package.json
@@ -16,7 +16,7 @@
     "react-redux": "7.1.1",
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
-    "reactstrap": "8.1.1",
+    "reactstrap": "8.9.0",
     "redux": "4.0.4",
     "redux-thunk": "2.3.0"
   },

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/App.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/App.tsx
@@ -9,6 +9,7 @@ import Layout from './components/Layout';
 
 import MappingListPage from './components/mapping/List.Page';
 import MappingDetailPage from './components/mapping/Detail.Page';
+import * as Constants from './components/Constants';
 
 import './custom.css'
 
@@ -16,6 +17,6 @@ export default () => (
     <Layout>
         <Route exact path='/' component={MappingListPage} />
         <Route exact path='/mappings' component={MappingListPage} />
-        <Route path="/mappings/:id" component={MappingDetailPage} />
+        <Route path={`${Constants.Text.PathMappings}:id`} component={MappingDetailPage} />
     </Layout>
 );

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/Constants.ts
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/Constants.ts
@@ -65,5 +65,7 @@ export const Text = {
     LabelUntitled: "Untitled",
     LabelMappingList: "Mapping Templates",
 
-    LabelTestResultFail: "Fail"
+    LabelTestResultFail: "Fail",
+
+    PathMappings: "/mappings/"
 }

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/NavMenu.css
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/NavMenu.css
@@ -7,3 +7,14 @@
 .box-shadow {
     box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
 }
+
+.page-heading {
+    color: #212529;
+    font-size: 1.25rem;
+    font-weight: bold;
+}
+
+span.navbar-text {
+    padding-top: 0px;
+    padding-bottom: 0px;
+}

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/NavMenu.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/NavMenu.tsx
@@ -8,7 +8,7 @@ import { Navbar, NavbarBrand, NavbarText } from 'reactstrap';
 import { Link, useLocation } from 'react-router-dom';
 import PersistService from '../services/PersistService';
 import { Mapping } from '../store/Mapping';
-import { default as MappingCreationModal, Action } from './mapping/List.Modals.Creation';
+import { default as MappingNameModal, Action } from './mapping/List.Modals.Name';
 import './NavMenu.css';
 
 const NavMenu = (props: {}) => {
@@ -48,7 +48,7 @@ const NavMenu = (props: {}) => {
                         <span className="page-heading" style={{ margin: "0px 10px 0px 50px" }}>
                             {mappingTypeName}
                         </span>
-                        <MappingCreationModal
+                        <MappingNameModal
                             onSave={(typename: string, errorHandler: Function) => renameMapping(mappingId, typename, errorHandler)}
                             action={Action.Rename}
                             inputDefaultValue={mappingTypeName}

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/NavMenu.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/NavMenu.tsx
@@ -4,17 +4,57 @@
 // -------------------------------------------------------------------------------------------------
 
 import * as React from 'react';
-import { Navbar, NavbarBrand } from 'reactstrap';
-import { Link } from 'react-router-dom';
+import { Navbar, NavbarBrand, NavbarText } from 'reactstrap';
+import { Link, useLocation } from 'react-router-dom';
+import PersistService from '../services/PersistService';
+import { Mapping } from '../store/Mapping';
+import { default as MappingCreationModal, Action } from './mapping/List.Modals.Creation';
 import './NavMenu.css';
 
 const NavMenu = (props: {}) => {
+    const [mappingId, setMappingId] = React.useState('');
+    const [mappingTypeName, setMappingTypeName] = React.useState('');
+
+    const location = useLocation();
+
+    React.useEffect(() => {
+        const pathname = location.pathname;
+        const id = pathname.substr(pathname.lastIndexOf('/') + 1);
+        const typeName = PersistService.getMapping(id)?.typeName;
+        setMappingId(id);
+        setMappingTypeName(typeName);
+    }, [location]);
+
+    const renameMapping = (id: string, typename: string, errorHandler?: Function) => {
+        PersistService.renameMapping(id, typename)
+            .then((mapping: Mapping) => {
+                setMappingTypeName(mapping.typeName);
+            })
+            .catch(err => {
+                if (errorHandler) {
+                    errorHandler(err);
+                }
+            });
+    }
+
     return (
         <header>
             <Navbar className="navbar-expand-sm border-bottom box-shadow mb-1" light>
                 <NavbarBrand tag={Link} to="/">
                     IoMT Connector Data Mapper
                 </NavbarBrand>
+                {mappingTypeName !== undefined &&
+                    <NavbarText>
+                        <span className="page-heading" style={{ margin: "0px 10px 0px 50px" }}>
+                            {mappingTypeName}
+                        </span>
+                        <MappingCreationModal
+                            onSave={(typename: string, errorHandler: Function) => renameMapping(mappingId, typename, errorHandler)}
+                            action={Action.Rename}
+                            inputDefaultValue={mappingTypeName}
+                        />
+                    </NavbarText>
+                }
             </Navbar>
         </header>
     );

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/NavMenu.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/NavMenu.tsx
@@ -25,10 +25,13 @@ const NavMenu = (props: {}) => {
         setMappingTypeName(typeName);
     }, [location]);
 
-    const renameMapping = (id: string, typename: string, errorHandler?: Function) => {
+    const renameMapping = (id: string, typename: string, errorHandler?: Function, setModal?: Function) => {
         PersistService.renameMapping(id, typename)
             .then((mapping: Mapping) => {
                 setMappingTypeName(mapping.typeName);
+                if (setModal) {
+                    setModal(false);
+                }
             })
             .catch(err => {
                 if (errorHandler) {
@@ -49,7 +52,7 @@ const NavMenu = (props: {}) => {
                             {mappingTypeName}
                         </span>
                         <MappingNameModal
-                            onSave={(typename: string, errorHandler: Function) => renameMapping(mappingId, typename, errorHandler)}
+                            onSave={(typename: string, errorHandler: Function, setModal: Function) => renameMapping(mappingId, typename, errorHandler, setModal)}
                             action={Action.Rename}
                             inputDefaultValue={mappingTypeName}
                         />

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/NavMenu.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/NavMenu.tsx
@@ -9,6 +9,7 @@ import { Link, useLocation } from 'react-router-dom';
 import PersistService from '../services/PersistService';
 import { Mapping } from '../store/Mapping';
 import { default as MappingNameModal, Action } from './mapping/List.Modals.Name';
+import * as Constants from './Constants';
 import './NavMenu.css';
 
 const NavMenu = (props: {}) => {
@@ -19,7 +20,18 @@ const NavMenu = (props: {}) => {
 
     React.useEffect(() => {
         const pathname = location.pathname;
-        const id = pathname.substr(pathname.lastIndexOf('/') + 1);
+
+        // Get mapping ID between start and end strings, if any, from the path
+        var id = '';
+        const start = Constants.Text.PathMappings;
+        const end = '/';
+        const startIndex = pathname.indexOf(start);
+        if (startIndex !== -1) {
+            const idIndex = startIndex + start.length;
+            const endIndex = pathname.indexOf(end, idIndex);
+            id = pathname.substring(idIndex, (endIndex !== -1 ? endIndex : undefined));
+        }
+
         const typeName = PersistService.getMapping(id)?.typeName;
         setMappingId(id);
         setMappingTypeName(typeName);

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Forms.Tutorials.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Forms.Tutorials.tsx
@@ -170,7 +170,7 @@ export const FhirComponentsFormTutorial = (props: {}) => {
                     <li>Codings of each component should be specified to the value in it.</li>
                 </ul>
                 <p>
-                    Please check "Blood Pressure - Sampled Data" as examples in <a href="https://github.com/microsoft/iomt-fhir/blob/master/docs/Configuration.md">IoMT Mapping Configuration</a>
+                    Please check "Heart Rate - Sampled Data" as an example in <a href="https://github.com/microsoft/iomt-fhir/blob/master/docs/Configuration.md">IoMT Mapping Configuration</a>
                 </p>
             </CardBody>
         </Card>

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Device.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Device.tsx
@@ -38,7 +38,7 @@ const DeviceMappingWidget = (props: { data: Mapping; onUpdate: Function}) => {
     return (
         <React.Fragment>
             <div className="iomt-cm-editor-title p-2 pb-3 m-0 border border-bottom-0">
-                <span className="h5">{props.data.typeName} - Device Mapping</span>
+                <span className="h5">Device Mapping</span>
             </div>
             <div className="iomt-cm-editor p-3 border">
                 {

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Fhir.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Widgets.Fhir.tsx
@@ -126,7 +126,7 @@ const FhirMappingWidget = (props: { data: Mapping; onUpdate: Function }) => {
     return (
         <React.Fragment>
             <div className="iomt-cm-editor-title p-2 pb-3 m-0 border border-bottom-0">
-                <span className="h5">{props.data.typeName} - FHIR Mapping</span>
+                <span className="h5">FHIR Mapping</span>
             </div>
             <div className="iomt-cm-editor border">
                 {

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Creation.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Creation.tsx
@@ -6,9 +6,13 @@
 import * as React from 'react';
 import { FormGroup, Label, Input, Modal, ModalHeader, ModalBody, ModalFooter, Form, Col } from 'reactstrap';
 
-const MappingCreationModal = (props: { onSave: Function }) => {
+export enum Action {
+    Create
+}
+
+const MappingCreationModal = (props: { onSave: Function; action: Action }) => {
     const {
-        onSave,
+        onSave, action
     } = props;
 
     const [typename, setTypename] = React.useState('');
@@ -16,10 +20,30 @@ const MappingCreationModal = (props: { onSave: Function }) => {
     const [modal, setModal] = React.useState(false);
     const toggle = () => setModal(!modal);
 
+    const modalTitleText = () => {
+        switch (action) {
+            case Action.Create:
+                return "Create new mapping";
+            default:
+                return "";
+        }
+    }
+
+    const buttonText = () => {
+        switch (action) {
+            case Action.Create:
+                return "Add new mapping";
+            default:
+                return "";
+        }
+    }
+
     const renderModal = () => {
         return (
             <Modal isOpen={modal} toggle={toggle}>
-                <ModalHeader toggle={toggle}>Create new mapping</ModalHeader>
+                <ModalHeader toggle={toggle}>
+                    {modalTitleText()}
+                </ModalHeader>
                 <ModalBody>
                     <Form>
                         <FormGroup row>
@@ -45,7 +69,7 @@ const MappingCreationModal = (props: { onSave: Function }) => {
     return (
         <div>
             <button className="btn iomt-cm-btn" onClick={toggle}>
-                Add new mapping
+                {buttonText()}
             </button>
             {renderModal()}
         </div>

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Creation.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Creation.tsx
@@ -19,7 +19,13 @@ const MappingCreationModal = (props: { onSave: Function; action: Action; inputDe
     const [typename, setTypename] = React.useState(inputDefaultValue ?? '');
     const [typenameError, setTypenameError] = React.useState('');
     const [modal, setModal] = React.useState(false);
-    const toggle = () => setModal(!modal);
+
+    const toggle = () => {
+        if (!modal) {
+            setTypenameError("");
+        }
+        setModal(!modal);
+    }
 
     const modalTitleText = () => {
         switch (action) {

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Creation.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Creation.tsx
@@ -7,15 +7,16 @@ import * as React from 'react';
 import { FormGroup, Label, Input, Modal, ModalHeader, ModalBody, ModalFooter, Form, Col } from 'reactstrap';
 
 export enum Action {
-    Create
+    Create,
+    Rename
 }
 
-const MappingCreationModal = (props: { onSave: Function; action: Action }) => {
+const MappingCreationModal = (props: { onSave: Function; action: Action; inputDefaultValue?: string; buttonClassName?: string }) => {
     const {
-        onSave, action
+        onSave, action, inputDefaultValue, buttonClassName
     } = props;
 
-    const [typename, setTypename] = React.useState('');
+    const [typename, setTypename] = React.useState(inputDefaultValue ?? '');
     const [typenameError, setTypenameError] = React.useState('');
     const [modal, setModal] = React.useState(false);
     const toggle = () => setModal(!modal);
@@ -24,6 +25,8 @@ const MappingCreationModal = (props: { onSave: Function; action: Action }) => {
         switch (action) {
             case Action.Create:
                 return "Create new mapping";
+            case Action.Rename:
+                return "Rename mapping";
             default:
                 return "";
         }
@@ -33,6 +36,8 @@ const MappingCreationModal = (props: { onSave: Function; action: Action }) => {
         switch (action) {
             case Action.Create:
                 return "Add new mapping";
+            case Action.Rename:
+                return "Rename";
             default:
                 return "";
         }
@@ -51,6 +56,7 @@ const MappingCreationModal = (props: { onSave: Function; action: Action }) => {
                             <Col sm={9}>
                                 <Input type="text" name="typename" id="typename"
                                     placeholder="input a unique type name"
+                                    defaultValue={inputDefaultValue}
                                     onChange={e => { setTypename(e.target.value) }}
                                 />
                                 <span>{typenameError}</span>
@@ -67,12 +73,12 @@ const MappingCreationModal = (props: { onSave: Function; action: Action }) => {
     }
 
     return (
-        <div>
-            <button className="btn iomt-cm-btn" onClick={toggle}>
+        <span>
+            <button className={buttonClassName ?? "btn iomt-cm-btn"} onClick={toggle}>
                 {buttonText()}
             </button>
             {renderModal()}
-        </div>
+        </span>
     );
 }
 

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Export.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Export.tsx
@@ -72,11 +72,11 @@ const MappingExportModal = (props: { mappings: Mapping[] }) => {
     }
 
     return (
-        <div>
+        <span>
             <button className="btn iomt-cm-btn" onClick={toggle}
                 disabled={props.mappings?.length === 0}>Export Mappings</button>
             {renderModal()}
-        </div>
+        </span>
     );
 }
 

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Name.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Name.tsx
@@ -11,7 +11,7 @@ export enum Action {
     Rename
 }
 
-const MappingCreationModal = (props: { onSave: Function; action: Action; inputDefaultValue?: string; buttonClassName?: string }) => {
+const MappingNameModal = (props: { onSave: Function; action: Action; inputDefaultValue?: string; buttonClassName?: string }) => {
     const {
         onSave, action, inputDefaultValue, buttonClassName
     } = props;
@@ -88,4 +88,4 @@ const MappingCreationModal = (props: { onSave: Function; action: Action; inputDe
     );
 }
 
-export default MappingCreationModal;
+export default MappingNameModal;

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Name.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Name.tsx
@@ -20,12 +20,14 @@ const MappingNameModal = (props: { onSave: Function; action: Action; inputDefaul
     const [typenameError, setTypenameError] = React.useState('');
     const [modal, setModal] = React.useState(false);
 
-    const toggle = () => {
-        if (!modal) {
-            setTypenameError("");
+    React.useEffect(() => {
+        if (modal) {
+            setTypename(inputDefaultValue ?? '');
+            setTypenameError('');
         }
-        setModal(!modal);
-    }
+    }, [modal]);
+
+    const toggle = () => setModal(!modal);
 
     const modalTitleText = () => {
         switch (action) {

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Name.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Name.tsx
@@ -71,7 +71,7 @@ const MappingNameModal = (props: { onSave: Function; action: Action; inputDefaul
                     </Form>
                 </ModalBody>
                 <ModalFooter>
-                    <button className="btn btn-primary" onClick={() => onSave(typename, setTypenameError)}>Confirm</button>{' '}
+                    <button className="btn btn-primary" onClick={() => onSave(typename, setTypenameError, setModal)}>Confirm</button>{' '}
                     <button className="btn btn-secondary" onClick={toggle}>Cancel</button>
                 </ModalFooter>
             </Modal>

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
@@ -57,10 +57,13 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
             });
     }
 
-    private renameMapping(id: string, typename: string, errorHandler?: Function) {
+    private renameMapping(id: string, typename: string, errorHandler?: Function, setModal?: Function) {
         PersistService.renameMapping(id, typename)
             .then(() => {
                 this.ensureMappingsFetched();
+                if (setModal) {
+                    setModal(false);
+                }
             })
             .catch(err => {
                 if (errorHandler) {
@@ -107,7 +110,7 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
                                         <td>{mapping.typeName}</td>
                                         <td className="text-right">
                                             <MappingNameModal
-                                                onSave={(typename: string, errorHandler: Function) => this.renameMapping(mapping.id, typename, errorHandler)}
+                                                onSave={(typename: string, errorHandler: Function, setModal: Function) => this.renameMapping(mapping.id, typename, errorHandler, setModal)}
                                                 action={Action.Rename}
                                                 inputDefaultValue={mapping.typeName}
                                                 buttonClassName="m-1 btn iomt-cm-btn-link"

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
@@ -9,7 +9,7 @@ import { RouteComponentProps } from 'react-router';
 
 import { ApplicationState } from '../../store';
 import * as MappingsStore from '../../store/Mapping';
-import { default as MappingCreationModal, Action } from './List.Modals.Creation';
+import { default as MappingNameModal, Action } from './List.Modals.Name';
 import MappingExportModal from './List.Modals.Export';
 import PersistService from '../../services/PersistService';
 import { Mapping } from '../../store/Mapping';
@@ -73,7 +73,7 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
         return (
             <React.Fragment>
                 <div className="d-inline-block m-1 mb-3">
-                    <MappingCreationModal
+                    <MappingNameModal
                         onSave={this.createMapping}
                         action={Action.Create}
                     />
@@ -106,7 +106,7 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
                                     <tr key={index}>
                                         <td>{mapping.typeName}</td>
                                         <td className="text-right">
-                                            <MappingCreationModal
+                                            <MappingNameModal
                                                 onSave={(typename: string, errorHandler: Function) => this.renameMapping(mapping.id, typename, errorHandler)}
                                                 action={Action.Rename}
                                                 inputDefaultValue={mapping.typeName}

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
@@ -13,6 +13,7 @@ import { default as MappingNameModal, Action } from './List.Modals.Name';
 import MappingExportModal from './List.Modals.Export';
 import PersistService from '../../services/PersistService';
 import { Mapping } from '../../store/Mapping';
+import * as Constants from '../Constants';
 
 import './List.css';
 
@@ -48,7 +49,7 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
     private createMapping(typename: string, errorHandler?: Function) {
         PersistService.createMapping(typename)
             .then((newMapping: Mapping) => {
-                window.location.href = `/mappings/${newMapping.id}`
+                window.location.href = `${Constants.Text.PathMappings}${newMapping.id}`
             })
             .catch(err => {
                 if (errorHandler) {
@@ -116,7 +117,7 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
                                                 buttonClassName="m-1 btn iomt-cm-btn-link"
                                             />
                                             <button className="m-1 btn iomt-cm-btn-link"
-                                                onClick={() => { window.location.href = `/mappings/${mapping.id}` }}>
+                                                onClick={() => { window.location.href = `${Constants.Text.PathMappings}${mapping.id}` }}>
                                                 Edit
                                             </button>
                                             <button className="m-1 btn iomt-cm-btn-link"

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
@@ -9,7 +9,7 @@ import { RouteComponentProps } from 'react-router';
 
 import { ApplicationState } from '../../store';
 import * as MappingsStore from '../../store/Mapping';
-import MappingCreationModal from './List.Modals.Creation';
+import { default as MappingCreationModal, Action } from './List.Modals.Creation';
 import MappingExportModal from './List.Modals.Export';
 import PersistService from '../../services/PersistService';
 import { Mapping } from '../../store/Mapping';
@@ -62,6 +62,7 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
                 <div className="d-inline-block m-1 mb-3">
                     <MappingCreationModal
                         onSave={this.createMapping}
+                        action={Action.Create}
                     />
                 </div>
                 <div className="d-inline-block m-1 mb-3">
@@ -95,11 +96,11 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
                                             <button className="m-1 btn iomt-cm-btn-link"
                                                 onClick={() => { window.location.href = `/mappings/${mapping.id}` }}>
                                                 Edit
-                                                </button>
+                                            </button>
                                             <button className="m-1 btn iomt-cm-btn-link"
                                                 onClick={() => { this.props.deleteMapping(mapping.id); this.props.listMappings() }}>
                                                 Delete
-                                                </button>
+                                            </button>
                                         </td>
                                     </tr>
                                 );

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
@@ -25,6 +25,7 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
 
     public componentDidMount() {
         this.createMapping = this.createMapping.bind(this);
+        this.renameMapping = this.renameMapping.bind(this);
         this.ensureMappingsFetched();
     }
 
@@ -48,6 +49,18 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
         PersistService.createMapping(typename)
             .then((newMapping: Mapping) => {
                 window.location.href = `/mappings/${newMapping.id}`
+            })
+            .catch(err => {
+                if (errorHandler) {
+                    errorHandler(err);
+                }
+            });
+    }
+
+    private renameMapping(id: string, typename: string, errorHandler?: Function) {
+        PersistService.renameMapping(id, typename)
+            .then(() => {
+                this.ensureMappingsFetched();
             })
             .catch(err => {
                 if (errorHandler) {
@@ -93,6 +106,12 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
                                     <tr key={index}>
                                         <td>{mapping.typeName}</td>
                                         <td className="text-right">
+                                            <MappingCreationModal
+                                                onSave={(typename: string, errorHandler: Function) => this.renameMapping(mapping.id, typename, errorHandler)}
+                                                action={Action.Rename}
+                                                inputDefaultValue={mapping.typeName}
+                                                buttonClassName="m-1 btn iomt-cm-btn-link"
+                                            />
                                             <button className="m-1 btn iomt-cm-btn-link"
                                                 onClick={() => { window.location.href = `/mappings/${mapping.id}` }}>
                                                 Edit

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
@@ -51,22 +51,31 @@ const getMapping = (mappingId: string): Mapping => {
 }
 
 const createMapping = (typename: string): Promise<Mapping> => {
-    return new Promise((resolve, reject) => {
-        const mappings = getAllMappings();
+    const id = generateUID();
+    return updateMapping(id, typename);
+}
 
-        if (_.find(mappings, { typeName: typename })) {
-            reject(`The typename ${typename} existed`);
+const updateMapping = (id: string, typename: string): Promise<Mapping> => {
+    return new Promise((resolve, reject) => {
+        const existingMapping = getMapping(id);
+        if (existingMapping && existingMapping.typeName === typename) {
+            resolve(existingMapping);
             return;
         }
 
-        const newMappingId = generateUID();
-        const newMapping = {
-            id: newMappingId,
+        const mappings = getAllMappings();
+        if (_.find(mappings, { typeName: typename })) {
+            reject(`The typename ${typename} already exists`);
+            return;
+        }
+
+        const mapping = {
+            id: id,
             typeName: typename
         } as Mapping;
-        saveMappingToLocalStorage(newMappingId, newMapping);
+        saveMappingToLocalStorage(id, mapping);
 
-        resolve(newMapping);
+        resolve(mapping);
         return;
     });
 }
@@ -88,6 +97,7 @@ const PersistService = {
     createMapping: createMapping,
     getAllMappings: getAllMappings,
     getMapping: getMapping,
+    renameMapping: updateMapping,
     saveMapping: saveMappingToLocalStorage,
     deleteMapping: deleteMappingInLocalStorage
 }

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
@@ -58,7 +58,7 @@ const createMapping = (typename: string): Promise<Mapping> => {
 const updateMapping = (id: string, typename: string): Promise<Mapping> => {
     return new Promise((resolve, reject) => {
         if (!typename || typename.trim().length < 1) {
-            reject(`The typename cannot be empty`);
+            reject(`The type name cannot be empty`);
             return;
         }
 
@@ -70,7 +70,7 @@ const updateMapping = (id: string, typename: string): Promise<Mapping> => {
 
         const mappings = getAllMappings();
         if (_.find(mappings, { typeName: typename })) {
-            reject(`The typename ${typename} already exists`);
+            reject(`The type name ${typename} already exists`);
             return;
         }
 

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
@@ -57,6 +57,11 @@ const createMapping = (typename: string): Promise<Mapping> => {
 
 const updateMapping = (id: string, typename: string): Promise<Mapping> => {
     return new Promise((resolve, reject) => {
+        if (!typename || typename.trim().length < 1) {
+            reject(`The typename cannot be empty`);
+            return;
+        }
+
         const existingMapping = getMapping(id);
         if (existingMapping && existingMapping.typeName === typename) {
             resolve(existingMapping);

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
@@ -37,8 +37,8 @@
     <None Remove="ClientApp\src\components\mapping\Detail.Fhir.tsx" />
     <None Remove="ClientApp\src\components\mapping\Detail.Forms.Tutorials.tsx" />
     <None Remove="ClientApp\src\components\mapping\Detail.Page.tsx" />
-    <None Remove="ClientApp\src\components\mapping\List.Modals.Creation.tsx" />
     <None Remove="ClientApp\src\components\mapping\List.Modals.Export.tsx" />
+    <None Remove="ClientApp\src\components\mapping\List.Modals.Name.tsx" />
     <None Remove="ClientApp\src\components\mapping\List.Page.tsx" />
     <None Remove="ClientApp\src\services\PersistService.ts" />
     <None Remove="ClientApp\src\services\TestService.ts" />
@@ -66,8 +66,8 @@
     <TypeScriptCompile Include="ClientApp\src\components\Icons.tsx" />
     <TypeScriptCompile Include="ClientApp\src\components\mapping\Detail.Forms.Tutorials.tsx" />
     <TypeScriptCompile Include="ClientApp\src\components\mapping\Detail.Page.tsx" />
-    <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Creation.tsx" />
     <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Export.tsx" />
+    <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Name.tsx" />
     <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Page.tsx" />
     <TypeScriptCompile Include="ClientApp\src\services\PersistService.ts" />
     <TypeScriptCompile Include="ClientApp\src\services\TestService.ts" />


### PR DESCRIPTION
Updated the IoMT Connector Data Mapper as follows:
- Enabled renaming a mapping's type name on the home page (containing the list of mappings) and on the mapping page, as shown in the following screenshots.
  - "Rename" option on home page:
    ![Home (list) page](https://user-images.githubusercontent.com/80931622/132593062-1bbb56af-7a55-47cf-a084-d222dcffc470.png)
  - "Rename" option on mapping page:
    ![Mapping page](https://user-images.githubusercontent.com/80931622/132593071-5db29f03-23ac-4658-a55c-69cd2e56aba0.png)
  - Pressing "Rename" from the home page or mapping page opens this dialog, which is pre-filled with the current type name:
    ![Rename dialog](https://user-images.githubusercontent.com/80931622/132593081-34da8a5e-94a2-4103-9e79-0eef6af636ca.png)
    - Note: Empty type names are not allowed anymore:
      ![Rename dialog - empty type name](https://user-images.githubusercontent.com/80931622/132593076-9c090d39-1384-4b59-aa7e-09b8872377bd.png)
- Also updated reference to Heart Rate (from Blood Pressure) in tutorial:
  ![Heart Rate](https://user-images.githubusercontent.com/80931622/132593676-3636225c-c84e-4ab7-9e8d-39886124114c.png)