### PR TITLE
Data Mapper: Import mappings

### DIFF
--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/JsonValidator.css
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/JsonValidator.css
@@ -1,0 +1,15 @@
+﻿.CodeMirror {
+    height: 400px;
+    border: 1px solid #dee2e6 !important;
+    font-size: 87.5%;
+}
+
+.line-color-error {
+    background-color: #ffc7ce;
+}
+
+.validation-result {
+    height: 100px;
+    margin-top: 10px;
+    overflow-y: scroll;
+}

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/JsonValidator.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/JsonValidator.tsx
@@ -1,0 +1,89 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+import * as React from 'react';
+import * as JsonLint from 'jsonlint-mod';
+import * as CodeMirror from 'codemirror';
+
+import 'codemirror/addon/display/placeholder.js'
+import 'codemirror/addon/edit/matchbrackets.js';
+import 'codemirror/lib/codemirror.css';
+import 'codemirror/mode/javascript/javascript.js';
+
+import './JsonValidator.css';
+
+const JsonValidator = (props: { onTextChange: Function; placeholder: string }) => {
+    const [validationResult, setValidationResult] = React.useState('');
+    const [isValid, setIsValid] = React.useState(true);
+
+    const textAreaRef = React.useRef<HTMLTextAreaElement>() as React.RefObject<HTMLTextAreaElement>;
+
+    var codeEditor: CodeMirror.EditorFromTextArea;
+    var errorLine: number | null = null;
+
+    React.useEffect(() => {
+        if (textAreaRef.current) {
+            codeEditor = CodeMirror.fromTextArea(
+                textAreaRef.current,
+                {
+                    mode: "javascript",
+                    lineNumbers: true,
+                    matchBrackets: true,
+                    placeholder: `Paste your ${props.placeholder} here...`
+                }
+            );
+
+            codeEditor.on('change', () => handleDataSampleChange(codeEditor.getValue()));
+
+            return () => {
+                codeEditor.toTextArea();
+            };
+        }
+    }, []);
+
+    const handleDataSampleChange = (newDataSample: string) => {
+        props.onTextChange(newDataSample);
+        try {
+            JsonLint.parse(newDataSample);
+            setValidationResult('Valid JSON');
+            setIsValid(true);
+            highlightErrorLine(null);
+        }
+        catch (err) {
+            setValidationResult(err.toString());
+            setIsValid(false);
+            const lineMatches = err.message.match(/line ([0-9]+)/);
+            if (lineMatches) {
+                highlightErrorLine(Number(lineMatches[1]) - 1);
+            }
+        }
+    }
+
+    const highlightErrorLine = (line: number | null) => {
+        if (line === errorLine || !codeEditor) {
+            return;
+        }
+        if (typeof line === 'number') {
+            codeEditor.addLineClass(line, 'background', 'line-color-error');
+        }
+        if (typeof errorLine === 'number') {
+            codeEditor.removeLineClass(errorLine, 'background', 'line-color-error');
+        }
+        errorLine = line;
+    }
+
+    return (
+        <div>
+            <textarea className="border overflow-auto p-2" ref={textAreaRef}
+                onChange={e => { handleDataSampleChange(e.target.value) }}>
+            </textarea>
+            <pre className={`validation-result overflow-auto p-2 ${isValid ? "text-success" : "text-danger"}`}>
+                {validationResult}
+            </pre>
+        </div>
+    );
+}
+
+export default JsonValidator;

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.css
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.css
@@ -1,31 +1,19 @@
-﻿.CodeMirror {
-    height: 200px;
-    border: 1px solid #dee2e6 !important;
-    font-size: 87.5%;
-}
-
-.iomt-cm-test-area {
+﻿.iomt-cm-test-area {
     width: calc(100vw - 30px);
     height: 380px;
 }
 
-.iomt-cm-test-area textarea {
+.iomt-cm-test-area .CodeMirror, .iomt-cm-test-area textarea {
     width: 100%;
     height: 200px;
 }
 
+.iomt-cm-test-area .validation-result {
+    height: 70px;
+}
+
 .iomt-cm-test {
     background-color: #f8f9fa;
-}
-
-.iomt-cm-data-error {
-    background-color: #ffc7ce;
-}
-
-.iomt-cm-data-result {
-    height: 70px;
-    margin-top: 10px;
-    overflow-y: scroll;
 }
 
 .iomt-cm-test-result {

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Export.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Export.tsx
@@ -74,7 +74,7 @@ const MappingExportModal = (props: { mappings: Mapping[] }) => {
     return (
         <span>
             <button className="btn iomt-cm-btn" onClick={toggle}
-                disabled={props.mappings?.length === 0}>Export Mappings</button>
+                disabled={props.mappings?.length === 0}>Export mappings</button>
             {renderModal()}
         </span>
     );

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Import.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Modals.Import.tsx
@@ -1,0 +1,96 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+import * as React from 'react';
+import { Alert, Modal, ModalHeader, ModalBody, ModalFooter, Col, Row } from 'reactstrap';
+
+import PersistService from '../../services/PersistService';
+import JsonValidator from '../JsonValidator';
+
+const MappingImportModal = (props: { onImported: Function }) => {
+    const [modal, setModal] = React.useState(false);
+    const [deviceTemplateContent, setDeviceTemplateContent] = React.useState('');
+    const [fhirTemplateContent, setFhirTemplateContent] = React.useState('');
+    const [importError, setImportError] = React.useState('');
+    const [showImportError, setShowImportError] = React.useState(false);
+
+    React.useEffect(() => {
+        if (modal) {
+            setDeviceTemplateContent('');
+            setFhirTemplateContent('');
+            setImportError('');
+            setShowImportError(false);
+        }
+    }, [modal]);
+
+    const toggle = () => setModal(!modal);
+
+    const onDismissImportError = () => setShowImportError(false);
+
+    const onConfirm = () => {
+        PersistService.createMappingsFromTemplates(deviceTemplateContent, fhirTemplateContent)
+            .then(() => {
+                props.onImported();
+                setImportError('');
+                setShowImportError(false);
+                setModal(false);
+            })
+            .catch(err => {
+                setImportError(`Import failed. ${err}`);
+                setShowImportError(true);
+            });
+    }
+
+    const renderModal = () => {
+        return (
+            <Modal isOpen={modal} toggle={toggle} className="iomt-cm-import-modal">
+                <ModalHeader toggle={toggle}>Enter mapping templates to import</ModalHeader>
+                <ModalBody>
+                    <div className="iomt-cm-modal-description">
+                        Full example templates can be found under <a href="https://github.com/microsoft/iomt-fhir/tree/master/sample/templates">here</a>.
+                    </div>
+                    <Row>
+                        {
+                            <Col>
+                                <h6>Device Mapping Template</h6>
+                                <JsonValidator
+                                    onTextChange={setDeviceTemplateContent}
+                                    placeholder='device mapping template'
+                                />
+                            </Col>
+                        }
+                        {
+                            <Col>
+                                <h6>FHIR Mapping Template</h6>
+                                <JsonValidator
+                                    onTextChange={setFhirTemplateContent}
+                                    placeholder='FHIR mapping template'
+                                />
+                            </Col>
+                        }
+                    </Row>
+                    <Alert color="danger" isOpen={showImportError} toggle={onDismissImportError}>
+                        {importError}
+                    </Alert>
+                </ModalBody>
+                <ModalFooter>
+                    <button className="btn btn-primary" onClick={onConfirm}>Generate</button>{' '}
+                    <button className="btn btn-secondary" onClick={toggle}>Close</button>
+                </ModalFooter>
+            </Modal>
+        );
+    }
+
+    return (
+        <span>
+            <button className="btn iomt-cm-btn" onClick={toggle}>
+                Import mappings
+            </button>
+            {renderModal()}
+        </span>
+    );
+}
+
+export default MappingImportModal;

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.Page.tsx
@@ -11,6 +11,7 @@ import { ApplicationState } from '../../store';
 import * as MappingsStore from '../../store/Mapping';
 import { default as MappingNameModal, Action } from './List.Modals.Name';
 import MappingExportModal from './List.Modals.Export';
+import MappingImportModal from './List.Modals.Import';
 import PersistService from '../../services/PersistService';
 import { Mapping } from '../../store/Mapping';
 import * as Constants from '../Constants';
@@ -25,6 +26,7 @@ type MappingListProps =
 class MappingListPage extends React.PureComponent<MappingListProps> {
 
     public componentDidMount() {
+        this.ensureMappingsFetched = this.ensureMappingsFetched.bind(this);
         this.createMapping = this.createMapping.bind(this);
         this.renameMapping = this.renameMapping.bind(this);
         this.ensureMappingsFetched();
@@ -80,6 +82,11 @@ class MappingListPage extends React.PureComponent<MappingListProps> {
                     <MappingNameModal
                         onSave={this.createMapping}
                         action={Action.Create}
+                    />
+                </div>
+                <div className="d-inline-block m-1 mb-3">
+                    <MappingImportModal
+                        onImported={this.ensureMappingsFetched}
                     />
                 </div>
                 <div className="d-inline-block m-1 mb-3">

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.css
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/List.css
@@ -1,3 +1,11 @@
 ﻿.iomt-cm-export-modal {
     max-width: 70%;
 }
+
+.iomt-cm-import-modal {
+    max-width: 70%;
+}
+
+.iomt-cm-modal-description {
+    margin-bottom: 30px;
+}

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
@@ -6,7 +6,7 @@
 // -------------
 // Persist Services.
 import * as _ from "lodash";
-import { Mapping } from "../store/Mapping";
+import { DeviceMapping, FhirMapping, Mapping } from "../store/Mapping";
 import * as Utils from "./Utils";
 
 const LocalStorageKey = 'iomt-mappings';
@@ -50,12 +50,70 @@ const getMapping = (mappingId: string): Mapping => {
     return storage.mappingsById[mappingId];
 }
 
-const createMapping = (typename: string): Promise<Mapping> => {
-    const id = generateUID();
-    return updateMapping(id, typename);
+const createMappingsFromTemplates = (deviceTemplate: string, fhirTemplate: string): Promise<Mapping[]> => {
+    return new Promise((resolve, reject) => {
+        Promise.all([Utils.generateDeviceMappings(deviceTemplate), Utils.generateFhirMappings(fhirTemplate)])
+            .then(mappings => {
+                const currentMappings = getAllMappings();
+                let newMappings: Mapping[] = [];
+
+                const deviceMappings = mappings[0];
+                let fhirMappings = mappings[1];
+
+                for (const deviceMapping of deviceMappings) {
+                    const typename = deviceMapping.typeName;
+                    if (_.find(currentMappings, { typeName: typename })) {
+                        reject(`A mapping in the Data Mapper already has the typeName "${typename}".
+                            Please enter another typeName for these templates or remove the templates with this typeName.`);
+                        return;
+                    }
+
+                    // Group device and FHIR mappings with the same type name into the same mapping
+                    const fhirMapping = _.remove(fhirMappings, { typeName: typename });
+                    createMapping(typename, deviceMapping.device, fhirMapping.length ? fhirMapping[0].fhir : undefined)
+                        .then((newMapping: Mapping) => {
+                            newMappings.push(newMapping);
+                        })
+                        .catch(err => {
+                            reject(err);
+                            return;
+                        });
+                }
+
+                for (const fhirMapping of fhirMappings) {
+                    const typename = fhirMapping.typeName;
+                    if (_.find(currentMappings, { typeName: typename })) {
+                        reject(`A mapping in the Data Mapper already has the typeName "${typename}".
+                            Please enter another typeName for these templates or remove the templates with this typeName.`);
+                        return;
+                    }
+
+                    createMapping(typename, undefined, fhirMapping.fhir)
+                        .then((newMapping: Mapping) => {
+                            newMappings.push(newMapping);
+                        })
+                        .catch(err => {
+                            reject(err);
+                            return;
+                        });
+                }
+
+                resolve(newMappings);
+                return;
+            })
+            .catch(err => {
+                reject(err);
+                return;
+            });
+    });
 }
 
-const updateMapping = (id: string, typename: string): Promise<Mapping> => {
+const createMapping = (typename: string, device?: DeviceMapping, fhir?: FhirMapping): Promise<Mapping> => {
+    const id = generateUID();
+    return updateMapping(id, typename, device, fhir);
+}
+
+const updateMapping = (id: string, typename: string, device?: DeviceMapping, fhir?: FhirMapping): Promise<Mapping> => {
     return new Promise((resolve, reject) => {
         if (!typename || typename.trim().length < 1) {
             reject(`The type name cannot be empty`);
@@ -70,13 +128,15 @@ const updateMapping = (id: string, typename: string): Promise<Mapping> => {
 
         const mappings = getAllMappings();
         if (_.find(mappings, { typeName: typename })) {
-            reject(`The type name ${typename} already exists`);
+            reject(`The type name "${typename}" already exists`);
             return;
         }
 
         const mapping = {
             id: id,
-            typeName: typename
+            typeName: typename,
+            device: device,
+            fhir: fhir
         } as Mapping;
         saveMappingToLocalStorage(id, mapping);
 
@@ -100,6 +160,7 @@ const generateUID = () => {
 // the backend server.
 const PersistService = {
     createMapping: createMapping,
+    createMappingsFromTemplates: createMappingsFromTemplates,
     getAllMappings: getAllMappings,
     getMapping: getMapping,
     renameMapping: updateMapping,

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/Utils.ts
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/Utils.ts
@@ -3,7 +3,80 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-import { Mapping, FhirValue } from "../store/Mapping";
+import * as _ from "lodash";
+import { DeviceMapping, DeviceValueSet, FhirCodeableConcept, FhirCoding, FhirComponent, FhirMapping, FhirValue, FhirValueType, Mapping } from "../store/Mapping";
+
+export const generateDeviceMappings = (deviceTemplates: string): Promise<Mapping[]> => {
+    return new Promise((resolve, reject) => {
+        let mappings: Mapping[] = [];
+        const errorPrefix = 'Device Mapping Template error:'
+
+        if (!deviceTemplates || deviceTemplates.trim().length < 1) {
+            resolve(mappings);
+            return;
+        }
+
+        let templates: any;
+        try {
+            templates = JSON.parse(deviceTemplates);
+        }
+        catch (err) {
+            reject(`${errorPrefix} ${err.message}.`);
+            return;
+        }
+
+        if (templates.template) {
+            for (const template of templates.template) {
+                const subTemplate = template.template;
+                if (!subTemplate) {
+                    continue;
+                }
+
+                const typename = subTemplate.typeName;
+                if (!typename || typename.trim().length < 1) {
+                    reject(`${errorPrefix} The type name cannot be empty.`);
+                    return;
+                }
+                if (_.find(mappings, { typeName: typename })) {
+                    reject(`${errorPrefix} More than one template has the typeName "${typename}".
+                        Please enter unique typeNames for these templates or remove the templates with duplicate typeNames.`);
+                    return;
+                }
+
+                let values: DeviceValueSet[] = [];
+                if (subTemplate.values) {
+                    for (const value of subTemplate.values) {
+                        values.push({
+                            valueExpression: value.valueExpression,
+                            valueName: value.valueName,
+                            required: value.required
+                        } as DeviceValueSet);
+                    }
+                }
+
+                const deviceMapping = {
+                    typeMatchExpression: subTemplate.typeMatchExpression,
+                    timestampExpression: subTemplate.timestampExpression,
+                    deviceIdExpression: subTemplate.deviceIdExpression,
+                    patientIdExpression: subTemplate.patientIdExpression,
+                    encounterIdExpression: subTemplate.encounterIdExpression,
+                    correlationIdExpression: subTemplate.correlationIdExpression,
+                    values: values
+                } as DeviceMapping;
+
+                const mapping = {
+                    typeName: typename,
+                    device: deviceMapping
+                } as Mapping;
+
+                mappings.push(mapping);
+            }
+        }
+
+        resolve(mappings);
+        return;
+    });
+}
 
 export const generateDeviceTemplate = (mappings: Mapping[]) => {
     const deviceTemplates = {
@@ -30,22 +103,158 @@ export const generateDeviceTemplate = (mappings: Mapping[]) => {
     return JSON.stringify(deviceTemplates, null, 4);
 }
 
+export const generateFhirMappings = (fhirTemplates: string): Promise<Mapping[]> => {
+    return new Promise((resolve, reject) => {
+        let mappings: Mapping[] = [];
+        const errorPrefix = 'FHIR Mapping Template error:'
+
+        if (!fhirTemplates || fhirTemplates.trim().length < 1) {
+            resolve(mappings);
+            return;
+        }
+
+        let templates: any;
+        try {
+            templates = JSON.parse(fhirTemplates);
+        }
+        catch (err) {
+            reject(`${errorPrefix} ${err.message}.`);
+            return;
+        }
+
+        if (templates.template) {
+            for (const template of templates.template) {
+                const subTemplate = template.template;
+                if (!subTemplate) {
+                    continue;
+                }
+
+                const typename = subTemplate.typeName;
+                if (!typename || typename.trim().length < 1) {
+                    reject(`${errorPrefix} The type name cannot be empty.`);
+                    return;
+                }
+                if (_.find(mappings, { typeName: typename })) {
+                    reject(`${errorPrefix} More than one template has the typeName "${typename}".
+                        Please enter unique typeNames for these templates or remove the templates with duplicate typeNames.`);
+                    return;
+                }
+
+                let categories: FhirCodeableConcept[] = [];
+                if (subTemplate.value?.valueType && subTemplate.value?.valueType == FhirValueType.CodeableConcept) {
+                    let codes: FhirCoding[] = [];
+                    if (subTemplate.value?.codes) {
+                        for (const code of subTemplate.value?.codes) {
+                            codes.push({
+                                code: code.code,
+                                display: code.display,
+                                system: code.system
+                            } as FhirCoding);
+                        }
+                    }
+
+                    categories.push({
+                        text: subTemplate.value?.text,
+                        codes: codes
+                    } as FhirCodeableConcept);
+                }
+
+                let codes: FhirCoding[] = [];
+                if (subTemplate.codes) {
+                    for (const code of subTemplate.codes) {
+                        codes.push({
+                            code: code.code,
+                            display: code.display,
+                            system: code.system
+                        } as FhirCoding);
+                    }
+                }
+
+                const value = {
+                    valueType: subTemplate.value?.valueType,
+                    valueName: subTemplate.value?.valueName,
+                    sampledData: subTemplate.value?.valueType == FhirValueType.SampledData && {
+                        defaultPeriod: subTemplate.value?.defaultPeriod,
+                        unit: subTemplate.value?.unit
+                    },
+                    quantity: subTemplate.value?.valueType == FhirValueType.Quantity && {
+                        unit: subTemplate.value?.unit,
+                        code: subTemplate.value?.code,
+                        system: subTemplate.value?.system
+                    }
+                } as FhirValue;
+
+                let components: FhirComponent[] = [];
+                if (subTemplate.components) {
+                    for (const component of subTemplate.components) {
+                        let codes: FhirCoding[] = [];
+                        if (component.codes) {
+                            for (const code of component.codes) {
+                                codes.push({
+                                    code: code.code,
+                                    display: code.display,
+                                    system: code.system
+                                } as FhirCoding);
+                            }
+                        }
+
+                        components.push({
+                            value: {
+                                valueType: component.value?.valueType,
+                                valueName: component.value?.valueName,
+                                sampledData: component.value?.valueType == FhirValueType.SampledData && {
+                                    defaultPeriod: component.value?.defaultPeriod,
+                                    unit: component.value?.unit
+                                },
+                                quantity: component.value?.valueType == FhirValueType.Quantity && {
+                                    unit: component.value?.unit,
+                                    code: component.value?.code,
+                                    system: component.value?.system
+                                }
+                            },
+                            codes: codes
+                        } as FhirComponent);
+                    }
+                }
+
+                let fhirMapping = {
+                    periodInterval: subTemplate.periodInterval,
+                    category: categories,
+                    codes: codes,
+                    value: value,
+                    components: components
+                } as FhirMapping;
+
+                const mapping = {
+                    typeName: typename,
+                    fhir: fhirMapping
+                } as Mapping;
+
+                mappings.push(mapping);
+            }
+        }
+
+        resolve(mappings);
+        return;
+    });
+}
+
 const generateFhirValueTemplate = (fhirValue: FhirValue) => {
     if (fhirValue) {
         switch (fhirValue.valueType) {
-            case "SampledData":
+            case FhirValueType.SampledData:
                 return {
                     valueName: fhirValue.valueName,
                     valueType: fhirValue.valueType,
                     ...fhirValue.sampledData
                 }
-            case "Quantity":
+            case FhirValueType.Quantity:
                 return {
                     valueName: fhirValue.valueName,
                     valueType: fhirValue.valueType,
                     ...fhirValue.quantity
                 }
-            case "String":
+            case FhirValueType.String:
             default:
                 return {
                     valueName: fhirValue.valueName,

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/store/Mapping.States.ts
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/store/Mapping.States.ts
@@ -37,6 +37,13 @@ export interface FhirValue {
     string: string;
 }
 
+export const FhirValueType = {
+    CodeableConcept: "CodeableConcept",
+    Quantity: "Quantity",
+    SampledData: "SampledData",
+    String: "String"
+}
+
 export interface FhirSampledData {
     defaultPeriod: number;
     unit: string;

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
@@ -39,6 +39,7 @@
     <None Remove="ClientApp\src\components\mapping\Detail.Forms.Tutorials.tsx" />
     <None Remove="ClientApp\src\components\mapping\Detail.Page.tsx" />
     <None Remove="ClientApp\src\components\mapping\List.Modals.Export.tsx" />
+    <None Remove="ClientApp\src\components\mapping\List.Modals.Import.tsx" />
     <None Remove="ClientApp\src\components\mapping\List.Modals.Name.tsx" />
     <None Remove="ClientApp\src\components\mapping\List.Page.tsx" />
     <None Remove="ClientApp\src\services\PersistService.ts" />
@@ -69,6 +70,7 @@
     <TypeScriptCompile Include="ClientApp\src\components\mapping\Detail.Forms.Tutorials.tsx" />
     <TypeScriptCompile Include="ClientApp\src\components\mapping\Detail.Page.tsx" />
     <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Export.tsx" />
+    <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Import.tsx" />
     <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Name.tsx" />
     <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Page.tsx" />
     <TypeScriptCompile Include="ClientApp\src\services\PersistService.ts" />

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <None Remove="ClientApp\src\components\Constants.ts" />
     <None Remove="ClientApp\src\components\Icons.tsx" />
+    <None Remove="ClientApp\src\components\JsonValidator.tsx" />
     <None Remove="ClientApp\src\components\mapping\Detail - Copy.DeviceEdit.tsx" />
     <None Remove="ClientApp\src\components\mapping\Detail.Fhir.tsx" />
     <None Remove="ClientApp\src\components\mapping\Detail.Forms.Tutorials.tsx" />
@@ -62,6 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <TypeScriptCompile Include="ClientApp\src\components\JsonValidator.tsx" />
     <TypeScriptCompile Include="ClientApp\src\components\Constants.ts" />
     <TypeScriptCompile Include="ClientApp\src\components\Icons.tsx" />
     <TypeScriptCompile Include="ClientApp\src\components\mapping\Detail.Forms.Tutorials.tsx" />


### PR DESCRIPTION
Updated the IoMT Connector Data Mapper as follows:
- Enabled importing mappings (i.e. entering mapping templates to generate mappings), as shown in the following screenshots.

  1. There is an "Import mappings" button on the home page:
    ![Button](https://user-images.githubusercontent.com/80931622/135919580-a7e3d5c6-24a4-4336-ba91-b4295c6c1f37.png)

  1. Clicking the "Import mappings" button opens a dialog, which contains text areas to enter templates and includes JSON validation of the entered templates:
    ![Dialog](https://user-images.githubusercontent.com/80931622/135919606-6273409a-3e4f-4d48-9036-2048fae93364.png)

  1. When the "Generate" button is pressed and if there are errors (e.g. empty type names, duplicate type names, invalid JSON), the entire import fails (i.e. no mappings are generated) and an error message is shown:
    ![Import fail](https://user-images.githubusercontent.com/80931622/135919707-1fcb994f-eb38-4000-a859-b1a7734da723.png)

  1. When the "Generate" button is pressed and if there are no errors, import succeeds and the dialog closes, showing the imported mappings on the home page:
    ![Import success - home page](https://user-images.githubusercontent.com/80931622/135919738-730b35cf-18c5-48c2-9d96-be04b3f8ed7f.png)

  1. Opening the imported mapping shows the properties that were in the templates:
    ![Import success - mapping page](https://user-images.githubusercontent.com/80931622/135919762-3347d495-01ef-44df-98b5-634d1ca06d60.png)

Note: During import, a FHIR Mapping and a Device Mapping are grouped into 1 Mapping if they share the same type name (provided that the type name is not empty or a duplicate). Any FHIR/Device Mapping without a corresponding Device/FHIR Mapping of the same type name is created as a Mapping, just without the corresponding `device`/`fhir` property.