### PR TITLE
refactor: Consolidate creation of error metric 

### DIFF
--- a/src/console/MeasurementCollectionToFhir/Processor.cs
+++ b/src/console/MeasurementCollectionToFhir/Processor.cs
@@ -71,17 +71,8 @@ namespace Microsoft.Health.Fhir.Ingest.Console.MeasurementCollectionToFhir
         private static void TrackExceptionMetric(Exception exception, ITelemetryLogger logger)
         {
             var type = exception.GetType().ToString();
-            var ToMetric = new Metric(
-                type,
-                new Dictionary<string, object>
-                {
-                    { DimensionNames.Name, type },
-                    { DimensionNames.Category, Category.Errors },
-                    { DimensionNames.ErrorType, ErrorType.GeneralError },
-                    { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
-                    { DimensionNames.Operation, ConnectorOperation.FHIRConversion},
-                });
-            logger.LogMetric(ToMetric, 1);
+            var metric = type.ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.GeneralError, ErrorSeverity.Warning);
+            logger.LogMetric(metric, 1);
         }
     }
 }

--- a/src/console/Normalize/Processor.cs
+++ b/src/console/Normalize/Processor.cs
@@ -25,7 +25,6 @@ using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Logging.Telemetry;
 using Polly;
 using static Microsoft.Azure.EventHubs.EventData;
-using AzureMessagingEventHubs = Azure.Messaging.EventHubs;
 
 namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
 {
@@ -125,17 +124,8 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
         private static void TrackExceptionMetric(Exception exception, ITelemetryLogger logger)
         {
             var type = exception.GetType().ToString();
-            var ToMetric = new Metric(
-                type,
-                new Dictionary<string, object>
-                {
-                    { DimensionNames.Name, type },
-                    { DimensionNames.Category, Category.Errors },
-                    { DimensionNames.ErrorType, ErrorType.DeviceMessageError },
-                    { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
-                    { DimensionNames.Operation, ConnectorOperation.Normalization},
-                });
-            logger.LogMetric(ToMetric, 1);
+            var metric = type.ToErrorMetric(ConnectorOperation.Normalization, ErrorType.DeviceMessageError, ErrorSeverity.Warning);
+            logger.LogMetric(metric, 1);
         }
     }
 }

--- a/src/lib/Microsoft.Health.Common/Telemetry/Exceptions/IomtTelemetryFormattableException.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/Exceptions/IomtTelemetryFormattableException.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using EnsureThat;
 
 namespace Microsoft.Health.Common.Telemetry
@@ -47,16 +46,6 @@ namespace Microsoft.Health.Common.Telemetry
 
         public virtual string ErrSource => nameof(ErrorSource.Undefined);
 
-        public Metric ToMetric => new Metric(
-            EnsureArg.IsNotNullOrWhiteSpace(_name, nameof(_name)),
-            new Dictionary<string, object>
-            {
-                { DimensionNames.Category, Category.Errors },
-            })
-            .AddDimension(DimensionNames.Name, _name)
-            .AddDimension(DimensionNames.Operation, _operation)
-            .AddDimension(DimensionNames.ErrorType, ErrType)
-            .AddDimension(DimensionNames.ErrorSeverity, ErrSeverity)
-            .AddDimension(DimensionNames.ErrorSource, ErrSource);
+        public Metric ToMetric => _name.ToErrorMetric(_operation, ErrType, ErrSeverity, ErrSource);
     }
 }

--- a/src/lib/Microsoft.Health.Common/Telemetry/Exceptions/IomtTelemetryFormattableException.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/Exceptions/IomtTelemetryFormattableException.cs
@@ -6,14 +6,14 @@
 using System;
 using EnsureThat;
 
-namespace Microsoft.Health.Common.Telemetry
+namespace Microsoft.Health.Common.Telemetry.Exceptions
 {
     public class IomtTelemetryFormattableException :
         Exception,
         ITelemetryFormattable
     {
         private readonly string _name;
-        private readonly string _operation;
+        private readonly string _operation = ConnectorOperation.Unknown;
 
         public IomtTelemetryFormattableException()
         {
@@ -46,6 +46,10 @@ namespace Microsoft.Health.Common.Telemetry
 
         public virtual string ErrSource => nameof(ErrorSource.Undefined);
 
-        public Metric ToMetric => _name.ToErrorMetric(_operation, ErrType, ErrSeverity, ErrSource);
+        public virtual string ErrName => _name;
+
+        public virtual string Operation => _operation;
+
+        public Metric ToMetric => ErrName.ToErrorMetric(Operation, ErrType, ErrSeverity, ErrSource);
     }
 }

--- a/src/lib/Microsoft.Health.Common/Telemetry/MetricExtension.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/MetricExtension.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Health.Common.Telemetry
 
         public static Metric CreateBaseMetric(this MetricDefinition iomtMetric, string category, string operation)
         {
+            EnsureArg.IsNotNull(iomtMetric);
             EnsureArg.IsNotNullOrWhiteSpace(category, nameof(category));
             EnsureArg.IsNotNullOrWhiteSpace(operation, nameof(operation));
 
@@ -32,7 +33,7 @@ namespace Microsoft.Health.Common.Telemetry
 
         public static Metric AddDimension(this Metric metric, string dimensionName, string dimensionValue)
         {
-            if (string.IsNullOrEmpty(dimensionValue))
+            if (string.IsNullOrWhiteSpace(dimensionValue))
             {
                 return metric;
             }
@@ -52,7 +53,7 @@ namespace Microsoft.Health.Common.Telemetry
                 metricName,
                 new Dictionary<string, object>
                 {
-                    { DimensionNames.Name, string.IsNullOrEmpty(errorName) ? metricName : errorName },
+                    { DimensionNames.Name, string.IsNullOrWhiteSpace(errorName) ? metricName : errorName },
                     { DimensionNames.Category, Category.Errors },
                     { DimensionNames.ErrorType, errorType },
                     { DimensionNames.ErrorSeverity, errorSeverity },

--- a/src/lib/Microsoft.Health.Common/Telemetry/MetricExtension.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/MetricExtension.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using EnsureThat;
 
 namespace Microsoft.Health.Common.Telemetry
 {
@@ -15,6 +16,9 @@ namespace Microsoft.Health.Common.Telemetry
 
         public static Metric CreateBaseMetric(this MetricDefinition iomtMetric, string category, string operation)
         {
+            EnsureArg.IsNotNullOrWhiteSpace(category, nameof(category));
+            EnsureArg.IsNotNullOrWhiteSpace(operation, nameof(operation));
+
             var metricName = iomtMetric.ToString();
             return new Metric(
                 metricName,
@@ -35,6 +39,26 @@ namespace Microsoft.Health.Common.Telemetry
 
             metric.Dimensions.Add(dimensionName, dimensionValue);
             return metric;
+        }
+
+        public static Metric ToErrorMetric(this string metricName, string operation, string errorType, string errorSeverity, string errorSource = "", string errorName = "")
+        {
+            EnsureArg.IsNotNullOrWhiteSpace(metricName, nameof(metricName));
+            EnsureArg.IsNotNullOrWhiteSpace(operation, nameof(operation));
+            EnsureArg.IsNotNullOrWhiteSpace(errorType, nameof(errorType));
+            EnsureArg.IsNotNullOrWhiteSpace(errorSeverity, nameof(errorSeverity));
+
+            return new Metric(
+                metricName,
+                new Dictionary<string, object>
+                {
+                    { DimensionNames.Name, string.IsNullOrEmpty(errorName) ? metricName : errorName },
+                    { DimensionNames.Category, Category.Errors },
+                    { DimensionNames.ErrorType, errorType },
+                    { DimensionNames.ErrorSeverity, errorSeverity },
+                    { DimensionNames.Operation, operation },
+                })
+                .AddDimension(DimensionNames.ErrorSource, errorSource);
         }
     }
 }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
 
         public override string ErrType => _errorType;
 
+        public override string ErrSeverity => ErrorSeverity.Critical;
+
         public override string ErrSource => nameof(ErrorSource.User);
     }
 }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/InvalidEventHubException.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Events.Telemetry.Exceptions
 {

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
 
         public override string ErrType => _errorType;
 
+        public override string ErrSeverity => ErrorSeverity.Critical;
+
         public override string ErrSource => nameof(ErrorSource.User);
     }
 }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/UnauthorizedAccessEventHubException.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Events.Telemetry.Exceptions
 {

--- a/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Health.Common.Telemetry;
 
 namespace Microsoft.Health.Events.Telemetry
@@ -108,16 +107,7 @@ namespace Microsoft.Health.Events.Telemetry
         /// <param name="connectorStage">The stage of the connector</param>
         public static Metric HandledException(string exceptionName, string connectorStage)
         {
-            return new Metric(
-                exceptionName,
-                new Dictionary<string, object>
-                {
-                    { _nameDimension, exceptionName },
-                    { _categoryDimension, Category.Errors },
-                    { _errorTypeDimension, ErrorType.EventHubError },
-                    { _errorSeverityDimension, ErrorSeverity.Critical },
-                    { _operationDimension, connectorStage },
-                });
+            return exceptionName.ToErrorMetric(connectorStage, ErrorType.EventHubError, ErrorSeverity.Critical);
         }
     }
 }

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/BundleExtensions.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/BundleExtensions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Extensions.Fhir
 
             if (throwOnMultipleFound && resourceCount > 1)
             {
-                throw new MultipleResourceFoundException<TResource>();
+                throw new MultipleResourceFoundException<TResource>(resourceCount);
             }
 
             return resources.FirstOrDefault();

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Telemetry/Metrics/FhirClientMetrics.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Telemetry/Metrics/FhirClientMetrics.cs
@@ -3,19 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using Microsoft.Health.Common.Telemetry;
 
 namespace Microsoft.Health.Extensions.Fhir.Telemetry.Metrics
 {
     public class FhirClientMetrics
     {
-        private static string _nameDimension = DimensionNames.Name;
-        private static string _categoryDimension = DimensionNames.Category;
-        private static string _errorTypeDimension = DimensionNames.ErrorType;
-        private static string _errorSeverityDimension = DimensionNames.ErrorSeverity;
-        private static string _operationDimension = DimensionNames.Operation;
-
         /// <summary>
         /// A metric recorded when there is an error reading from or connecting with a FHIR server.
         /// </summary>
@@ -24,16 +17,7 @@ namespace Microsoft.Health.Extensions.Fhir.Telemetry.Metrics
         /// <param name="connectorStage">The stage of the connector</param>
         public static Metric HandledException(string exceptionName, string severity, string connectorStage)
         {
-            return new Metric(
-                exceptionName,
-                new Dictionary<string, object>
-                {
-                    { _nameDimension, exceptionName },
-                    { _categoryDimension, Category.Errors },
-                    { _errorTypeDimension, ErrorType.GeneralError },
-                    { _errorSeverityDimension, severity },
-                    { _operationDimension, connectorStage },
-                });
+            return exceptionName.ToErrorMetric(connectorStage, ErrorType.GeneralError, severity);
         }
     }
 }

--- a/src/lib/Microsoft.Health.Extensions.Fhir/MultipleResourceFoundException.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/MultipleResourceFoundException.cs
@@ -5,12 +5,11 @@
 
 using System;
 using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Extensions.Fhir
 {
-    public class MultipleResourceFoundException<T> :
-        Exception,
-        ITelemetryFormattable
+    public class MultipleResourceFoundException<T> : IomtTelemetryFormattableException
     {
         public MultipleResourceFoundException(int resourceCount)
             : base($"Multiple resources {resourceCount} of type {typeof(T)} found, expected one")
@@ -31,8 +30,10 @@ namespace Microsoft.Health.Extensions.Fhir
         {
         }
 
-        public string EventName => $"Multiple{typeof(T).Name}FoundException";
+        public override string ErrName => $"Multiple{typeof(T).Name}FoundException";
 
-        public Metric ToMetric => EventName.ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.FHIRResourceError, ErrorSeverity.Warning);
+        public override string ErrType => ErrorType.FHIRResourceError;
+
+        public override string Operation => ConnectorOperation.FHIRConversion;
     }
 }

--- a/src/lib/Microsoft.Health.Extensions.Fhir/MultipleResourceFoundException.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/MultipleResourceFoundException.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Health.Common.Telemetry;
 
 namespace Microsoft.Health.Extensions.Fhir
@@ -34,15 +33,6 @@ namespace Microsoft.Health.Extensions.Fhir
 
         public string EventName => $"Multiple{typeof(T).Name}FoundException";
 
-        public Metric ToMetric => new Metric(
-            $"{EventName}",
-            new Dictionary<string, object>
-            {
-                { DimensionNames.Name, $"{EventName}" },
-                { DimensionNames.Category, Category.Errors },
-                { DimensionNames.ErrorType, ErrorType.FHIRResourceError },
-                { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
-                { DimensionNames.Operation, ConnectorOperation.FHIRConversion },
-            });
+        public Metric ToMetric => EventName.ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.FHIRResourceError, ErrorSeverity.Warning);
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateNotFoundException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateNotFoundException.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Health.Common.Telemetry;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
@@ -13,17 +12,6 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         Exception,
         ITelemetryFormattable
     {
-        private static Metric _templateNotFound = new Metric(
-            "TemplateNotFoundException",
-            new Dictionary<string, object>
-            {
-                { DimensionNames.Name, "TemplateNotFoundException" },
-                { DimensionNames.Category, Category.Errors },
-                { DimensionNames.ErrorType, ErrorType.GeneralError },
-                { DimensionNames.ErrorSeverity, ErrorSeverity.Critical },
-                { DimensionNames.Operation, ConnectorOperation.Unknown },
-            });
-
         public TemplateNotFoundException(string message)
             : base(message)
         {
@@ -38,6 +26,6 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         {
         }
 
-        public Metric ToMetric => _templateNotFound;
+        public Metric ToMetric => nameof(TemplateNotFoundException).ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.GeneralError, ErrorSeverity.Critical);
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateNotFoundException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateNotFoundException.cs
@@ -5,12 +5,11 @@
 
 using System;
 using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class TemplateNotFoundException :
-        Exception,
-        ITelemetryFormattable
+    public class TemplateNotFoundException : IomtTelemetryFormattableException
     {
         public TemplateNotFoundException(string message)
             : base(message)
@@ -26,6 +25,12 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         {
         }
 
-        public Metric ToMetric => nameof(TemplateNotFoundException).ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.GeneralError, ErrorSeverity.Critical);
+        public override string ErrName => nameof(TemplateNotFoundException);
+
+        public override string ErrType => ErrorType.GeneralError;
+
+        public override string ErrSeverity => ErrorSeverity.Critical;
+
+        public override string Operation => ConnectorOperation.FHIRConversion;
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Data/CorrelationIdNotDefinedException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Data/CorrelationIdNotDefinedException.cs
@@ -5,12 +5,11 @@
 
 using System;
 using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Fhir.Ingest.Data
 {
-    public class CorrelationIdNotDefinedException :
-        Exception,
-        ITelemetryFormattable
+    public class CorrelationIdNotDefinedException : IomtTelemetryFormattableException
     {
         public CorrelationIdNotDefinedException(string message)
             : base(message)
@@ -26,6 +25,12 @@ namespace Microsoft.Health.Fhir.Ingest.Data
         {
         }
 
-        public Metric ToMetric => nameof(CorrelationIdNotDefinedException).ToErrorMetric(ConnectorOperation.Grouping, ErrorType.DeviceMessageError, ErrorSeverity.Critical);
+        public override string ErrName => nameof(CorrelationIdNotDefinedException);
+
+        public override string ErrType => ErrorType.DeviceMessageError;
+
+        public override string ErrSeverity => ErrorSeverity.Critical;
+
+        public override string Operation => ConnectorOperation.Grouping;
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Data/CorrelationIdNotDefinedException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Data/CorrelationIdNotDefinedException.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Health.Common.Telemetry;
 
 namespace Microsoft.Health.Fhir.Ingest.Data
@@ -27,15 +26,6 @@ namespace Microsoft.Health.Fhir.Ingest.Data
         {
         }
 
-        public Metric ToMetric => new Metric(
-            "CorrelationIdNotDefinedException",
-            new Dictionary<string, object>
-           {
-                { DimensionNames.Name, "CorrelationIdNotDefinedException" },
-                { DimensionNames.Category, Category.Errors },
-                { DimensionNames.ErrorType, ErrorType.DeviceMessageError },
-                { DimensionNames.ErrorSeverity, ErrorSeverity.Critical },
-                { DimensionNames.Operation, ConnectorOperation.Grouping },
-           });
+        public Metric ToMetric => nameof(CorrelationIdNotDefinedException).ToErrorMetric(ConnectorOperation.Grouping, ErrorType.DeviceMessageError, ErrorSeverity.Critical);
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/FhirResourceNotFoundException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/FhirResourceNotFoundException.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Data;
 
@@ -38,15 +37,6 @@ namespace Microsoft.Health.Fhir.Ingest
 
         public string EventName => $"{FhirResourceType}NotFoundException";
 
-        public Metric ToMetric => new Metric(
-            $"{EventName}",
-            new Dictionary<string, object>
-            {
-                { DimensionNames.Name, $"{EventName}" },
-                { DimensionNames.Category, Category.Errors },
-                { DimensionNames.ErrorType, ErrorType.FHIRResourceError },
-                { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
-                { DimensionNames.Operation, ConnectorOperation.FHIRConversion },
-            });
+        public Metric ToMetric => EventName.ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.FHIRResourceError, ErrorSeverity.Warning);
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/FhirResourceNotFoundException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/FhirResourceNotFoundException.cs
@@ -5,13 +5,12 @@
 
 using System;
 using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Common.Telemetry.Exceptions;
 using Microsoft.Health.Fhir.Ingest.Data;
 
 namespace Microsoft.Health.Fhir.Ingest
 {
-    public class FhirResourceNotFoundException :
-        Exception,
-        ITelemetryFormattable
+    public class FhirResourceNotFoundException : IomtTelemetryFormattableException
     {
         public FhirResourceNotFoundException(ResourceType resourceType)
            : base($"Fhir resource of type {resourceType} not found.")
@@ -35,8 +34,10 @@ namespace Microsoft.Health.Fhir.Ingest
 
         public ResourceType FhirResourceType { get; private set; }
 
-        public string EventName => $"{FhirResourceType}NotFoundException";
+        public override string ErrName => $"{FhirResourceType}NotFoundException";
 
-        public Metric ToMetric => EventName.ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.FHIRResourceError, ErrorSeverity.Warning);
+        public override string ErrType => ErrorType.FHIRResourceError;
+
+        public override string Operation => ConnectorOperation.FHIRConversion;
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/ResourceIdentityNotDefinedException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/ResourceIdentityNotDefinedException.cs
@@ -5,13 +5,12 @@
 
 using System;
 using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Common.Telemetry.Exceptions;
 using Microsoft.Health.Fhir.Ingest.Data;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
-    public class ResourceIdentityNotDefinedException :
-        Exception,
-        ITelemetryFormattable
+    public class ResourceIdentityNotDefinedException : IomtTelemetryFormattableException
     {
         public ResourceIdentityNotDefinedException(ResourceType resourceType)
            : base($"Fhir resource of type {resourceType} not found.")
@@ -35,8 +34,10 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
         public ResourceType FhirResourceType { get; private set; }
 
-        public string EventName => $"{FhirResourceType}IdentityNotDefinedException";
+        public override string ErrName => $"{FhirResourceType}IdentityNotDefinedException";
 
-        public Metric ToMetric => EventName.ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.FHIRResourceError, ErrorSeverity.Warning);
+        public override string ErrType => ErrorType.FHIRResourceError;
+
+        public override string Operation => ConnectorOperation.FHIRConversion;
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/ResourceIdentityNotDefinedException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/ResourceIdentityNotDefinedException.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Data;
 
@@ -38,15 +37,6 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
         public string EventName => $"{FhirResourceType}IdentityNotDefinedException";
 
-        public Metric ToMetric => new Metric(
-            $"{EventName}",
-            new Dictionary<string, object>
-            {
-                { DimensionNames.Name, $"{EventName}" },
-                { DimensionNames.Category, Category.Errors },
-                { DimensionNames.ErrorType, ErrorType.FHIRResourceError },
-                { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
-                { DimensionNames.Operation, ConnectorOperation.FHIRConversion },
-            });
+        public Metric ToMetric => EventName.ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.FHIRResourceError, ErrorSeverity.Warning);
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/PatientDeviceMismatchException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/PatientDeviceMismatchException.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Health.Common.Telemetry;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
@@ -27,15 +26,6 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         {
         }
 
-        public Metric ToMetric => new Metric(
-            "PatientDeviceMismatchException",
-            new Dictionary<string, object>
-            {
-                { DimensionNames.Name, "PatientDeviceMismatchException" },
-                { DimensionNames.Category, Category.Errors },
-                { DimensionNames.ErrorType, ErrorType.FHIRResourceError },
-                { DimensionNames.ErrorSeverity, ErrorSeverity.Warning },
-                { DimensionNames.Operation, ConnectorOperation.FHIRConversion },
-            });
+        public Metric ToMetric => nameof(PatientDeviceMismatchException).ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.FHIRResourceError, ErrorSeverity.Warning);
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/PatientDeviceMismatchException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/PatientDeviceMismatchException.cs
@@ -5,13 +5,17 @@
 
 using System;
 using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
-    public class PatientDeviceMismatchException :
-        Exception,
-        ITelemetryFormattable
+    public class PatientDeviceMismatchException : IomtTelemetryFormattableException
     {
+        public PatientDeviceMismatchException()
+            : base()
+        {
+        }
+
         public PatientDeviceMismatchException(string message)
             : base(message)
         {
@@ -22,10 +26,10 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         {
         }
 
-        public PatientDeviceMismatchException()
-        {
-        }
+        public override string ErrName => nameof(PatientDeviceMismatchException);
 
-        public Metric ToMetric => nameof(PatientDeviceMismatchException).ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.FHIRResourceError, ErrorSeverity.Warning);
+        public override string ErrType => ErrorType.FHIRResourceError;
+
+        public override string Operation => ConnectorOperation.FHIRConversion;
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
@@ -150,14 +150,13 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
 
         public static Metric UnhandledException(string exceptionName, string connectorStage)
         {
-            EnsureArg.IsNotNull(exceptionName);
-            var metricName = "UnhandledException";
-            return metricName.ToErrorMetric(connectorStage, ErrorType.GeneralError, ErrorSeverity.Critical, errorName: exceptionName);
+            EnsureArg.IsNotNullOrWhiteSpace(exceptionName);
+
+            return nameof(UnhandledException).ToErrorMetric(connectorStage, ErrorType.GeneralError, ErrorSeverity.Critical, errorName: exceptionName);
         }
 
         public static Metric HandledException(string exceptionName, string connectorStage)
         {
-            EnsureArg.IsNotNull(exceptionName);
             return exceptionName.ToErrorMetric(connectorStage, ErrorType.GeneralError, ErrorSeverity.Critical);
         }
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using EnsureThat;
 using Microsoft.Health.Common.Telemetry;
@@ -24,16 +25,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
 
         private static Metric _deviceIngressSizeBytes = IomtMetricDefinition.DeviceIngressSizeBytes.CreateBaseMetric(Category.Traffic, ConnectorOperation.Normalization);
 
-        private static Metric _notSupported = new Metric(
-            "NotSupportedException",
-            new Dictionary<string, object>
-            {
-                { _nameDimension, "NotSupportedException" },
-                { _categoryDimension, Category.Errors },
-                { _errorTypeDimension, ErrorType.FHIRResourceError },
-                { _errorSeverityDimension, ErrorSeverity.Warning },
-                { _operationDimension, ConnectorOperation.FHIRConversion },
-            });
+        private static Metric _notSupported = nameof(NotSupportedException).ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.FHIRResourceError, ErrorSeverity.Warning);
 
         /// <summary>
         /// The latency between event ingestion and output to FHIR processor.
@@ -159,30 +151,14 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
         public static Metric UnhandledException(string exceptionName, string connectorStage)
         {
             EnsureArg.IsNotNull(exceptionName);
-            return new Metric(
-                "UnhandledException",
-                new Dictionary<string, object>
-                {
-                    { _nameDimension, exceptionName },
-                    { _categoryDimension, Category.Errors },
-                    { _errorTypeDimension, ErrorType.GeneralError },
-                    { _errorSeverityDimension, ErrorSeverity.Critical },
-                    { _operationDimension, connectorStage },
-                });
+            var metricName = "UnhandledException";
+            return metricName.ToErrorMetric(connectorStage, ErrorType.GeneralError, ErrorSeverity.Critical, errorName: exceptionName);
         }
 
         public static Metric HandledException(string exceptionName, string connectorStage)
         {
-            return new Metric(
-                exceptionName,
-                new Dictionary<string, object>
-                {
-                    { _nameDimension, exceptionName },
-                    { _categoryDimension, Category.Errors },
-                    { _errorTypeDimension, ErrorType.GeneralError },
-                    { _errorSeverityDimension, ErrorSeverity.Critical },
-                    { _operationDimension, connectorStage },
-                });
+            EnsureArg.IsNotNull(exceptionName);
+            return exceptionName.ToErrorMetric(connectorStage, ErrorType.GeneralError, ErrorSeverity.Critical);
         }
     }
 }


### PR DESCRIPTION
Changes include:
* minor refactor to have a common method create the error metric so that the metric definition is consistent.
* update InvalidEventHubException and EventHubUnauthorizedAccessException to Critical severity
* update other custom exceptions to use IomtTelemetryFormattableException