### PR TITLE
Improve Observation Value Merge Type Mismatch Errors

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.Ingest/Template/FhirValueProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Template/FhirValueProcessor.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
     public abstract class FhirValueProcessor<TValueType, TInValue, TOutValue> : IFhirValueProcessor<TInValue, TOutValue>
         where TValueType : FhirValueType
     {
+        private const string NullValueText = "null";
         private static readonly Type SupportedType = typeof(TValueType);
 
         public Type SupportedValueType => SupportedType;
@@ -40,5 +41,10 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         protected abstract TOutValue CreateValueImpl(TValueType template, TInValue inValue);
 
         protected abstract TOutValue MergeValueImpl(TValueType template, TInValue inValue, TOutValue existingValue);
+
+        protected static string GetValueTypeName(object value)
+        {
+            return value?.GetType()?.Name ?? NullValueText;
+        }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest.Templates/Template/CodeableConceptFhirValueProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest.Templates/Template/CodeableConceptFhirValueProcessor.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         {
             if (!(existingValue is CodeableConcept))
             {
-                throw new NotSupportedException($"Element {nameof(existingValue)} expected to be of type {typeof(CodeableConcept)}.");
+                throw new NotSupportedException($"Element {nameof(existingValue)} expected to be of type {typeof(CodeableConcept)}. Actual type is {GetValueTypeName(existingValue)}.");
             }
 
             // Currently no way to merge codeable concepts. Just replace.

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest.Templates/Template/QuantityFhirValueProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest.Templates/Template/QuantityFhirValueProcessor.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         {
             if (!(existingValue is Quantity))
             {
-                throw new NotSupportedException($"Element {nameof(existingValue)} expected to be of type {typeof(Quantity)}.");
+                throw new NotSupportedException($"Element {nameof(existingValue)} expected to be of type {typeof(Quantity)}. Actual type is {GetValueTypeName(existingValue)}.");
             }
 
             // Only a single value, just replace.

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest.Templates/Template/SampledDataFhirValueProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest.Templates/Template/SampledDataFhirValueProcessor.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
             if (!(existingValue is SampledData sampledData))
             {
-                throw new NotSupportedException($"Element {nameof(existingValue)} expected to be of type {typeof(SampledData)}.");
+                throw new NotSupportedException($"Element {nameof(existingValue)} expected to be of type {typeof(SampledData)}. Actual type is {GetValueTypeName(existingValue)}.");
             }
 
             if (sampledData.Dimensions > 1)

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest.Templates/Template/StringFhirValueProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest.Templates/Template/StringFhirValueProcessor.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         {
             if (!(existingValue is FhirString))
             {
-                throw new NotSupportedException($"Element {nameof(existingValue)} expected to be of type {typeof(FhirString)}.");
+                throw new NotSupportedException($"Element {nameof(existingValue)} expected to be of type {typeof(FhirString)}. Actual type is {GetValueTypeName(existingValue)}.");
             }
 
             // Only a single value, just replace.

--- a/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4FhirImportServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4FhirImportServiceTests.cs
@@ -113,14 +113,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 Device = new ResourceReference(@"Device/123"),
                 Subject = new ResourceReference(@"Patient/abc"),
                 Status = ObservationStatus.Final,
-                Identifier = new List<Identifier>
-                {
-                    new Identifier
-                    {
-                        System = "Test",
-                        Value = "id",
-                    },
-                },
+                Identifier = BuildIdentifiers(),
                 Effective = new Period(new FhirDateTime(DateTimeOffset.Now.AddHours(-1)), new FhirDateTime(DateTimeOffset.Now)),
             };
 
@@ -170,7 +163,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         [Fact]
         public async void GivenFoundObservationAndConflictOnSave_WhenSaveObservationAsync_ThenGetAndUpdateInvoked_Test()
         {
-            var foundObservation1 = new Observation { Id = "1" };
+            var foundObservation1 = new Observation { Id = "1", Identifier = BuildIdentifiers() };
             var foundBundle1 = new Bundle
             {
                 Entry = new List<Bundle.EntryComponent>
@@ -350,7 +343,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         [Fact]
         public async void GivenFoundObservationUnchanged_WhenSaveObservationAsync_ThenUpdateInvoked_Test()
         {
-            var foundObservation = new Observation { Id = "1" };
+            var foundObservation = new Observation { Id = "1", Identifier = BuildIdentifiers() };
             var foundBundle = new Bundle
             {
                 Entry = new List<Bundle.EntryComponent>
@@ -396,6 +389,18 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             lookup[ResourceType.Device] = "deviceId";
             lookup[ResourceType.Patient] = "patientId";
             return lookup;
+        }
+
+        private static List<Identifier> BuildIdentifiers()
+        {
+            return new List<Identifier>
+            {
+                new Identifier
+                {
+                    System = "https://azure.microsoft.com/en-us/services/iomt-fhir-connector/",
+                    Value = "patientId.deviceId..",
+                },
+            };
         }
 
         private static Observation ThrowConflictException()


### PR DESCRIPTION
* Add additional error information on existing type when merge value detect type mismatch.
* Add additional check to fail observation save if the observation found on the initial get doesn't contain the desired identifier.