### PR TITLE
Data Mapper: Bug fixes

### DIFF
--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Forms.Fhir.Value.tsx
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/components/mapping/Detail.Forms.Fhir.Value.tsx
@@ -213,7 +213,7 @@ const FhirValueForm = (props: { data: FhirValue; context: Mapping; onUpdate: Fun
                             data={data.quantity?.code}
                             onUpdate={(updatedCode: number) => {
                                 const updatedQuantity = {
-                                    ...props.data.sampledData,
+                                    ...props.data.quantity,
                                     code: updatedCode
                                 }
                                 const updatedFhirValue = {
@@ -229,7 +229,7 @@ const FhirValueForm = (props: { data: FhirValue; context: Mapping; onUpdate: Fun
                             data={data.quantity?.system}
                             onUpdate={(updatedSystem: number) => {
                                 const updatedQuantity = {
-                                    ...props.data.sampledData,
+                                    ...props.data.quantity,
                                     system: updatedSystem
                                 }
                                 const updatedFhirValue = {
@@ -245,7 +245,7 @@ const FhirValueForm = (props: { data: FhirValue; context: Mapping; onUpdate: Fun
                             data={data.quantity?.unit}
                             onUpdate={(updatedUnit: number) => {
                                 const updatedQuantity = {
-                                    ...props.data.sampledData,
+                                    ...props.data.quantity,
                                     unit: updatedUnit
                                 }
                                 const updatedFhirValue = {

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/ClientApp/src/services/PersistService.ts
@@ -122,6 +122,14 @@ const createMapping = (typename: string, device?: DeviceMapping, fhir?: FhirMapp
     return updateMapping(id, typename, device, fhir);
 }
 
+const renameMapping = (id: string, typename: string): Promise<Mapping> => {
+    const mapping = getMapping(id);
+    if (!mapping) {
+        return Promise.reject(`The mapping with id ${id} does not exist`);
+    }
+    return updateMapping(id, typename, mapping.device, mapping.fhir);
+}
+
 const updateMapping = (id: string, typename: string, device?: DeviceMapping, fhir?: FhirMapping): Promise<Mapping> => {
     return new Promise((resolve, reject) => {
         if (!typename || typename.trim().length < 1) {
@@ -172,7 +180,7 @@ const PersistService = {
     createMappingsFromTemplates: createMappingsFromTemplates,
     getAllMappings: getAllMappings,
     getMapping: getMapping,
-    renameMapping: updateMapping,
+    renameMapping: renameMapping,
     saveMapping: saveMappingToLocalStorage,
     deleteMapping: deleteMappingInLocalStorage
 }


### PR DESCRIPTION
Fixed Data Mapper bugs:

- Specified a mapping's current device and FHIR mappings when renaming the mapping; otherwise undefined device and FHIR mappings get saved over the current ones. Fixes a bug where renaming a mapping's type name (either from the mapping page or from the home page) cleared all the Device Mapping and FHIR Mapping fields; when the user refreshed or navigated to the mapping page, the fields were shown empty.

   <img width="1123" alt="bug_rename" src="https://user-images.githubusercontent.com/80931622/148575855-d972531c-e39b-43ff-b6a6-19dea65f9ef9.png">

- Corrected FhirValue property for Quantity. Fixes a bug where, when ValueType is "Quantity", adding or deleting a component cleared the Code, System, and/or Unit field(s).

   <img width="524" alt="bug_quantity" src="https://user-images.githubusercontent.com/80931622/148575918-5290ff1b-2afc-4f7e-8e21-6a330239946f.png">