### PR TITLE
Downgrading Validation and transitive projects to netstandard2.0

### DIFF
--- a/src/lib/Microsoft.Health.Common/Extension/StringExtensions.cs
+++ b/src/lib/Microsoft.Health.Common/Extension/StringExtensions.cs
@@ -1,0 +1,28 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+
+namespace Microsoft.Health.Common.Extension
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Returns a value indicating whether a specified substring occurs within this string, using the provided comparison rule.
+        ///
+        /// Note: This method is provided on the String object in .Net Core 2.1 and later.
+        /// </summary>
+        /// <param name="stringToSearch">The string to search</param>
+        /// <param name="stringToSeek">The string to seek</param>
+        /// <param name="comparison">The comparison rule</param>
+        /// <returns>True if the string to seek is contained within the string to search.</returns>
+        public static bool Contains(this string stringToSearch, string stringToSeek, StringComparison comparison)
+        {
+            EnsureArg.IsNotNull(stringToSearch, nameof(stringToSearch));
+            return stringToSearch.IndexOf(stringToSeek, comparison) >= 0;
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
@@ -16,6 +16,7 @@ using Azure.Messaging.EventHubs;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using EnsureThat;
+using Microsoft.Health.Common.Extension;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Events.Common;
 using Microsoft.Health.Events.Model;

--- a/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
+++ b/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>

--- a/src/lib/Microsoft.Health.Events/Model/EventMessage.cs
+++ b/src/lib/Microsoft.Health.Events/Model/EventMessage.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Events.Model
             Offset = offset;
             EnqueuedTime = enqueuedTime;
             Properties = new Dictionary<string, object>(properties);
-            SystemProperties = systemProperties.ToDictionary(kv => kv.Key, kv => kv.Value);
+            SystemProperties = systemProperties == null ? new Dictionary<string, object>() : systemProperties.ToDictionary(kv => kv.Key, kv => kv.Value);
         }
 
         public string PartitionId { get; }

--- a/src/lib/Microsoft.Health.Events/Model/EventMessage.cs
+++ b/src/lib/Microsoft.Health.Events/Model/EventMessage.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Health.Events.Model
 {
@@ -31,7 +32,7 @@ namespace Microsoft.Health.Events.Model
             Offset = offset;
             EnqueuedTime = enqueuedTime;
             Properties = new Dictionary<string, object>(properties);
-            SystemProperties = new Dictionary<string, object>(systemProperties);
+            SystemProperties = systemProperties.ToDictionary(kv => kv.Key, kv => kv.Value);
         }
 
         public string PartitionId { get; }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionProcessor.cs
@@ -8,6 +8,7 @@ using System.Net.Sockets;
 using Azure;
 using Azure.Messaging.EventHubs;
 using EnsureThat;
+using Microsoft.Health.Common.Extension;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Common.Telemetry.Exceptions;
 using Microsoft.Health.Events.Resources;

--- a/src/lib/Microsoft.Health.Extensions.Fhir/Microsoft.Health.Extensions.Fhir.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/Microsoft.Health.Extensions.Fhir.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="2.0.55" />
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <IsPackable>true</IsPackable>

--- a/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <LangVersion>7.3</LangVersion>

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Validation/MappingValidator.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Validation/MappingValidator.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Health.Fhir.Ingest.Validation
                 {
                     var innerTemplate = extractor.Template;
                     var matchingFhirTemplate = fhirTemplate.GetTemplate(innerTemplate.TypeName) as CodeValueFhirTemplate;
-                    var availableFhirValueNames = GetFhirValues(matchingFhirTemplate).Select(v => v.ValueName).ToHashSet();
+                    var availableFhirValueNames = new HashSet<string>(GetFhirValues(matchingFhirTemplate).Select(v => v.ValueName));
                     var availableFhirValueNamesDisplay = string.Join(" ,", availableFhirValueNames);
 
                     // Ensure all values are present

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Microsoft.Health.Fhir.Ingest.Validation.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Microsoft.Health.Fhir.Ingest.Validation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <AssemblyName>Microsoft.Health.Fhir.Ingest.Validation</AssemblyName>
@@ -39,9 +39,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Common\Microsoft.Health.Common.csproj" />
-    <ProjectReference Include="..\Microsoft.Health.Events\Microsoft.Health.Events.csproj" />
-    <ProjectReference Include="..\Microsoft.Health.Extensions.Fhir\Microsoft.Health.Extensions.Fhir.csproj" />
-    <ProjectReference Include="..\Microsoft.Health.Extensions.Host\Microsoft.Health.Extensions.Host.csproj" />
     <ProjectReference Include="..\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />
     <ProjectReference Include="..\Microsoft.Health.Fhir.Ingest.Template\Microsoft.Health.Fhir.Ingest.Template.csproj" />
   </ItemGroup>

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Data/SampledDataProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Data/SampledDataProcessor.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Ingest.Data
             EnsureArg.IsNotNullOrWhiteSpace(stream, nameof(stream));
             EnsureArg.IsNotNull(samplePeriod, nameof(samplePeriod));
 
-            var tokens = stream.Split(" ");
+            var tokens = stream.Split(' ');
             var timeValues = new List<(DateTime Time, string Value)>(tokens.Length);
             var timeIncrement = Convert.ToDouble(samplePeriod.Value);
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <HighEntropyVA>true</HighEntropyVA>
     <AssemblyName>Microsoft.Health.Fhir.Ingest</AssemblyName>


### PR DESCRIPTION
This PR updates the validation project to target netstandard as this is supported in the hosting service. 

Various changes were made throughout the codebase to become compliant with netstandard2.0