### PR TITLE
Customized Event Hub configuration exceptions

### DIFF
--- a/src/lib/Microsoft.Health.Common/Telemetry/IomtException.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/IomtException.cs
@@ -1,0 +1,68 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using EnsureThat;
+
+namespace Microsoft.Health.Common.Telemetry
+{
+    public class IomtException :
+        Exception,
+        ITelemetryFormattable
+    {
+        private readonly string _name;
+        private readonly string _errorType;
+        private readonly string _errorSeverity;
+        private readonly string _errorSource;
+        private readonly string _operation;
+
+        public IomtException()
+        {
+        }
+
+        public IomtException(string message)
+            : base(message)
+        {
+        }
+
+        public IomtException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public IomtException(
+            string message,
+            Exception innerException,
+            string helpLink,
+            string name,
+            string errorType,
+            string errorSeverity,
+            string errorSource,
+            string operation)
+            : base(message, innerException)
+        {
+            _name = EnsureArg.IsNotNullOrWhiteSpace(name, nameof(name));
+
+            HelpLink = helpLink;
+            _errorType = errorType;
+            _errorSeverity = errorSeverity;
+            _errorSource = errorSource;
+            _operation = operation;
+        }
+
+        public Metric ToMetric => new Metric(
+            EnsureArg.IsNotNullOrWhiteSpace(_name, nameof(_name)),
+            new Dictionary<string, object>
+            {
+                { DimensionNames.Category, Category.Errors },
+            })
+            .AddDimension(DimensionNames.Name, _name)
+            .AddDimension(DimensionNames.ErrorType, _errorType)
+            .AddDimension(DimensionNames.ErrorSeverity, _errorSeverity)
+            .AddDimension(DimensionNames.ErrorSource, _errorSource)
+            .AddDimension(DimensionNames.Operation, _operation);
+    }
+}

--- a/src/lib/Microsoft.Health.Common/Telemetry/IomtTelemetryFormattableException.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/IomtTelemetryFormattableException.cs
@@ -9,49 +9,43 @@ using EnsureThat;
 
 namespace Microsoft.Health.Common.Telemetry
 {
-    public class IomtException :
+    public class IomtTelemetryFormattableException :
         Exception,
         ITelemetryFormattable
     {
         private readonly string _name;
-        private readonly string _errorType;
-        private readonly string _errorSeverity;
-        private readonly string _errorSource;
         private readonly string _operation;
 
-        public IomtException()
+        public IomtTelemetryFormattableException()
         {
         }
 
-        public IomtException(string message)
+        public IomtTelemetryFormattableException(string message)
             : base(message)
         {
         }
 
-        public IomtException(string message, Exception innerException)
+        public IomtTelemetryFormattableException(string message, Exception innerException)
             : base(message, innerException)
         {
         }
 
-        public IomtException(
+        public IomtTelemetryFormattableException(
             string message,
             Exception innerException,
-            string helpLink,
             string name,
-            string errorType,
-            string errorSeverity,
-            string errorSource,
             string operation)
             : base(message, innerException)
         {
             _name = EnsureArg.IsNotNullOrWhiteSpace(name, nameof(name));
-
-            HelpLink = helpLink;
-            _errorType = errorType;
-            _errorSeverity = errorSeverity;
-            _errorSource = errorSource;
-            _operation = operation;
+            _operation = EnsureArg.IsNotNullOrWhiteSpace(operation, nameof(operation));
         }
+
+        public virtual string ErrType => ErrorType.GeneralError;
+
+        public virtual string ErrSeverity => ErrorSeverity.Warning;
+
+        public virtual string ErrSource => nameof(ErrorSource.Undefined);
 
         public Metric ToMetric => new Metric(
             EnsureArg.IsNotNullOrWhiteSpace(_name, nameof(_name)),
@@ -60,9 +54,9 @@ namespace Microsoft.Health.Common.Telemetry
                 { DimensionNames.Category, Category.Errors },
             })
             .AddDimension(DimensionNames.Name, _name)
-            .AddDimension(DimensionNames.ErrorType, _errorType)
-            .AddDimension(DimensionNames.ErrorSeverity, _errorSeverity)
-            .AddDimension(DimensionNames.ErrorSource, _errorSource)
-            .AddDimension(DimensionNames.Operation, _operation);
+            .AddDimension(DimensionNames.Operation, _operation)
+            .AddDimension(DimensionNames.ErrorType, ErrType)
+            .AddDimension(DimensionNames.ErrorSeverity, ErrSeverity)
+            .AddDimension(DimensionNames.ErrorSource, ErrSource);
     }
 }

--- a/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/DimensionNames.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/DimensionNames.cs
@@ -41,5 +41,10 @@ namespace Microsoft.Health.Common.Telemetry
         /// A metric dimension that represents the reason that caused the metric to be emitted.
         /// </summary>
         public static string Reason => nameof(Reason);
+
+        /// <summary>
+        /// A metric dimension to identify the error source, e.g. the user or system.
+        /// </summary>
+        public static string ErrorSource => nameof(ErrorSource);
     }
 }

--- a/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/DimensionNames.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/DimensionNames.cs
@@ -38,13 +38,13 @@ namespace Microsoft.Health.Common.Telemetry
         public static string ErrorSeverity => nameof(ErrorSeverity);
 
         /// <summary>
+        /// A metric dimension to identify the error source, e.g. the user or service.
+        /// </summary>
+        public static string ErrorSource => nameof(ErrorSource);
+
+        /// <summary>
         /// A metric dimension that represents the reason that caused the metric to be emitted.
         /// </summary>
         public static string Reason => nameof(Reason);
-
-        /// <summary>
-        /// A metric dimension to identify the error source, e.g. the user or system.
-        /// </summary>
-        public static string ErrorSource => nameof(ErrorSource);
     }
 }

--- a/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/ErrorSource.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/ErrorSource.cs
@@ -16,5 +16,10 @@ namespace Microsoft.Health.Common.Telemetry
         /// A user error.
         /// </summary>
         User,
+
+        /// <summary>
+        /// An error with an undefined source.
+        /// </summary>
+        Undefined,
     }
 }

--- a/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/ErrorSource.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/ErrorSource.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Health.Common.Telemetry
     public enum ErrorSource
     {
         /// <summary>
+        /// An error with an undefined source.
+        /// </summary>
+        Undefined,
+
+        /// <summary>
         /// A service error.
         /// </summary>
         Service,
@@ -16,10 +21,5 @@ namespace Microsoft.Health.Common.Telemetry
         /// A user error.
         /// </summary>
         User,
-
-        /// <summary>
-        /// An error with an undefined source.
-        /// </summary>
-        Undefined,
     }
 }

--- a/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/ErrorSource.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/ErrorSource.cs
@@ -1,0 +1,20 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Common.Telemetry
+{
+    public static class ErrorSource
+    {
+        /// <summary>
+        /// A system error.
+        /// </summary>
+        public static string System => nameof(System);
+
+        /// <summary>
+        /// A user error.
+        /// </summary>
+        public static string User => nameof(User);
+    }
+}

--- a/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/ErrorSource.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/ErrorSource.cs
@@ -5,16 +5,16 @@
 
 namespace Microsoft.Health.Common.Telemetry
 {
-    public static class ErrorSource
+    public enum ErrorSource
     {
         /// <summary>
-        /// A system error.
+        /// A service error.
         /// </summary>
-        public static string System => nameof(System);
+        Service,
 
         /// <summary>
         /// A user error.
         /// </summary>
-        public static string User => nameof(User);
+        User,
     }
 }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubConfigurationExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubConfigurationExceptionTelemetryProcessor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
 {
     public class EventHubConfigurationExceptionTelemetryProcessor
     {
-        private readonly HashSet<Type> _handledExceptions;
+        private readonly ISet<Type> _handledExceptions;
 
         public EventHubConfigurationExceptionTelemetryProcessor()
             : this(

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubConfigurationExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubConfigurationExceptionTelemetryProcessor.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
         {
             EnsureArg.IsNotNull(ex, nameof(ex));
             EnsureArg.IsNotNull(logger, nameof(logger));
+            EnsureArg.IsNotNullOrWhiteSpace(connectorStage, nameof(connectorStage));
 
             var exType = ex.GetType();
 

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubConfigurationExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubConfigurationExceptionTelemetryProcessor.cs
@@ -1,0 +1,63 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using EnsureThat;
+using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Logging.Telemetry;
+
+namespace Microsoft.Health.Events.Telemetry.Exceptions
+{
+    public class EventHubConfigurationExceptionTelemetryProcessor
+    {
+        private readonly HashSet<Type> _handledExceptions;
+
+        public EventHubConfigurationExceptionTelemetryProcessor()
+            : this(
+                typeof(InvalidEventHubException),
+                typeof(UnauthorizedAccessEventHubException))
+        {
+        }
+
+        public EventHubConfigurationExceptionTelemetryProcessor(params Type[] handledExceptionTypes)
+        {
+            _handledExceptions = new HashSet<Type>(handledExceptionTypes);
+        }
+
+        public bool HandleException(Exception ex, ITelemetryLogger logger, string connectorStage)
+        {
+            EnsureArg.IsNotNull(ex, nameof(ex));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+
+            var exType = ex.GetType();
+
+            var lookupType = exType.IsGenericType ? exType.GetGenericTypeDefinition() : exType;
+
+            if (_handledExceptions.Contains(lookupType))
+            {
+                if (ex is ITelemetryFormattable tel)
+                {
+                    logger.LogMetric(
+                        metric: tel.ToMetric,
+                        metricValue: 1);
+                }
+                else
+                {
+                    var metric = EventMetrics.HandledException(
+                        exType.Name,
+                        connectorStage);
+                    logger.LogMetric(
+                        metric: metric,
+                        metricValue: 1);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubErrorCode.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubErrorCode.cs
@@ -8,19 +8,19 @@ namespace Microsoft.Health.Events.Telemetry
     public enum EventHubErrorCode
     {
         /// <summary>
-        /// Error code that categorizes exceptions of the type EventHubsException
+        /// Error code for an issue relating to an Event Hub (e.g. invalid name or consumer group)
         /// </summary>
-        OperationError,
+        InstanceError,
+
+        /// <summary>
+        /// Error code for an issue relating to an Event Hubs Namespace (e.g. invalid FQDN)
+        /// </summary>
+        NamespaceError,
 
         /// <summary>
         /// Error code that indicates failures in initializing event hub partition
         /// </summary>
         EventHubPartitionInitFailed,
-
-        /// <summary>
-        /// Error code that categorizes exceptions of the type SocketException
-        /// </summary>
-        SocketError,
 
         /// <summary>
         /// Error code that categorizes authentication errors (eg: exceptions of the type UnauthorizedAccessException)

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubErrorCode.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubErrorCode.cs
@@ -8,19 +8,14 @@ namespace Microsoft.Health.Events.Telemetry
     public enum EventHubErrorCode
     {
         /// <summary>
-        /// Error code for an issue relating to an Event Hub (e.g. invalid name or consumer group)
-        /// </summary>
-        InstanceError,
-
-        /// <summary>
-        /// Error code for an issue relating to an Event Hubs Namespace (e.g. invalid FQDN)
-        /// </summary>
-        NamespaceError,
-
-        /// <summary>
         /// Error code that indicates failures in initializing event hub partition
         /// </summary>
         EventHubPartitionInitFailed,
+
+        /// <summary>
+        /// Error code that categorizes invalid configurations (e.g. invalid namespace/FQDN, event hub name, or consumer group)
+        /// </summary>
+        ConfigurationError,
 
         /// <summary>
         /// Error code that categorizes authentication errors (eg: exceptions of the type UnauthorizedAccessException)

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionTelemetryProcessor.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
         public static Exception CustomizeException(Exception exception)
         {
             string message = exception.Message;
-            string helpLink = exception.HelpLink;
 
             switch (exception)
             {
@@ -66,11 +65,11 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
                             return exception;
                     }
 
-                    return new InvalidEventHubException(message, exception, helpLink, EventHubErrorCode.ConfigurationError.ToString());
+                    return new InvalidEventHubException(message, exception, EventHubErrorCode.ConfigurationError.ToString());
 
                 case InvalidOperationException _:
                     message = "Verify that the provided Event Hub contains the provided consumer group.";
-                    return new InvalidEventHubException(message, exception, helpLink, EventHubErrorCode.ConfigurationError.ToString());
+                    return new InvalidEventHubException(message, exception, EventHubErrorCode.ConfigurationError.ToString());
 
                 case SocketException _:
                     SocketException socketException = (SocketException)exception;
@@ -78,14 +77,14 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
                     {
                         case SocketError.HostNotFound:
                             message = "Verify that the provided Event Hubs Namespace exists.";
-                            return new InvalidEventHubException(message, exception, helpLink, EventHubErrorCode.ConfigurationError.ToString());
+                            return new InvalidEventHubException(message, exception, EventHubErrorCode.ConfigurationError.ToString());
                         default:
                             return exception;
                     }
 
                 case UnauthorizedAccessException _:
                     message = "Verify that the provided Event Hub's 'Azure Event Hubs Data Receiver' role has been assigned to the applicable Azure Active Directory security principal or managed identity.";
-                    helpLink = "https://docs.microsoft.com/azure/event-hubs/authenticate-application";
+                    string helpLink = "https://docs.microsoft.com/azure/event-hubs/authenticate-application";
                     return new UnauthorizedAccessEventHubException(message, exception, helpLink, EventHubErrorCode.AuthorizationError.ToString());
 
                 default:

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionTelemetryProcessor.cs
@@ -54,9 +54,6 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
                     var reason = ((EventHubsException)exception).Reason;
                     switch (reason)
                     {
-                        case EventHubsException.FailureReason.ConsumerDisconnected:
-                            message = "Verify that the provided Event Hub's consumer group is not already receiving data for another IoT connector or Azure resource.";
-                            break;
                         case EventHubsException.FailureReason.ResourceNotFound:
                             message = "Verify that the provided Event Hubs Namespace contains the provided Event Hub and that the provided Event Hub contains the provided consumer group.";
                             break;

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionTelemetryProcessor.cs
@@ -23,26 +23,69 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
             EnsureArg.IsNotNull(exception, nameof(exception));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
-            logger.LogError(exception);
+            var ex = CustomizeException(exception);
+
+            logger.LogError(ex);
 
             if (shouldLogMetric)
             {
-                logger.LogMetric(EventMetrics.HandledException(errorMetricName ?? GetErrorMetricName(exception), ConnectorOperation.Setup), 1);
+                if (ex.Equals(exception))
+                {
+                    logger.LogMetric(
+                        EventMetrics.HandledException(
+                            errorMetricName ?? $"{ErrorType.EventHubError}{EventHubErrorCode.GeneralError}",
+                            ConnectorOperation.Setup),
+                        1);
+                }
+                else
+                {
+                    var processor = new EventHubConfigurationExceptionTelemetryProcessor();
+                    processor.HandleException(ex, logger, ConnectorOperation.Setup);
+                }
             }
         }
 
-        private static string GetErrorMetricName(Exception exception)
+        public static Exception CustomizeException(Exception exception)
         {
+            string message = exception.Message;
+            string helpLink = exception.HelpLink;
+
             switch (exception)
             {
                 case EventHubsException _:
-                    return $"{ErrorType.EventHubError}{EventHubErrorCode.OperationError}";
+                    EventHubsException eventHubsException = (EventHubsException)exception;
+                    switch (eventHubsException.Reason)
+                    {
+                        case EventHubsException.FailureReason.ConsumerDisconnected:
+                            message = "Verify that the provided Event Hub is not already receiving data for another IoT connector or Azure resource.";
+                            break;
+                        case EventHubsException.FailureReason.ResourceNotFound:
+                            message = "Verify that the provided Event Hubs Namespace contains the provided Event Hub and that the provided Event Hub contains the provided consumer group.";
+                            break;
+                        case EventHubsException.FailureReason.ServiceCommunicationProblem:
+                            message = "Verify that the provided Event Hub Namespace, Event Hub name, and consumer group are correct and that access permissions to the provided Event Hub have been granted.";
+                            break;
+                        default:
+                            return exception;
+                    }
+
+                    return new InvalidEventHubException(message, exception, helpLink, EventHubErrorCode.InstanceError.ToString());
+
+                case InvalidOperationException _:
+                    message = "Verify that the provided Event Hub contains the provided consumer group.";
+                    return new InvalidEventHubException(message, exception, helpLink, EventHubErrorCode.InstanceError.ToString());
+
                 case SocketException _:
-                    return $"{ErrorType.EventHubError}{EventHubErrorCode.SocketError}";
+                    message = "Verify that the provided Event Hubs Namespace exists.";
+                    return new InvalidEventHubException(message, exception, helpLink, EventHubErrorCode.NamespaceError.ToString());
+
                 case UnauthorizedAccessException _:
-                    return $"{ErrorType.EventHubError}{EventHubErrorCode.AuthorizationError}";
+                    message = "Verify that the provided Event Hub's 'Azure Event Hubs Data Receiver' role has been assigned to the applicable Azure Active Directory security principal or managed identity.";
+                    helpLink = "https://docs.microsoft.com/azure/event-hubs/authenticate-application";
+                    return new UnauthorizedAccessEventHubException(message, exception, helpLink, EventHubErrorCode.AuthorizationError.ToString());
+
                 default:
-                    return $"{ErrorType.EventHubError}{EventHubErrorCode.GeneralError}";
+                    return exception;
             }
         }
     }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
 {
     public sealed class InvalidEventHubException : IomtTelemetryFormattableException
     {
+        private static readonly string _errorType = ErrorType.EventHubError;
+
         public InvalidEventHubException(
             string message,
             Exception innerException,
@@ -17,12 +19,12 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
             : base(
                   message,
                   innerException,
-                  name: $"{ErrorType.EventHubError}{errorName}",
+                  name: $"{_errorType}{errorName}",
                   operation: ConnectorOperation.Setup)
         {
         }
 
-        public override string ErrType => ErrorType.EventHubError;
+        public override string ErrType => _errorType;
 
         public override string ErrSource => nameof(ErrorSource.User);
     }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
@@ -1,0 +1,54 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using EnsureThat;
+using Microsoft.Health.Common.Telemetry;
+
+namespace Microsoft.Health.Events.Telemetry.Exceptions
+{
+    public class InvalidEventHubException :
+        Exception,
+        ITelemetryFormattable
+    {
+        private readonly string _metricName;
+
+        public InvalidEventHubException()
+        {
+        }
+
+        public InvalidEventHubException(string message)
+            : base(message)
+        {
+        }
+
+        public InvalidEventHubException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public InvalidEventHubException(string message, Exception innerException, string helpLink, string errorName)
+            : base(message, innerException)
+        {
+            EnsureArg.IsNotNullOrWhiteSpace(errorName, nameof(errorName));
+
+            HelpLink = helpLink;
+            _metricName = $"{ErrorType.EventHubError}{errorName}";
+        }
+
+        public Metric ToMetric => new Metric(
+            _metricName,
+            new Dictionary<string, object>
+            {
+                { DimensionNames.Name, _metricName },
+                { DimensionNames.Category, Category.Errors },
+                { DimensionNames.ErrorType, ErrorType.EventHubError },
+                { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
+                { DimensionNames.ErrorSource, ErrorSource.User },
+                { DimensionNames.Operation, ConnectorOperation.Setup },
+            });
+    }
+}

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
@@ -4,51 +4,27 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using EnsureThat;
 using Microsoft.Health.Common.Telemetry;
 
 namespace Microsoft.Health.Events.Telemetry.Exceptions
 {
-    public class InvalidEventHubException :
-        Exception,
-        ITelemetryFormattable
+    public sealed class InvalidEventHubException : IomtException
     {
-        private readonly string _metricName;
-
-        public InvalidEventHubException()
+        public InvalidEventHubException(
+            string message,
+            Exception innerException,
+            string helpLink,
+            string errorName)
+            : base(
+                  message,
+                  innerException,
+                  helpLink,
+                  name: $"{ErrorType.EventHubError}{errorName}",
+                  errorType: ErrorType.EventHubError,
+                  errorSeverity: ErrorSeverity.Warning,
+                  errorSource: nameof(ErrorSource.User),
+                  operation: ConnectorOperation.Setup)
         {
         }
-
-        public InvalidEventHubException(string message)
-            : base(message)
-        {
-        }
-
-        public InvalidEventHubException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        public InvalidEventHubException(string message, Exception innerException, string helpLink, string errorName)
-            : base(message, innerException)
-        {
-            EnsureArg.IsNotNullOrWhiteSpace(errorName, nameof(errorName));
-
-            HelpLink = helpLink;
-            _metricName = $"{ErrorType.EventHubError}{errorName}";
-        }
-
-        public Metric ToMetric => new Metric(
-            _metricName,
-            new Dictionary<string, object>
-            {
-                { DimensionNames.Name, _metricName },
-                { DimensionNames.Category, Category.Errors },
-                { DimensionNames.ErrorType, ErrorType.EventHubError },
-                { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
-                { DimensionNames.ErrorSource, ErrorSource.User },
-                { DimensionNames.Operation, ConnectorOperation.Setup },
-            });
     }
 }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
@@ -8,23 +8,22 @@ using Microsoft.Health.Common.Telemetry;
 
 namespace Microsoft.Health.Events.Telemetry.Exceptions
 {
-    public sealed class InvalidEventHubException : IomtException
+    public sealed class InvalidEventHubException : IomtTelemetryFormattableException
     {
         public InvalidEventHubException(
             string message,
             Exception innerException,
-            string helpLink,
             string errorName)
             : base(
                   message,
                   innerException,
-                  helpLink,
                   name: $"{ErrorType.EventHubError}{errorName}",
-                  errorType: ErrorType.EventHubError,
-                  errorSeverity: ErrorSeverity.Warning,
-                  errorSource: nameof(ErrorSource.User),
                   operation: ConnectorOperation.Setup)
         {
         }
+
+        public override string ErrType => ErrorType.EventHubError;
+
+        public override string ErrSource => nameof(ErrorSource.User);
     }
 }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
@@ -8,7 +8,7 @@ using Microsoft.Health.Common.Telemetry;
 
 namespace Microsoft.Health.Events.Telemetry.Exceptions
 {
-    public sealed class UnauthorizedAccessEventHubException : IomtException
+    public sealed class UnauthorizedAccessEventHubException : IomtTelemetryFormattableException
     {
         public UnauthorizedAccessEventHubException(
             string message,
@@ -18,13 +18,14 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
             : base(
                   message,
                   innerException,
-                  helpLink,
                   name: $"{ErrorType.EventHubError}{errorName}",
-                  errorType: ErrorType.EventHubError,
-                  errorSeverity: ErrorSeverity.Warning,
-                  errorSource: nameof(ErrorSource.User),
                   operation: ConnectorOperation.Setup)
         {
+            HelpLink = helpLink;
         }
+
+        public override string ErrType => ErrorType.EventHubError;
+
+        public override string ErrSource => nameof(ErrorSource.User);
     }
 }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
@@ -1,0 +1,54 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using EnsureThat;
+using Microsoft.Health.Common.Telemetry;
+
+namespace Microsoft.Health.Events.Telemetry.Exceptions
+{
+    public class UnauthorizedAccessEventHubException :
+        Exception,
+        ITelemetryFormattable
+    {
+        private readonly string _metricName;
+
+        public UnauthorizedAccessEventHubException()
+        {
+        }
+
+        public UnauthorizedAccessEventHubException(string message)
+            : base(message)
+        {
+        }
+
+        public UnauthorizedAccessEventHubException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public UnauthorizedAccessEventHubException(string message, Exception innerException, string helpLink, string errorName)
+            : base(message, innerException)
+        {
+            EnsureArg.IsNotNullOrWhiteSpace(errorName, nameof(errorName));
+
+            HelpLink = helpLink;
+            _metricName = $"{ErrorType.EventHubError}{errorName}";
+        }
+
+        public Metric ToMetric => new Metric(
+            _metricName,
+            new Dictionary<string, object>
+            {
+                { DimensionNames.Name, _metricName },
+                { DimensionNames.Category, Category.Errors },
+                { DimensionNames.ErrorType, ErrorType.EventHubError },
+                { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
+                { DimensionNames.ErrorSource, ErrorSource.User },
+                { DimensionNames.Operation, ConnectorOperation.Setup },
+            });
+    }
+}

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
@@ -4,51 +4,27 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using EnsureThat;
 using Microsoft.Health.Common.Telemetry;
 
 namespace Microsoft.Health.Events.Telemetry.Exceptions
 {
-    public class UnauthorizedAccessEventHubException :
-        Exception,
-        ITelemetryFormattable
+    public sealed class UnauthorizedAccessEventHubException : IomtException
     {
-        private readonly string _metricName;
-
-        public UnauthorizedAccessEventHubException()
+        public UnauthorizedAccessEventHubException(
+            string message,
+            Exception innerException,
+            string helpLink,
+            string errorName)
+            : base(
+                  message,
+                  innerException,
+                  helpLink,
+                  name: $"{ErrorType.EventHubError}{errorName}",
+                  errorType: ErrorType.EventHubError,
+                  errorSeverity: ErrorSeverity.Warning,
+                  errorSource: nameof(ErrorSource.User),
+                  operation: ConnectorOperation.Setup)
         {
         }
-
-        public UnauthorizedAccessEventHubException(string message)
-            : base(message)
-        {
-        }
-
-        public UnauthorizedAccessEventHubException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        public UnauthorizedAccessEventHubException(string message, Exception innerException, string helpLink, string errorName)
-            : base(message, innerException)
-        {
-            EnsureArg.IsNotNullOrWhiteSpace(errorName, nameof(errorName));
-
-            HelpLink = helpLink;
-            _metricName = $"{ErrorType.EventHubError}{errorName}";
-        }
-
-        public Metric ToMetric => new Metric(
-            _metricName,
-            new Dictionary<string, object>
-            {
-                { DimensionNames.Name, _metricName },
-                { DimensionNames.Category, Category.Errors },
-                { DimensionNames.ErrorType, ErrorType.EventHubError },
-                { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
-                { DimensionNames.ErrorSource, ErrorSource.User },
-                { DimensionNames.Operation, ConnectorOperation.Setup },
-            });
     }
 }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
 {
     public sealed class UnauthorizedAccessEventHubException : IomtTelemetryFormattableException
     {
+        private static readonly string _errorType = ErrorType.EventHubError;
+
         public UnauthorizedAccessEventHubException(
             string message,
             Exception innerException,
@@ -18,13 +20,13 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
             : base(
                   message,
                   innerException,
-                  name: $"{ErrorType.EventHubError}{errorName}",
+                  name: $"{_errorType}{errorName}",
                   operation: ConnectorOperation.Setup)
         {
             HelpLink = helpLink;
         }
 
-        public override string ErrType => ErrorType.EventHubError;
+        public override string ErrType => _errorType;
 
         public override string ErrSource => nameof(ErrorSource.User);
     }

--- a/test/Microsoft.Health.Events.UnitTest/EventHubConfigurationExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventHubConfigurationExceptionTelemetryProcessorTests.cs
@@ -1,0 +1,46 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Events.Telemetry.Exceptions;
+using Microsoft.Health.Logging.Telemetry;
+using NSubstitute;
+using System;
+using Xunit;
+
+namespace Microsoft.Health.Events.UnitTest
+{
+    public class EventHubConfigurationExceptionTelemetryProcessorTests
+    {
+        [Theory]
+        [InlineData(typeof(InvalidEventHubException))]
+        [InlineData(typeof(UnauthorizedAccessEventHubException))]
+        public void GivenHandledExceptionType_WhenHandleExpection_ThenMetricLoggedAndTrueReturned_Test(Type exType)
+        {
+            var logger = Substitute.For<ITelemetryLogger>();
+            var ex = Activator.CreateInstance(exType) as Exception;
+
+            var processor = new EventHubConfigurationExceptionTelemetryProcessor();
+            var handled = processor.HandleException(ex, logger, ConnectorOperation.Setup);
+            Assert.True(handled);
+
+            logger.ReceivedWithAnyArgs(1).LogMetric(null, default(double));
+        }
+
+        [Theory]
+        [InlineData(typeof(Exception))]
+        public void GivenUnhandledExceptionType_WhenHandleExpection_ThenNoMetricLoggedAndFalseReturned_Test(Type exType)
+        {
+            var logger = Substitute.For<ITelemetryLogger>();
+            var ex = Activator.CreateInstance(exType) as Exception;
+
+            var processor = new EventHubConfigurationExceptionTelemetryProcessor();
+            var handled = processor.HandleException(ex, logger, ConnectorOperation.Setup);
+            Assert.False(handled);
+
+            logger.DidNotReceiveWithAnyArgs().LogMetric(null, default(double));
+        }
+    }
+}

--- a/test/Microsoft.Health.Events.UnitTest/EventHubConfigurationExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventHubConfigurationExceptionTelemetryProcessorTests.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Health.Events.UnitTest
         public void GivenHandledExceptionType_WhenHandleExpection_ThenMetricLoggedAndTrueReturned_Test(Type exType)
         {
             var logger = Substitute.For<ITelemetryLogger>();
-            var ex = Activator.CreateInstance(exType) as Exception;
+            var testEx = Substitute.For<Exception>();
+            var ex = Activator.CreateInstance(exType, new object[] { "test", testEx, "test", "test" }) as Exception;
 
             var processor = new EventHubConfigurationExceptionTelemetryProcessor();
             var handled = processor.HandleException(ex, logger, ConnectorOperation.Setup);

--- a/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Health.Events.UnitTest
         [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ConsumerDisconnected }, "EventHubErrorConfigurationError")]
         [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ResourceNotFound }, "EventHubErrorConfigurationError")]
         [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ServiceCommunicationProblem }, "EventHubErrorConfigurationError")]
-        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.GeneralError }, "EventHubErrorGeneralError")]
+        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ClientClosed }, "EventHubErrorClientClosed")]
         [InlineData(typeof(InvalidOperationException), null, "EventHubErrorConfigurationError")]
         [InlineData(typeof(SocketException), new object[] { SocketError.HostNotFound }, "EventHubErrorConfigurationError")]
-        [InlineData(typeof(SocketException), new object[] { SocketError.SocketError }, "EventHubErrorGeneralError")]
+        [InlineData(typeof(SocketException), new object[] { SocketError.SocketError }, "EventHubErrorSocketError")]
         [InlineData(typeof(UnauthorizedAccessException), null, "EventHubErrorAuthorizationError")]
         [InlineData(typeof(Exception), null, "EventHubErrorGeneralError")]
         public void GivenExceptionType_WhenProcessExpection_ThenExceptionLoggedAndEventHubErrorMetricLogged_Test(Type exType, object[] param, string expectedErrorMetricName)

--- a/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Events.UnitTest
         [InlineData(typeof(SocketException), new object[] { SocketError.SocketError }, "EventHubErrorGeneralError")]
         [InlineData(typeof(UnauthorizedAccessException), null, "EventHubErrorAuthorizationError")]
         [InlineData(typeof(Exception), null, "EventHubErrorGeneralError")]
-        public void GivenExceptionTypes_WhenProcessExpection_ThenExceptionLoggedAndEventHubErrorMetricLogged_Test(Type exType, object[] param, string expectedErrorMetricName)
+        public void GivenExceptionType_WhenProcessExpection_ThenExceptionLoggedAndEventHubErrorMetricLogged_Test(Type exType, object[] param, string expectedErrorMetricName)
         {
             var logger = Substitute.For<ITelemetryLogger>();
             Exception ex = Activator.CreateInstance(exType, param) as Exception;
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Events.UnitTest
 
         [Theory]
         [InlineData(typeof(Exception))]
-        public void GivenExceptionAndErrorMetricName_WhenProcessExpection_ThenExceptionLoggedAndErrorMetricNameLogged_Test(System.Type exType)
+        public void GivenExceptionTypeAndErrorMetricName_WhenProcessExpection_ThenExceptionLoggedAndErrorMetricNameLogged_Test(Type exType)
         {
             var logger = Substitute.For<ITelemetryLogger>();
             var ex = Activator.CreateInstance(exType) as Exception;

--- a/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Health.Events.UnitTest
         {
             var ex = Activator.CreateInstance(exType, param) as Exception;
 
-            var customEx = EventHubExceptionTelemetryProcessor.CustomizeException(ex);
+            var (customEx, errName) = EventHubExceptionTelemetryProcessor.CustomizeException(ex);
 
             Assert.IsType(customExType, customEx);
         }

--- a/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Health.Events.UnitTest
     public class EventHubExceptionTelemetryProcessorTests
     {
         [Theory]
-        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ConsumerDisconnected }, "EventHubErrorConfigurationError")]
         [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ResourceNotFound }, "EventHubErrorConfigurationError")]
         [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ServiceCommunicationProblem }, "EventHubErrorConfigurationError")]
         [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ClientClosed }, "EventHubErrorClientClosed")]
@@ -58,7 +57,6 @@ namespace Microsoft.Health.Events.UnitTest
         }
 
         [Theory]
-        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ConsumerDisconnected }, typeof(InvalidEventHubException))]
         [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ResourceNotFound }, typeof(InvalidEventHubException))]
         [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ServiceCommunicationProblem }, typeof(InvalidEventHubException))]
         [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.GeneralError }, typeof(EventHubsException))]

--- a/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventHubExceptionTelemetryProcessorTests.cs
@@ -1,4 +1,9 @@
-﻿using Azure.Messaging.EventHubs;
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Azure.Messaging.EventHubs;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Events.Telemetry;
 using Microsoft.Health.Events.Telemetry.Exceptions;
@@ -13,8 +18,12 @@ namespace Microsoft.Health.Events.UnitTest
     public class EventHubExceptionTelemetryProcessorTests
     {
         [Theory]
-        [InlineData(typeof(EventHubsException), new object [] { false, "test" }, "EventHubErrorOperationError")]
-        [InlineData(typeof(SocketException), null, "EventHubErrorSocketError")]
+        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ConsumerDisconnected }, "EventHubErrorInstanceError")]
+        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ResourceNotFound }, "EventHubErrorInstanceError")]
+        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ServiceCommunicationProblem }, "EventHubErrorInstanceError")]
+        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.GeneralError }, "EventHubErrorGeneralError")]
+        [InlineData(typeof(InvalidOperationException), null, "EventHubErrorInstanceError")]
+        [InlineData(typeof(SocketException), null, "EventHubErrorNamespaceError")]
         [InlineData(typeof(UnauthorizedAccessException), null, "EventHubErrorAuthorizationError")]
         [InlineData(typeof(Exception), null, "EventHubErrorGeneralError")]
         public void GivenExceptionTypes_WhenProcessExpection_ThenExceptionLoggedAndEventHubErrorMetricLogged_Test(Type exType, object[] param, string expectedErrorMetricName)
@@ -24,7 +33,7 @@ namespace Microsoft.Health.Events.UnitTest
 
             EventHubExceptionTelemetryProcessor.ProcessException(ex, logger);
 
-            logger.Received(1).LogError(ex);
+            logger.ReceivedWithAnyArgs(1).LogError(ex);
             logger.Received(1).LogMetric(Arg.Is<Metric>(m =>
                 m.Name.Equals(expectedErrorMetricName) &&
                 ValidateEventHubErrorMetricProperties(m)),
@@ -33,14 +42,14 @@ namespace Microsoft.Health.Events.UnitTest
 
         [Theory]
         [InlineData(typeof(SocketException))]
-        public void GivenExceptionAndShouldNotLogMetric_WhenProcessExpection_ThenExceptionLoggedAndEventHubErrorMetricNotLogged_Test(System.Type exType)
+        public void GivenExceptionAndShouldNotLogMetric_WhenProcessExpection_ThenExceptionLoggedAndEventHubErrorMetricNotLogged_Test(Type exType)
         {
             var logger = Substitute.For<ITelemetryLogger>();
             var ex = Activator.CreateInstance(exType) as Exception;
 
             EventHubExceptionTelemetryProcessor.ProcessException(ex, logger, shouldLogMetric: false);
 
-            logger.Received(1).LogError(ex);
+            logger.ReceivedWithAnyArgs(1).LogError(ex);
             logger.DidNotReceiveWithAnyArgs().LogMetric(null, default);
         }
 
@@ -58,6 +67,24 @@ namespace Microsoft.Health.Events.UnitTest
                 m.Name.Equals(EventHubErrorCode.EventHubPartitionInitFailed.ToString()) &&
                 ValidateEventHubErrorMetricProperties(m)),
                 1);
+        }
+
+        [Theory]
+        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ConsumerDisconnected }, typeof(InvalidEventHubException))]
+        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ResourceNotFound }, typeof(InvalidEventHubException))]
+        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.ServiceCommunicationProblem }, typeof(InvalidEventHubException))]
+        [InlineData(typeof(EventHubsException), new object[] { false, "test", EventHubsException.FailureReason.GeneralError }, typeof(EventHubsException))]
+        [InlineData(typeof(InvalidOperationException), null, typeof(InvalidEventHubException))]
+        [InlineData(typeof(SocketException), null, typeof(InvalidEventHubException))]
+        [InlineData(typeof(UnauthorizedAccessException), null, typeof(UnauthorizedAccessEventHubException))]
+        [InlineData(typeof(Exception), null, typeof(Exception))]
+        public void GivenExceptionType_WhenCustomizeException_ThenCustomExceptionTypeReturned_Test(Type exType, object[] param, Type customExType)
+        {
+            var ex = Activator.CreateInstance(exType, param) as Exception;
+
+            var customEx = EventHubExceptionTelemetryProcessor.CustomizeException(ex);
+
+            Assert.IsType(customExType, customEx);
         }
 
         private bool ValidateEventHubErrorMetricProperties(Metric metric)


### PR DESCRIPTION
Added custom exceptions for the following scenarios:
- Event Hub not configured (e.g. Namespace/FQDN, name, or consumer group is incorrect)
- Event Hub access not authorized (e.g. Azure Event Hubs Data Receiver role is missing)