### PR TITLE
Throwing an exception if supplied field is null and is marked required

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -203,7 +203,7 @@ The CalculatedContentTemplate allows matching on and extracting values from an E
 | CorrelationIdExpression  | Optional: The expression to extract the correlation identifier. If extracted this value can be used to group values into a single observation in the FHIR mapping template.                                           | $.matchedToken.correlationId |
 | Values[].ValueName       | The name to associate with the value extracted by the subsequent expression. Used to bind the desired value/component in the FHIR mapping template.                                                                   | hr                           |
 | Values[].ValueExpression | The expression to extract the desired value.                                                                                                                                                                          | $.matchedToken.heartRate     |
-| Values[].Required        | Will require the value to be present in the payload. If not found a measurement will not be generated and an InvalidOperationException will be thrown.                                                                | true                         |
+| Values[].Required        | Will require the value to be present in the payload. If not found a measurement will not be generated and an InvalidOperationException will be thrown. A value is considered present within the payload when it is not null. If the value is a String it must also not be empty.                                                              | true                         |
 
 ### Expression Languages
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
@@ -64,11 +64,11 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                         try
                         {
                             var value = evaluatedToken.Value<T>();
-                            var isNull = value is string s ? string.IsNullOrEmpty(s) : value == null;
+                            var isNull = value is string s ? string.IsNullOrWhiteSpace(s) : value == null;
 
                             if (isRequired && isNull)
                             {
-                                exceptions.Add(new IncompatibleDataException($"A null value was supplied"));
+                                exceptions.Add(new IncompatibleDataException($"A null value was supplied for [{name}]"));
                             }
                             else
                             {

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
@@ -64,8 +64,9 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                         try
                         {
                             var value = evaluatedToken.Value<T>();
+                            var isNull = value is string s ? string.IsNullOrEmpty(s) : value == null;
 
-                            if (isRequired && value == null)
+                            if (isRequired && isNull)
                             {
                                 exceptions.Add(new IncompatibleDataException($"A null value was supplied"));
                             }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
@@ -63,7 +63,16 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                     {
                         try
                         {
-                            return evaluatedToken.Value<T>();
+                            var value = evaluatedToken.Value<T>();
+
+                            if (isRequired && value == null)
+                            {
+                                exceptions.Add(new IncompatibleDataException($"A null value was supplied"));
+                            }
+                            else
+                            {
+                                return value;
+                            }
                         }
                         catch (Exception e)
                         {

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
                             if (isRequired && isNull)
                             {
-                                exceptions.Add(new IncompatibleDataException($"A null value was supplied for [{name}]"));
+                                exceptions.Add(new IncompatibleDataException($"A null or empty value was supplied for the required field [{name}]"));
                             }
                             else
                             {

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CalculatedFunctionContentTemplateTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CalculatedFunctionContentTemplateTests.cs
@@ -177,6 +177,23 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
         [Theory]
         [MemberData(nameof(GetMultiValueRequiredTemplates))]
+        public void GivenMultiValueRequiredTemplateAndValidTokenWithNullValue_WhenGetMeasurements_ThenInvalidOperationException_Test(IContentTemplate template)
+        {
+            var time = DateTime.UtcNow;
+            var token = JToken.FromObject(
+                new
+                {
+                    Body = new[]
+                    {
+                        new { systolic = "120", diastolic = (string)null, device = "abc", date = time },
+                    },
+                });
+
+            Assert.Throws<IncompatibleDataException>(() => template.GetMeasurements(token).ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(GetMultiValueRequiredTemplates))]
         public void GivenMultiValueRequiredTemplateAndValidTokenWithAllValues_WhenGetMeasurements_ThenSingleMeasurementReturned_Test(IContentTemplate template)
         {
             var time = DateTime.UtcNow;
@@ -239,6 +256,16 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                     Assert.Equal("60", p.Value);
                 });
             });
+        }
+
+        [Theory]
+        [MemberData(nameof(GetSingleValueTemplates))]
+        public void GivenSingleValueTemplateAndNullTimestampToken_WhenGetMeasurements_Then_ExceptionIsThrown(IContentTemplate contentTemplate)
+        {
+            var time = DateTime.UtcNow;
+            var token = JToken.FromObject(new { heartrate = "60", device = "abc", date = (DateTime?)null });
+
+            Assert.Throws<IncompatibleDataException>(() => contentTemplate.GetMeasurements(token).ToArray());
         }
 
         [Theory]

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CalculatedFunctionContentTemplateTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CalculatedFunctionContentTemplateTests.cs
@@ -194,6 +194,23 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
         [Theory]
         [MemberData(nameof(GetMultiValueRequiredTemplates))]
+        public void GivenMultiValueRequiredTemplateAndValidTokenWithEmptyValue_WhenGetMeasurements_ThenInvalidOperationException_Test(IContentTemplate template)
+        {
+            var time = DateTime.UtcNow;
+            var token = JToken.FromObject(
+                new
+                {
+                    Body = new[]
+                    {
+                        new { systolic = "120", diastolic = string.Empty, device = "abc", date = time },
+                    },
+                });
+
+            Assert.Throws<IncompatibleDataException>(() => template.GetMeasurements(token).ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(GetMultiValueRequiredTemplates))]
         public void GivenMultiValueRequiredTemplateAndValidTokenWithAllValues_WhenGetMeasurements_ThenSingleMeasurementReturned_Test(IContentTemplate template)
         {
             var time = DateTime.UtcNow;


### PR DESCRIPTION
We currently throw an exception if a required field is not present within the device event. This PR throws an exception when the field is supplied,  is `null` and is marked as required.