### PR TITLE
Data Mapper: Fixed bug with accessing an empty list of mappings

### DIFF
--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
@@ -47,7 +47,11 @@ const getAllMappings = (): Mapping[] => {
 
 const getMapping = (mappingId: string): Mapping => {
     const storage = loadFromLocalStorage();
-    return storage.mappingsById[mappingId];
+    const mappings = storage.mappingsById;
+    if (!mappings) {
+        return {} as Mapping;
+    }
+    return mappings[mappingId];
 }
 
 const createMapping = (typename: string): Promise<Mapping> => {


### PR DESCRIPTION
As a result of my changes in pull request #131, `getMapping()` is called from `NavMenu` whenever the page loads in order to display any type name on the page top. `getMapping()` calls `loadFromLocalStorage()` to get all the mappings that are saved locally and get the desired mapping by its `mappingId`.

However, if there are no mappings saved locally (e.g. when you first run Data Mapper), then Data Mapper would not load because it is not possible to access undefined mappings and a `TypeError` would be thrown. This pull request's change fixes this bug by checking that mappings are defined before accessing them.