### PR TITLE
fix: Set connector operation for event metrics

### DIFF
--- a/src/console/MeasurementCollectionToFhir/Processor.cs
+++ b/src/console/MeasurementCollectionToFhir/Processor.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Events.EventConsumers;
 using Microsoft.Health.Events.Model;
+using Microsoft.Health.Events.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Console.Template;
 using Microsoft.Health.Fhir.Ingest.Host;
 using Microsoft.Health.Fhir.Ingest.Service;
@@ -39,6 +40,8 @@ namespace Microsoft.Health.Fhir.Ingest.Console.MeasurementCollectionToFhir
             _measurementImportService = EnsureArg.IsNotNull(measurementImportService, nameof(measurementImportService));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
             _retryPolicy = CreateRetryPolicy(logger);
+
+            EventMetrics.SetConnectorOperation(ConnectorOperation.FHIRConversion);
         }
 
         public async Task ConsumeAsync(IEnumerable<IEventMessage> events)

--- a/src/console/Normalize/Processor.cs
+++ b/src/console/Normalize/Processor.cs
@@ -5,18 +5,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
-using Azure;
-using Azure.Identity;
 using EnsureThat;
 using Microsoft.Azure.EventHubs;
-using Microsoft.Azure.WebJobs;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Events.EventConsumers;
 using Microsoft.Health.Events.Model;
+using Microsoft.Health.Events.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Console.Template;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Service;
@@ -52,6 +48,8 @@ namespace Microsoft.Health.Fhir.Ingest.Console.Normalize
             _retryPolicy = CreateRetryPolicy(logger);
             _collectionTemplateFactory = EnsureArg.IsNotNull(collectionTemplateFactory, nameof(collectionTemplateFactory));
             _exceptionTelemetryProcessor = new NormalizationExceptionTelemetryProcessor();
+
+            EventMetrics.SetConnectorOperation(ConnectorOperation.Normalization);
         }
 
         public async Task ConsumeAsync(IEnumerable<IEventMessage> events)

--- a/src/console/Startup.cs
+++ b/src/console/Startup.cs
@@ -82,7 +82,6 @@ namespace Microsoft.Health.Fhir.Ingest.Console
                 var collectionContentFactory = serviceProvider.GetRequiredService<CollectionTemplateFactory<IContentTemplate, IContentTemplate>>();
                 var deviceDataNormalization = new Normalize.Processor(template, templateManager, collector, logger, collectionContentFactory);
                 eventConsumers.Add(deviceDataNormalization);
-                EventMetrics.SetConnectorOperation(ConnectorOperation.Normalization);
             }
             else if (applicationType == _measurementToFhirAppType)
             {
@@ -90,7 +89,6 @@ namespace Microsoft.Health.Fhir.Ingest.Console
                 var importService = serviceProvider.GetRequiredService<MeasurementFhirImportService>();
                 var measurementCollectionToFhir = new MeasurementCollectionToFhir.Processor(template, templateManager, importService, logger);
                 eventConsumers.Add(measurementCollectionToFhir);
-                EventMetrics.SetConnectorOperation(ConnectorOperation.FHIRConversion);
             }
             else
             {


### PR DESCRIPTION
Bug: Operation field for Event metrics is being set with the default value Unknown through PaaS workflow.
Issue: As part of the nuget package update, the corresponding change in Startup.cs to set the connector operation was not also updated in the workspace plat code.
Fix: Instead of setting this context in the startup code in workspace plat, setting this value when instantiating the respective processors.
