### PR TITLE
Added StatusCode to error metric name

### DIFF
--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Telemetry/Exceptions/FhirServiceExceptionProcessor.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Telemetry/Exceptions/FhirServiceExceptionProcessor.cs
@@ -75,7 +75,6 @@ namespace Microsoft.Health.Extensions.Fhir.Telemetry.Exceptions
                     return (new InvalidFhirServiceException(message, exception, errorName), errorName);
 
                 case HttpRequestException _:
-                    // TODO: In .NET 5 and later, check HttpRequestException's StatusCode property instead of the Message property
                     if (exception.Message.Contains(FhirResources.HttpRequestErrorNotKnown, StringComparison.CurrentCultureIgnoreCase))
                     {
                         message = FhirResources.FhirServiceHttpRequestError;
@@ -83,7 +82,8 @@ namespace Microsoft.Health.Extensions.Fhir.Telemetry.Exceptions
                         return (new InvalidFhirServiceException(message, exception, errorName), errorName);
                     }
 
-                    return (exception, nameof(FhirServiceErrorCode.HttpRequestError));
+                    var statusCode = ((HttpRequestException)exception).StatusCode;
+                    return (exception, $"{FhirServiceErrorCode.HttpRequestError}{statusCode}");
 
                 case MsalServiceException _:
                     var errorCode = ((MsalServiceException)exception).ErrorCode;

--- a/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/FhirServiceExceptionProcessorTests.cs
+++ b/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/FhirServiceExceptionProcessorTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Health.Extensions.Fhir.R4.UnitTests
         private static readonly Exception _argEx = new ArgumentException("test_message", "test_param");
         private static readonly Exception _uriEx = new UriFormatException();
         private static readonly Exception _httpNotKnownEx = new HttpRequestException("Name or service not known");
+        private static readonly Exception _httpNotFoundEx = new HttpRequestException("test_message", new Exception(), HttpStatusCode.NotFound);
         private static readonly Exception _httpEx = new HttpRequestException();
         private static readonly Exception _msalInvalidResourceEx = new MsalServiceException("invalid_resource", "test_message");
         private static readonly Exception _msalInvalidScopeEx = new MsalServiceException("invalid_scope", "test_message");
@@ -44,6 +45,7 @@ namespace Microsoft.Health.Extensions.Fhir.R4.UnitTests
                 new object[] { _argEx, "FHIRServiceErrorArgumentErrortest_param" },
                 new object[] { _uriEx, "FHIRServiceErrorConfigurationError", nameof(ErrorSource.User) },
                 new object[] { _httpNotKnownEx, "FHIRServiceErrorConfigurationError", nameof(ErrorSource.User) },
+                new object[] { _httpNotFoundEx, "FHIRServiceErrorHttpRequestErrorNotFound" },
                 new object[] { _httpEx, "FHIRServiceErrorHttpRequestError" },
                 new object[] { _msalInvalidResourceEx, "FHIRServiceErrorConfigurationError", nameof(ErrorSource.User) },
                 new object[] { _msalInvalidScopeEx, "FHIRServiceErrorConfigurationError", nameof(ErrorSource.User) },
@@ -62,6 +64,7 @@ namespace Microsoft.Health.Extensions.Fhir.R4.UnitTests
                 new object[] { _argEx, typeof(ArgumentException) },
                 new object[] { _uriEx, typeof(InvalidFhirServiceException) },
                 new object[] { _httpNotKnownEx, typeof(InvalidFhirServiceException) },
+                new object[] { _httpNotFoundEx, typeof(HttpRequestException) },
                 new object[] { _httpEx, typeof(HttpRequestException) },
                 new object[] { _msalInvalidResourceEx, typeof(InvalidFhirServiceException) },
                 new object[] { _msalInvalidScopeEx, typeof(InvalidFhirServiceException) },


### PR DESCRIPTION
Added `HttpRequestException`'s `StatusCode` property (if any) to the error metric name for a FHIR service configuration error.

`HttpRequestException`'s `StatusCode` property is available in .NET 5 and later.

Note: It turns out that we cannot check the `StatusCode` property instead of the `Message` property to catch this particular FHIR service configuration error (c.f. Line 78: `if (exception.Message.Contains(FhirResources.HttpRequestErrorNotKnown, StringComparison.CurrentCultureIgnoreCase))`), because the corresponding `HttpRequestException` has a null `StatusCode`.