### PR TITLE
Updated checkpointing logic to checkpoint after every event batch is processed

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/ICheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/ICheckpointClient.cs
@@ -15,9 +15,7 @@ namespace Microsoft.Health.Events.EventCheckpointing
     {
         Task SetCheckpointAsync(IEventMessage eventArg, IEnumerable<KeyValuePair<Metric, double>> metrics = null);
 
-        Task PublishCheckpointAsync(string partitionId);
-
-        Task<Checkpoint> GetCheckpointForPartitionAsync(string partitionId);
+        Task<Checkpoint> GetCheckpointForPartitionAsync(string partitionId, CancellationToken cancellationToken);
 
         Task ResetCheckpointsAsync(CancellationToken cancellationToken = default);
     }

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
@@ -7,14 +7,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs;
-using Azure.Messaging.EventHubs.Consumer;
-using Azure.Messaging.EventHubs.Processor;
-using EnsureThat;
 using Microsoft.Health.Events.EventCheckpointing;
 using Microsoft.Health.Events.EventConsumers.Service;
-using Microsoft.Health.Events.Model;
-using Microsoft.Health.Events.Telemetry;
-using Microsoft.Health.Events.Telemetry.Exceptions;
 using Microsoft.Health.Logging.Telemetry;
 
 namespace Microsoft.Health.Events.EventHubProcessor


### PR DESCRIPTION
The previous checkpointing logic would use the StorageCheckpointOptions.CheckpointBatchCount property to wait until the specified number of checkpoint attempts occurred before actually recording a checkpoint. This can result in very infrequent checkpointing that will cause events to replay if the process is restarted.

There is already a batching mechanism in place that reduces the number of times a checkpoint is created, so this additional checkpoint delay is somewhat redundant. EventBatchingOptions.FlushTimespan and EventBatchingOptions.MaxEvents provide settings to the batching logic (at the event processing level) that dictate when a batch of events should be processed based on a time window or number of events in the batch. This PR updates the StorageCheckpoint Client to simply record a checkpoint for a given partition when SetCheckpointAsync is called. This will ensure that after each batch of events is processed, a new checkpoint will be created for a given partition.

Also in this PR is additional logging and logic to respect CancellationTokens. This was added to track the behavior of the application during shutdown, and improve graceful termination. 