### PR TITLE
Upgrade version of Webjobs Extension Storage

### DIFF
--- a/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
+++ b/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
@@ -7,7 +7,7 @@
 		<IsPackable>true</IsPackable>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.4" />
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -20,11 +20,11 @@
   </PropertyGroup>  
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.27" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.3.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.4" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.27" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.12" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.12" />


### PR DESCRIPTION
We currently have a transitive dependency on the deprecated package `Microsoft.Azure.DocumentDB.Core`. This is being pulled in from `Microsoft.Azure.WebJobs.Extensions.Storage -> Microsoft.Azure.Cosmos.Table -> Microsoft.Azure.DocumentDB.Core`. This PR upgrades our version of `Microsoft.Azure.WebJobs.Extensions.Storage` which no longer depends on `Microsoft.Azure.Cosmos.Table`.

Testing:

- Ran console app locally
- Ran Function Apps locally