### PR TITLE
fix: Incompatible event data does not cause normalization processing to stall

### DIFF
--- a/src/console/Normalize/Processor.cs
+++ b/src/console/Normalize/Processor.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
         private IEnumerableAsyncCollector<IMeasurement> _collector;
         private AsyncPolicy _retryPolicy;
         private CollectionTemplateFactory<IContentTemplate, IContentTemplate> _collectionTemplateFactory;
+        private IExceptionTelemetryProcessor _exceptionTelemetryProcessor;
 
         public Processor(
             string templateDefinition,
@@ -50,6 +51,7 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
             _retryPolicy = CreateRetryPolicy(logger);
             _collectionTemplateFactory = EnsureArg.IsNotNull(collectionTemplateFactory, nameof(collectionTemplateFactory));
+            _exceptionTelemetryProcessor = new NormalizationExceptionTelemetryProcessor();
         }
 
         public async Task ConsumeAsync(IEnumerable<IEventMessage> events)
@@ -100,7 +102,7 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
                     return eventData;
                 });
 
-            var dataNormalizationService = new MeasurementEventNormalizationService(_logger, template);
+            var dataNormalizationService = new MeasurementEventNormalizationService(_logger, template, _exceptionTelemetryProcessor);
             await dataNormalizationService.ProcessAsync(eventHubEvents, _collector).ConfigureAwait(false);
         }
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IncompatibleDataException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IncompatibleDataException.cs
@@ -1,0 +1,35 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Common.Telemetry.Exceptions;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public class IncompatibleDataException : IomtTelemetryFormattableException
+    {
+        public IncompatibleDataException()
+            : base()
+        {
+        }
+
+        public IncompatibleDataException(string message)
+            : base(message)
+        {
+        }
+
+        public IncompatibleDataException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public override string ErrName => nameof(IncompatibleDataException);
+
+        public override string ErrType => ErrorType.DeviceMessageError;
+
+        public override string Operation => ConnectorOperation.Normalization;
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IncompatibleDataException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IncompatibleDataException.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
         public override string ErrType => ErrorType.DeviceMessageError;
 
+        public override string ErrSource => nameof(ErrorSource.User);
+
         public override string Operation => ConnectorOperation.Normalization;
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                         }
                         catch (Exception e)
                         {
-                            exceptions.Add(new InvalidOperationException($"Encounted an error while extracting value for [{name}] using expression {expression.Value}", e));
+                            exceptions.Add(new IncompatibleDataException($"Encounted an error while extracting value for [{name}] using expression {expression.Value}", e));
                         }
                     }
                 }
@@ -76,15 +76,15 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                 {
                     if (exceptions.Count > 0)
                     {
-                        throw new InvalidOperationException($"Unable to extract required value for [{name}]", new AggregateException(exceptions));
+                        throw new IncompatibleDataException($"Unable to extract required value for [{name}]", new AggregateException(exceptions));
                     }
 
-                    throw new InvalidOperationException($"Unable to extract required value for [{name}] using {string.Join(",", expressions.Select(e => e.Value).ToArray())}");
+                    throw new IncompatibleDataException($"Unable to extract required value for [{name}] using {string.Join(",", expressions.Select(e => e.Value).ToArray())}");
                 }
             }
             else if (isRequired)
             {
-                throw new InvalidOperationException($"An expression must be set for [{name}]");
+                throw new IncompatibleDataException($"An expression must be set for [{name}]");
             }
 
             return default;

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/NormalizationExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/NormalizationExceptionTelemetryProcessor.cs
@@ -1,0 +1,32 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Fhir.Ingest.Template;
+using Microsoft.Health.Logging.Telemetry;
+
+namespace Microsoft.Health.Fhir.Ingest.Telemetry
+{
+    public class NormalizationExceptionTelemetryProcessor : ExceptionTelemetryProcessor
+    {
+        private readonly string _connectorStage = ConnectorOperation.Normalization;
+
+        public NormalizationExceptionTelemetryProcessor()
+            : base(typeof(IncompatibleDataException))
+        {
+        }
+
+        public override bool HandleException(Exception ex, ITelemetryLogger logger)
+        {
+            EnsureArg.IsNotNull(ex, nameof(ex));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+
+            var exceptionTypeName = ex.GetType().Name;
+            return HandleException(ex, logger, IomtMetrics.HandledException(exceptionTypeName, _connectorStage), IomtMetrics.UnhandledException(exceptionTypeName, _connectorStage));
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CalculatedFunctionContentTemplateConfigurationTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CalculatedFunctionContentTemplateConfigurationTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         [Fact]
         public void Given_MissingRequiredValueExpression_And_UsingJsonPath_ExceptionIsThrown_Test()
         {
-            var exp = Assert.Throws<InvalidOperationException>(() =>
+            var exp = Assert.Throws<IncompatibleDataException>(() =>
             {
                 PerformEvaluation(
                 new CalculatedFunctionContentTemplate
@@ -163,7 +163,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         [Fact]
         public void Given_MissingRequiredValueExpression_And_UsingJMESPath_ExceptionIsThrown_Test()
         {
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<IncompatibleDataException>(() =>
             {
                 PerformEvaluation(
                 new CalculatedFunctionContentTemplate
@@ -187,7 +187,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         [Fact]
         public void Given_MissingRequiredDeviceIdExpression_ExceptionIsThrown_Test()
         {
-            var exp = Assert.Throws<InvalidOperationException>(() =>
+            var exp = Assert.Throws<IncompatibleDataException>(() =>
             {
                 PerformEvaluation(
                 new CalculatedFunctionContentTemplate
@@ -210,7 +210,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         [Fact]
         public void Given_MissingRequiredTimestampExpression_ExceptionIsThrown_Test()
         {
-            var exp = Assert.Throws<InvalidOperationException>(() =>
+            var exp = Assert.Throws<IncompatibleDataException>(() =>
             {
                 PerformEvaluation(
                 new CalculatedFunctionContentTemplate
@@ -233,7 +233,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         [Fact]
         public void Given_MissingRequiredCorrelationIdValue_ExceptionIsThrown_Test()
         {
-            var exp = Assert.Throws<InvalidOperationException>(() =>
+            var exp = Assert.Throws<IncompatibleDataException>(() =>
             {
                 PerformEvaluation(
                 new CalculatedFunctionContentTemplate
@@ -257,7 +257,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         [Fact]
         public void Given_MissingRequiredDeviceIdValue_ExceptionIsThrown_Test()
         {
-            var exp = Assert.Throws<InvalidOperationException>(() =>
+            var exp = Assert.Throws<IncompatibleDataException>(() =>
             {
                 PerformEvaluation(
                 new CalculatedFunctionContentTemplate

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CalculatedFunctionContentTemplateTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CalculatedFunctionContentTemplateTests.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                     },
                 });
 
-            Assert.Throws<InvalidOperationException>(() => template.GetMeasurements(token).ToArray());
+            Assert.Throws<IncompatibleDataException>(() => template.GetMeasurements(token).ToArray());
         }
 
         [Theory]
@@ -415,7 +415,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             var time = DateTime.UtcNow;
             var token = JToken.FromObject(new { heartrate = "60", device = "abc", date = time });
 
-            var ex = Assert.Throws<InvalidOperationException>(() => template.GetMeasurements(token).ToArray());
+            var ex = Assert.Throws<IncompatibleDataException>(() => template.GetMeasurements(token).ToArray());
             Assert.Contains("Unable to extract required value for [CorrelationIdExpression]", ex.Message);
         }
 

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/JsonPathContentTemplateTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/JsonPathContentTemplateTests.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Health.Fhir.Ingest.Template;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -251,7 +250,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             var time = DateTime.UtcNow;
             var token = JToken.FromObject(new { systolic = "120", device = "abc", date = time });
 
-            Assert.Throws<InvalidOperationException>(() => MultiValueRequiredTemplate.GetMeasurements(token).ToArray());
+            Assert.Throws<IncompatibleDataException>(() => MultiValueRequiredTemplate.GetMeasurements(token).ToArray());
         }
 
         [Fact]
@@ -471,7 +470,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             var time = DateTime.UtcNow;
             var token = JToken.FromObject(new { heartrate = "60", device = "abc", date = time });
 
-            var ex = Assert.Throws<InvalidOperationException>(() => CorrelationIdTemplate.GetMeasurements(token).ToArray());
+            var ex = Assert.Throws<IncompatibleDataException>(() => CorrelationIdTemplate.GetMeasurements(token).ToArray());
             Assert.StartsWith("Unable to extract required value for [CorrelationIdExpression]", ex.Message);
         }
 

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/NormalizationExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/NormalizationExceptionTelemetryProcessorTests.cs
@@ -1,0 +1,50 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Fhir.Ingest.Template;
+using Microsoft.Health.Logging.Telemetry;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Ingest.Telemetry
+{
+    public class NormalizationExceptionTelemetryProcessorTests
+    {
+        [Theory]
+        [InlineData(typeof(IncompatibleDataException))]
+        public void GivenHandledExceptionTypes_WhenHandleExpection_ThenMetricLoggedAndTrueReturned_Test(System.Type exType)
+        {
+            var log = Substitute.For<ITelemetryLogger>();
+            var ex = Activator.CreateInstance(exType) as Exception;
+
+            var exProcessor = new NormalizationExceptionTelemetryProcessor();
+            var handled = exProcessor.HandleException(ex, log);
+            Assert.True(handled);
+
+            log.ReceivedWithAnyArgs(1).LogMetric(null, default(double));
+        }
+
+        [Theory]
+        [InlineData(typeof(Exception))]
+        public void GivenUnhandledExceptionTypes_WhenHandleExpection_ThenMetricLoggedAndFalseReturned_Test(System.Type exType)
+        {
+            var log = Substitute.For<ITelemetryLogger>();
+            var ex = Activator.CreateInstance(exType) as Exception;
+
+            var exProcessor = new NormalizationExceptionTelemetryProcessor();
+            var handled = exProcessor.HandleException(ex, log);
+            Assert.False(handled);
+
+            log.Received(1).LogError(ex);
+            log.Received(1).LogMetric(
+                Arg.Is<Metric>(m =>
+                string.Equals(m.Name, nameof(IomtMetrics.UnhandledException)) &&
+                string.Equals(m.Dimensions[DimensionNames.Name], exType.Name)),
+                1);
+        }
+    }
+}


### PR DESCRIPTION
Bug: If there is an incompatibility b/w the event data and the template, then we end up stalling the processing until the data/template is fixed.
Issue: When the above situation occurs, we throw an exception which is currently set to retry forever, thereby stalling the entire processing of the subsequent data. 
Fix: For such cases, we should log an error (which will be exposed to the customer), drop these events and continue processing the remaining events. 
(A longer-term solution that will prevent the customer from resending the rectified events is to have a dead letter queue where they can an action from for such dropped events.)
Changes include:
* Adding a custom exception to throw when there is incompatible data and we cannot evaluate the expression.
* Add a normalization exception telemetry processor that handles this exception (logs the associated error metric).
* Updated UTs

Note: This PR is currently based off of a refactor PR - #145