### PR TITLE
Set Newtonsoft type handling to none

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/AbstractJsonConverter.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/AbstractJsonConverter.cs
@@ -34,7 +34,11 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                 .Where(t => _baseType.IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface)
                 .ToDictionary(t => TrimBaseType(t.Name, _baseType.Name), StringComparer.InvariantCultureIgnoreCase);
 
-            _knownTypeSettings = new JsonSerializerSettings { ContractResolver = new KnownTypeContractResolver(baseType) };
+            _knownTypeSettings = new JsonSerializerSettings
+            {
+                ContractResolver = new KnownTypeContractResolver(baseType),
+                TypeNameHandling = TypeNameHandling.None,
+            };
         }
 
         public override bool CanConvert(Type objectType)

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExtensions.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                     errors.Add(args.ErrorContext.Error);
                     args.ErrorContext.Handled = true;
                 },
+                TypeNameHandling = TypeNameHandling.None,
             });
 
             T obj = token.ToObject<T>(jsonSerializer);


### PR DESCRIPTION
Follow Safe Deserialization practices and ensure type handling is disabled for Newtonsoft JSON serializers