### PR TITLE
Using latest version of Ubuntu image

### DIFF
--- a/build/azure-pipelines-ci.yml
+++ b/build/azure-pipelines-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
 - job: Linux
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - template: build.yml
     parameters:

--- a/build/azure-pipelines-pr.yml
+++ b/build/azure-pipelines-pr.yml
@@ -13,7 +13,7 @@ jobs:
 
 - job: Linux
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - template: build.yml
     parameters:


### PR DESCRIPTION
The current build pipeline fails as it cannot find the Ubuntu image '16.04'. It appears that this image has reached end of life and has been removed. This PR bumps the Ubuntu version to the latest one available.