### PR TITLE
fix: QuantityFhirValueProcessor format exceptions cause connector to spin on bad data

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.Ingest/InvalidQuantityFhirValueException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/InvalidQuantityFhirValueException.cs
@@ -1,0 +1,35 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Common.Telemetry.Exceptions;
+
+namespace Microsoft.Health.Fhir.Ingest.Service
+{
+    public class InvalidQuantityFhirValueException : IomtTelemetryFormattableException
+    {
+        public InvalidQuantityFhirValueException()
+            : base()
+        {
+        }
+
+        public InvalidQuantityFhirValueException(string message)
+            : base(message)
+        {
+        }
+
+        public InvalidQuantityFhirValueException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public override string ErrName => nameof(InvalidQuantityFhirValueException);
+
+        public override string ErrType => ErrorType.FHIRResourceError;
+
+        public override string Operation => ConnectorOperation.FHIRConversion;
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/FhirExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/FhirExceptionTelemetryProcessor.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
                 typeof(FhirResourceNotFoundException),
                 typeof(MultipleResourceFoundException<>),
                 typeof(TemplateNotFoundException),
-                typeof(CorrelationIdNotDefinedException))
+                typeof(CorrelationIdNotDefinedException),
+                typeof(InvalidQuantityFhirValueException))
         {
         }
 

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/FhirExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/FhirExceptionTelemetryProcessorTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
         [InlineData(typeof(FhirResourceNotFoundException))]
         [InlineData(typeof(ResourceIdentityNotDefinedException))]
         [InlineData(typeof(TemplateNotFoundException))]
+        [InlineData(typeof(InvalidQuantityFhirValueException))]
         public void GivenHandledExceptionTypes_WhenHandleExpection_ThenMetricLoggedAndTrueReturned_Test(System.Type exType)
         {
             var log = Substitute.For<ITelemetryLogger>();


### PR DESCRIPTION
Bug: QuantityFhirValueProcessor format exceptions cause connector to spin on bad data
Issue: When an invalid data value such as "NaN" is passed as a QuantityFhirValue, we are unable to parse it to decimal and the exception thrown is not handled, causing the processor to continuously retry on this exception.
Fix: Add custom exception for invalid data quantity type values. Throw this custom exception for invalid data and add it to the list of handleable FHIR exceptions that will just log the associated error metric and continue processing subsequent event batches.

Note: This PR is currently based off of a refactor PR - https://github.com/microsoft/iomt-fhir/pull/145