### PR TITLE
Throw proper exception when TypeNameMatch expression is missing

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotJsonPathContentTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotJsonPathContentTemplateFactory.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
-using Microsoft.Health.Fhir.Ingest.Template;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Health.Fhir.Ingest.Template

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotJsonPathLegacyMeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotJsonPathLegacyMeasurementExtractor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 {
     public class IotJsonPathLegacyMeasurementExtractor : LegacyMeasurementExtractor
     {
-        private IotJsonPathContentTemplate _template;
+        private readonly IotJsonPathContentTemplate _template;
 
         public IotJsonPathLegacyMeasurementExtractor(
             IotJsonPathContentTemplate template)

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathExpressionEvaluatorFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathExpressionEvaluatorFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
     {
         public IExpressionEvaluator Create(TemplateExpression expression)
         {
-            EnsureArg.IsNotEmptyOrWhiteSpace(expression?.Value, nameof(expression.Value));
+            EnsureArg.IsNotNullOrWhiteSpace(expression?.Value, nameof(expression.Value));
 
             var expressionLanguage = expression.Language ?? TemplateExpressionLanguage.JsonPath;
             if (expressionLanguage != TemplateExpressionLanguage.JsonPath)

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/LegacyMeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/LegacyMeasurementExtractor.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         protected override IEnumerable<JToken> MatchTypeTokens(JObject token)
         {
             EnsureArg.IsNotNull(token, nameof(token));
-            var evaluator = ExpressionEvaluatorFactory.Create(Template.TypeMatchExpression);
+            var evaluator = CreateRequiredExpressionEvaluator(Template.TypeMatchExpression, nameof(Template.TypeMatchExpression));
 
             return evaluator.SelectTokens(token);
         }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         protected virtual IEnumerable<JToken> MatchTypeTokens(JObject token)
         {
             EnsureArg.IsNotNull(token, nameof(token));
-            var evaluator = ExpressionEvaluatorFactory.Create(Template.TypeMatchExpression);
+            var evaluator = CreateRequiredExpressionEvaluator(Template.TypeMatchExpression, nameof(Template.TypeMatchExpression));
 
             foreach (var extractedToken in evaluator.SelectTokens(token))
             {
@@ -132,6 +132,19 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                 tokenClone.Add(MatchedToken, extractedToken);
                 yield return tokenClone;
             }
+        }
+
+        protected IExpressionEvaluator CreateRequiredExpressionEvaluator(TemplateExpression expression, string expressionName)
+        {
+            EnsureArg.IsNotNullOrWhiteSpace(expressionName, nameof(expressionName));
+
+            // If the expression object or its value aren't set, throw a detailed exception
+            if (string.IsNullOrWhiteSpace(expression?.Value))
+            {
+                throw new IncompatibleDataException($"An expression must be set for [{expressionName}]");
+            }
+
+            return ExpressionEvaluatorFactory.Create(Template.TypeMatchExpression);
         }
 
         private Measurement CreateMeasurementFromToken(JToken token)

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExpressionEvaluatorFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExpressionEvaluatorFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
         public IExpressionEvaluator Create(TemplateExpression expression)
         {
-            EnsureArg.IsNotEmptyOrWhiteSpace(expression?.Value, nameof(expression.Value));
+            EnsureArg.IsNotNullOrWhiteSpace(expression?.Value, nameof(expression.Value));
             EnsureArg.IsNotNull(expression?.Language, nameof(expression.Language));
 
             return expression.Language switch

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/JsonPathContentTemplateTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/JsonPathContentTemplateTests.cs
@@ -414,6 +414,31 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             });
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public void GivenInvalidTypeMatchExpression_WhenGetMeasurements_ThenExceptionIsThrown_Test(string typeMatchExpression)
+        {
+            var time = DateTime.UtcNow;
+            var token = JToken.FromObject(new JsonWidget { MyProperty = "data", Time = time });
+
+            var template = new JsonPathContentTemplate
+            {
+                TypeName = "space",
+                TypeMatchExpression = typeMatchExpression,
+                DeviceIdExpression = "$.['My Property']",
+                TimestampExpression = "$.Time",
+                Values = new List<JsonPathValueExpression>
+                {
+                    new JsonPathValueExpression { ValueName = "prop", ValueExpression = "$.['My Property']", Required = false },
+                },
+            };
+
+            var ex = Assert.Throws<IncompatibleDataException>(() => BuildMeasurementExtractor(template).GetMeasurements(token).ToArray());
+            Assert.Equal("An expression must be set for [TypeMatchExpression]", ex.Message);
+        }
+
         [Fact]
         public void GivenSingleValueCompoundAndTemplateAndPartialToken_WhenGetMeasurements_ThenEmptyIEnumerableReturned_Test()
         {


### PR DESCRIPTION
This PR ensure that we throw a better exception when the `typeNameMatch` expression is not provided. Now, the following exception will be thrown: `An expression must be set for [TypeNameMatchExpression]`