### PR TITLE
.NET 6 Upgrade of Iot Connector Core Components

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -4,7 +4,9 @@ parameters:
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET Core sdk'
+  displayName: 'Use .NET Core sdk 6.0.x'
+  inputs:
+    version: 6.0.x
 
 - script: dotnet build --configuration $(buildConfiguration) --version-suffix $(build.buildNumber) /warnaserror
   displayName: 'dotnet build $(buildConfiguration)'

--- a/deploy/templates/consumption-azuredeploy.json
+++ b/deploy/templates/consumption-azuredeploy.json
@@ -570,7 +570,7 @@
           "properties": {
             "InputEventHub": "[concat('Endpoint=sb://', variables('app_service_name'), '.servicebus.windows.net/;Authentication=ManagedIdentity;EntityPath=devicedata')]",
             "OutputEventHub": "[concat('Endpoint=sb://', variables('app_service_name'), '.servicebus.windows.net/;Authentication=ManagedIdentity;EntityPath=normalizeddata')]",
-            "FUNCTIONS_EXTENSION_VERSION": "~3",
+            "FUNCTIONS_EXTENSION_VERSION": "~4",
             "FUNCTIONS_EXTENSION_RUNTIME": "dotnet",
             "PROJECT": "src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj",
             "AzureWebJobsStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(resourceId('Microsoft.KeyVault/vaults/secrets', variables('key_vault_name'),'blob-storage-cs'), '2018-02-14').secretUriWithVersion, ')')]",

--- a/deploy/templates/default-managed-identity-azuredeploy.json
+++ b/deploy/templates/default-managed-identity-azuredeploy.json
@@ -567,7 +567,7 @@
           "properties": {
             "InputEventHub": "[concat('Endpoint=sb://', variables('eventhub_hostname'), '/;Authentication=ManagedIdentity;EntityPath=', variables('devicedata_name'))]",
             "OutputEventHub": "[concat('Endpoint=sb://', variables('eventhub_hostname'), '/;Authentication=ManagedIdentity;EntityPath=', variables('normalizeddata_name'))]",
-            "FUNCTIONS_EXTENSION_VERSION": "~3",
+            "FUNCTIONS_EXTENSION_VERSION": "~4",
             "FUNCTIONS_EXTENSION_RUNTIME": "dotnet",
             "PROJECT": "src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj",
             "AzureWebJobsStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(resourceId('Microsoft.KeyVault/vaults/secrets', variables('key_vault_name'),'blob-storage-cs'), '2018-02-14').secretUriWithVersion, ')')]",

--- a/deploy/templates/premium-azuredeploy.json
+++ b/deploy/templates/premium-azuredeploy.json
@@ -570,7 +570,7 @@
           "properties": {
             "InputEventHub": "[concat('Endpoint=sb://', variables('app_service_name'), '.servicebus.windows.net/;Authentication=ManagedIdentity;EntityPath=devicedata')]",
             "OutputEventHub": "[concat('Endpoint=sb://', variables('app_service_name'), '.servicebus.windows.net/;Authentication=ManagedIdentity;EntityPath=normalizeddata')]",
-            "FUNCTIONS_EXTENSION_VERSION": "~3",
+            "FUNCTIONS_EXTENSION_VERSION": "~4",
             "FUNCTIONS_EXTENSION_RUNTIME": "dotnet",
             "PROJECT": "src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj",
             "AzureWebJobsStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(resourceId('Microsoft.KeyVault/vaults/secrets', variables('key_vault_name'),'blob-storage-cs'), '2018-02-14').secretUriWithVersion, ')')]",

--- a/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
+++ b/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
@@ -16,7 +16,7 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<ProjectReference Include="..\lib\Microsoft.Health.Common\Microsoft.Health.Common.csproj" />
 		<ProjectReference Include="..\lib\Microsoft.Health.Events\Microsoft.Health.Events.csproj" />
@@ -24,12 +24,12 @@
 		<ProjectReference Include="..\lib\Microsoft.Health.Fhir.R4.Ingest\Microsoft.Health.Fhir.R4.Ingest.csproj" />
 		<ProjectReference Include="..\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<None Update="local.appsettings.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
 		</None>
-	</ItemGroup>  
-	
+	</ItemGroup>
+
 </Project>

--- a/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
+++ b/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
@@ -1,36 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\lib\Microsoft.Health.Common\Microsoft.Health.Common.csproj" />
-    <ProjectReference Include="..\lib\Microsoft.Health.Events\Microsoft.Health.Events.csproj" />
-    <ProjectReference Include="..\lib\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />
-    <ProjectReference Include="..\lib\Microsoft.Health.Fhir.R4.Ingest\Microsoft.Health.Fhir.R4.Ingest.csproj" />
-    <ProjectReference Include="..\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="local.appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-  </ItemGroup>
-  
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.4" />
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.3.261602">
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	
+	<ItemGroup>
+		<ProjectReference Include="..\lib\Microsoft.Health.Common\Microsoft.Health.Common.csproj" />
+		<ProjectReference Include="..\lib\Microsoft.Health.Events\Microsoft.Health.Events.csproj" />
+		<ProjectReference Include="..\lib\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />
+		<ProjectReference Include="..\lib\Microsoft.Health.Fhir.R4.Ingest\Microsoft.Health.Fhir.R4.Ingest.csproj" />
+		<ProjectReference Include="..\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<None Update="local.appsettings.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</None>
+	</ItemGroup>  
+	
 </Project>

--- a/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
+++ b/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
@@ -12,9 +12,6 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.3.261602">
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/console/appsettings.json
+++ b/src/console/appsettings.json
@@ -9,7 +9,7 @@
   "TemplateStorage:AuthenticationType": "ManagedIdentity",
   "TemplateStorage:BlobStorageContainerUri": "",
   "Console:ApplicationType": "",
-  "FhirClient:UseManagedIdentity": 1,
+  "FhirClient:UseManagedIdentity": true,
   "FhirService:Url": "",
   "InputEventHub:AuthenticationType": "ManagedIdentity",
   "InputEventHub:EventHubNamespaceFQDN": "",

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
     <PackageReference Include="Ensure.That" Version="10.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <AssemblyName>Microsoft.Health.Fhir.Ingest.Host</AssemblyName>
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.12" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.12" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
+++ b/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>
@@ -19,7 +19,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.8.1" />
     <PackageReference Include="Ensure.That" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
+++ b/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>

--- a/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
+++ b/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Expressions/Microsoft.Health.Expressions.csproj
+++ b/src/lib/Microsoft.Health.Expressions/Microsoft.Health.Expressions.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
 		<RootNamespace>Microsoft.Health.Expressions</RootNamespace>
 	</PropertyGroup>
@@ -15,7 +15,7 @@
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="Ensure.That" Version="10.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/lib/Microsoft.Health.Expressions/Microsoft.Health.Expressions.csproj
+++ b/src/lib/Microsoft.Health.Expressions/Microsoft.Health.Expressions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
 		<RootNamespace>Microsoft.Health.Expressions</RootNamespace>
 	</PropertyGroup>

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>
@@ -20,7 +20,7 @@
     <PackageReference Include="Ensure.That" Version="10.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="Hl7.Fhir.R4" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Extensions.Fhir/Microsoft.Health.Extensions.Fhir.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/Microsoft.Health.Extensions.Fhir.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>
@@ -18,7 +18,7 @@
     <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Schema/Microsoft.Health.Fhir.Ingest.Schema.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Schema/Microsoft.Health.Fhir.Ingest.Schema.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <RootNamespace>Microsoft.Health.Fhir.Ingest.Data</RootNamespace>

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Schema/Microsoft.Health.Fhir.Ingest.Schema.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Schema/Microsoft.Health.Fhir.Ingest.Schema.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <RootNamespace>Microsoft.Health.Fhir.Ingest.Data</RootNamespace>
@@ -17,7 +17,7 @@
     <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/Microsoft.Health.Fhir.Ingest.Template.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/Microsoft.Health.Fhir.Ingest.Template.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <RootNamespace>Microsoft.Health.Fhir.Ingest.Template</RootNamespace>
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/Microsoft.Health.Fhir.Ingest.Template.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/Microsoft.Health.Fhir.Ingest.Template.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <RootNamespace>Microsoft.Health.Fhir.Ingest.Template</RootNamespace>

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Microsoft.Health.Fhir.Ingest.Validation.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Microsoft.Health.Fhir.Ingest.Validation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <AssemblyName>Microsoft.Health.Fhir.Ingest.Validation</AssemblyName>
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <AssemblyName>Microsoft.Health.Fhir.Ingest</AssemblyName>
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.12" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.12" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Microsoft.Health.Fhir.R4.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Microsoft.Health.Fhir.R4.Ingest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <AssemblyName>Microsoft.Health.Fhir.Ingest.R4</AssemblyName>
@@ -29,7 +29,7 @@
     <PackageReference Include="Ensure.That" Version="10.0.0" />
     <PackageReference Include="Hl7.Fhir.R4" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Logger/Microsoft.Health.Logging.csproj
+++ b/src/lib/Microsoft.Health.Logger/Microsoft.Health.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/lib/Microsoft.Health.Logger/Microsoft.Health.Logging.csproj
+++ b/src/lib/Microsoft.Health.Logger/Microsoft.Health.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.17.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
+++ b/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
@@ -12,7 +12,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Events.UnitTest/Microsoft.Health.Events.UnitTest.csproj
+++ b/test/Microsoft.Health.Events.UnitTest/Microsoft.Health.Events.UnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Microsoft.Health.Expressions.UnitTests/Microsoft.Health.Expressions.UnitTests.csproj
+++ b/test/Microsoft.Health.Expressions.UnitTests/Microsoft.Health.Expressions.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
 		<GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
 		<RootNamespace>Microsoft.Health.Expressions.UnitTests</RootNamespace>
@@ -13,7 +13,7 @@
 		<WarningsAsErrors />
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/Microsoft.Health.Extensions.Fhir.R4.UnitTests.csproj
+++ b/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/Microsoft.Health.Extensions.Fhir.R4.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <IsPackable>false</IsPackable>
@@ -11,7 +11,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Extensions.Fhir.UnitTests/Microsoft.Health.Extensions.Fhir.UnitTests.csproj
+++ b/test/Microsoft.Health.Extensions.Fhir.UnitTests/Microsoft.Health.Extensions.Fhir.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <IsPackable>false</IsPackable>
@@ -11,7 +11,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/Microsoft.Health.Fhir.Ingest.Template.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/Microsoft.Health.Fhir.Ingest.Template.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
@@ -13,7 +13,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
     <RootNamespace>Microsoft.Health.Fhir.Ingest</RootNamespace>
@@ -13,7 +13,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Fhir.Ingest.Validation.UnitTests/Microsoft.Health.Fhir.Ingest.Validation.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.Validation.UnitTests/Microsoft.Health.Fhir.Ingest.Validation.UnitTests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
@@ -15,7 +15,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -27,7 +27,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
     <RootNamespace>Microsoft.Health.Fhir.Ingest</RootNamespace>
@@ -13,7 +13,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Tests.Common.R4/Microsoft.Health.Tests.Common.R4.csproj
+++ b/test/Microsoft.Health.Tests.Common.R4/Microsoft.Health.Tests.Common.R4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>

--- a/test/Microsoft.Health.Tests.Common.R4/Microsoft.Health.Tests.Common.R4.csproj
+++ b/test/Microsoft.Health.Tests.Common.R4/Microsoft.Health.Tests.Common.R4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Tests.Common/Microsoft.Health.Tests.Common.csproj
+++ b/test/Microsoft.Health.Tests.Common/Microsoft.Health.Tests.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>

--- a/test/Microsoft.Health.Tests.Common/Microsoft.Health.Tests.Common.csproj
+++ b/test/Microsoft.Health.Tests.Common/Microsoft.Health.Tests.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
**Code Changes:**
Migrated the projects below to .NET 6
- Microsoft.Health.Fhir.Ingest.Console
- Microsoft.Health.Events
- Microsoft.Health.Extensions.Fhir
- Microsoft.Health.Extensions.Fhir.R4
- Microsoft.Health.Extensions.Host
- Microsoft.Health.Fhir.Ingest
- Microsoft.Health.Fhir.Ingest.Validation
- Microsoft.Health.Fhir.R4.Ingest
- Microsoft.Health.Common.UnitTests
- Microsoft.Health.Events.UnitTests
- Microsoft.Health.Expressions.UnitTests
- Microsoft.Health.Extensions.Fhir.UnitTests
- Microsoft.Health.Extensions.Fhir.R4.UnitTests
- Microsoft.Health.Fhir.Ingest.UnitTests
- Microsoft.Health.Fhir.Ingest.Template.UnitTests
- Microsoft.Health.Fhir.Ingest.Validation.UnitTests
- Microsoft.Health.Fhir.R4.Ingest.UnitTests

Upgraded Azure functions from v3 to v4 
- Microsoft.Health.Fhir.Ingest.Host

Updated Microsoft.Net.Compilers.Toolset from 3.9.0 -> 4.0.1
Updated Microsoft.NET.Sdk.Functions from 3.9.0 -> 4.0.1

Updated FUNCTIONS_EXTENSION_VERSION in arm templates to v4

_App Service running the Azure Function successfully_: [test-net6-upgrade-2](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/4092fd42-145e-4e91-aa15-96f66d2b6deb/resourceGroups/test-net6-upgrade-2/overview)

