### PR TITLE
Add line numbers to template exceptions

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/CalculatedFunctionContentTemplate.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/CalculatedFunctionContentTemplate.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Converters;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class CalculatedFunctionContentTemplate
+    public class CalculatedFunctionContentTemplate : LineAwareJsonObject
     {
         [JsonProperty(Required = Required.Always)]
         public virtual string TypeName { get; set; }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/CalculatedFunctionContentTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/CalculatedFunctionContentTemplateFactory.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
             if (jsonTemplate.Template?.Type != JTokenType.Object)
             {
-                throw new InvalidTemplateException($"Expected an object for the template property value for template type {TargetTypeName}.");
+                var lineInfo = jsonTemplate.GetLineInfoForProperty(nameof(TemplateContainer.Template));
+                throw new InvalidTemplateException($"Expected an object for the template property value for template type {TargetTypeName}.", lineInfo);
             }
 
             var calculatedFunctionTemplate = jsonTemplate.Template.ToValidTemplate<CalculatedFunctionContentTemplate>();
@@ -69,7 +70,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             IDictionary<string, IExpressionEvaluator> cache,
             TemplateExpression expression,
             string expressionName,
-            LineInfo templateLineInfo,
+            ILineInfo templateLineInfo,
             bool isRequired = false)
         {
             if (expression != null)

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/CalculatedFunctionContentTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/CalculatedFunctionContentTemplateFactory.cs
@@ -50,16 +50,16 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         {
             var evaluatorCache = new Dictionary<string, IExpressionEvaluator>();
 
-            AddExpression(evaluatorCache, template.TypeMatchExpression, nameof(template.TypeMatchExpression), true);
-            AddExpression(evaluatorCache, template.DeviceIdExpression, nameof(template.DeviceIdExpression), true);
-            AddExpression(evaluatorCache, template.PatientIdExpression, nameof(template.PatientIdExpression));
-            AddExpression(evaluatorCache, template.EncounterIdExpression, nameof(template.EncounterIdExpression));
-            AddExpression(evaluatorCache, template.TimestampExpression, nameof(template.TimestampExpression));
-            AddExpression(evaluatorCache, template.CorrelationIdExpression, nameof(template.CorrelationIdExpression));
+            AddExpression(evaluatorCache, template.TypeMatchExpression, nameof(template.TypeMatchExpression), template, true);
+            AddExpression(evaluatorCache, template.DeviceIdExpression, nameof(template.DeviceIdExpression), template, true);
+            AddExpression(evaluatorCache, template.PatientIdExpression, nameof(template.PatientIdExpression), template);
+            AddExpression(evaluatorCache, template.EncounterIdExpression, nameof(template.EncounterIdExpression), template);
+            AddExpression(evaluatorCache, template.TimestampExpression, nameof(template.TimestampExpression), template);
+            AddExpression(evaluatorCache, template.CorrelationIdExpression, nameof(template.CorrelationIdExpression), template);
 
             foreach (var value in template.Values)
             {
-                AddExpression(evaluatorCache, value.ValueExpression, value.ValueName, value.Required);
+                AddExpression(evaluatorCache, value.ValueExpression, value.ValueName, template, value.Required);
             }
 
             return new CachingExpressionEvaluatorFactory(new ReadOnlyDictionary<string, IExpressionEvaluator>(evaluatorCache));
@@ -69,6 +69,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             IDictionary<string, IExpressionEvaluator> cache,
             TemplateExpression expression,
             string expressionName,
+            LineInfo templateLineInfo,
             bool isRequired = false)
         {
             if (expression != null)
@@ -78,7 +79,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             }
             else if (isRequired)
             {
-                throw new TemplateExpressionException($"Unable to create the template; the expression for [{expressionName}] is missing");
+                throw new TemplateExpressionException($"Unable to create the template; the expression for [{expressionName}] is missing", templateLineInfo);
             }
         }
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/CalculatedFunctionValueExpression.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/CalculatedFunctionValueExpression.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class CalculatedFunctionValueExpression
+    public class CalculatedFunctionValueExpression : LineAwareJsonObject
     {
         [JsonProperty(Required = Newtonsoft.Json.Required.Always)]
         public string ValueName { get; set; }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/CodeValueFhirTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/CodeValueFhirTemplateFactory.cs
@@ -16,14 +16,15 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             EnsureArg.IsNotNull(jsonTemplate, nameof(jsonTemplate));
 
             const string targetTypeName = "CodeValueFhirTemplate";
+            var lineInfo = jsonTemplate.GetLineInfoForProperty(nameof(TemplateContainer.TemplateType));
             if (!jsonTemplate.MatchTemplateName(targetTypeName))
             {
-                throw new InvalidTemplateException($"Expected {nameof(jsonTemplate.TemplateType)} value {targetTypeName}, actual {jsonTemplate.TemplateType}.");
+                throw new InvalidTemplateException($"Expected {nameof(jsonTemplate.TemplateType)} value {targetTypeName}, actual {jsonTemplate.TemplateType}.", lineInfo);
             }
 
             if (jsonTemplate.Template?.Type != JTokenType.Object)
             {
-                throw new InvalidTemplateException($"Expected an object for the template property value for template type {targetTypeName}.");
+                throw new InvalidTemplateException($"Expected an object for the template property value for template type {targetTypeName}.", lineInfo);
             }
 
             return jsonTemplate.Template.ToValidTemplate<CodeValueFhirTemplate>();

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/CollectionContentTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/CollectionContentTemplateFactory.cs
@@ -53,18 +53,9 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                 }
                 catch (AggregateException ex)
                 {
-                    errors.Add(new TemplateError(ex.Message));
-
-                    foreach (var innerException in ex.InnerExceptions)
+                    foreach (var error in ex.ConvertExceptionToTemplateErrors())
                     {
-                        if (innerException is InvalidTemplateException ite)
-                        {
-                            errors.Add(new TemplateError(ite.Message, ite.GetLineInfo));
-                        }
-                        else
-                        {
-                            errors.Add(new TemplateError(innerException.Message));
-                        }
+                        errors.Add(error);
                     }
                 }
             }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/CollectionFhirTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/CollectionFhirTemplateFactory.cs
@@ -51,18 +51,9 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                 }
                 catch (AggregateException ex)
                 {
-                    errors.Add(new TemplateError(ex.Message));
-
-                    foreach (var innerException in ex.InnerExceptions)
+                    foreach (var error in ex.ConvertExceptionToTemplateErrors())
                     {
-                        if (innerException is InvalidTemplateException ite)
-                        {
-                            errors.Add(new TemplateError(ite.Message, ite.GetLineInfo));
-                        }
-                        else
-                        {
-                            errors.Add(new TemplateError(innerException.Message));
-                        }
+                        errors.Add(error);
                     }
                 }
             }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/CollectionFhirTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/CollectionFhirTemplateFactory.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using EnsureThat;
 using Newtonsoft.Json;
@@ -42,11 +43,27 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                 }
                 catch (InvalidTemplateException ex)
                 {
-                    errors.Add(new TemplateError(ex.Message));
+                    errors.Add(new TemplateError(ex.Message, ex.GetLineInfo));
                 }
                 catch (JsonSerializationException ex)
                 {
+                    errors.Add(new TemplateError(ex.Message, new LineInfo() { LineNumber = ex.LineNumber, LinePosition = ex.LinePosition }));
+                }
+                catch (AggregateException ex)
+                {
                     errors.Add(new TemplateError(ex.Message));
+
+                    foreach (var innerException in ex.InnerExceptions)
+                    {
+                        if (innerException is InvalidTemplateException ite)
+                        {
+                            errors.Add(new TemplateError(ite.Message, ite.GetLineInfo));
+                        }
+                        else
+                        {
+                            errors.Add(new TemplateError(innerException.Message));
+                        }
+                    }
                 }
             }
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/FhirLookupTemplate.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/FhirLookupTemplate.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         public FhirLookupTemplate RegisterTemplate(IFhirTemplate fhirTemplate)
         {
             EnsureArg.IsNotNull(fhirTemplate, nameof(fhirTemplate));
-
+            var lineInfo = fhirTemplate.GetLineInfoForProperty(nameof(fhirTemplate.TypeName));
             if (!string.IsNullOrWhiteSpace(fhirTemplate.TypeName))
             {
                 if (!_templates.ContainsKey(fhirTemplate.TypeName))
@@ -28,12 +28,12 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                 }
                 else
                 {
-                    throw new InvalidTemplateException($"Duplicate template defined for type name: '{fhirTemplate.TypeName}'");
+                    throw new InvalidTemplateException($"Duplicate template defined for type name: '{fhirTemplate.TypeName}'", lineInfo);
                 }
             }
             else
             {
-                throw new InvalidTemplateException($"Empty type name is not allowed: '{fhirTemplate.TypeName}'");
+                throw new InvalidTemplateException($"Empty type name is not allowed: '{fhirTemplate.TypeName}'", lineInfo);
             }
 
             return this;

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/FhirTemplate.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/FhirTemplate.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public abstract class FhirTemplate : IFhirTemplate
+    public abstract class FhirTemplate : LineAwareJsonObject, IFhirTemplate
     {
         [JsonProperty(Required = Required.Always)]
         public virtual string TypeName { get; set; }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IExceptionWithLineInfo.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IExceptionWithLineInfo.cs
@@ -5,15 +5,10 @@
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class LineInfo : ILineInfo
+    public interface IExceptionWithLineInfo
     {
-        public int LineNumber { get; set; } = -1;
+        LineInfo GetLineInfo { get; }
 
-        public int LinePosition { get; set; } = -1;
-
-        public bool HasLineInfo()
-        {
-            return LineNumber >= 0 && LinePosition >= 0;
-        }
+        bool HasLineInfo { get; }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IFhirTemplate.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IFhirTemplate.cs
@@ -5,7 +5,7 @@
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public interface IFhirTemplate
+    public interface IFhirTemplate : ILineAwareJsonObject
     {
         string TypeName { get; }
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/ILineAwareJsonObject.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/ILineAwareJsonObject.cs
@@ -3,12 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public interface IExceptionWithLineInfo
+    public interface ILineAwareJsonObject : ILineInfo
     {
-        ILineInfo GetLineInfo { get; }
-
-        bool HasLineInfo { get; }
+        IDictionary<string, LineInfo> LineInfoForProperties { get; set; }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/ILineInfo.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/ILineInfo.cs
@@ -5,15 +5,12 @@
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class LineInfo : ILineInfo
+    public interface ILineInfo
     {
-        public int LineNumber { get; set; } = -1;
+        public int LineNumber { get; set; }
 
-        public int LinePosition { get; set; } = -1;
+        public int LinePosition { get; set; }
 
-        public bool HasLineInfo()
-        {
-            return LineNumber >= 0 && LinePosition >= 0;
-        }
+        public bool HasLineInfo();
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IncompatibleDataException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IncompatibleDataException.cs
@@ -12,19 +12,19 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 {
     public class IncompatibleDataException : IomtTelemetryFormattableException, IExceptionWithLineInfo
     {
-        private readonly LineInfo _lineInfo;
+        private readonly ILineInfo _lineInfo;
 
         public IncompatibleDataException()
             : this(null, new LineInfo())
         {
         }
 
-        public IncompatibleDataException(string message, LineInfo lineInfo)
+        public IncompatibleDataException(string message, ILineInfo lineInfo)
             : this(message, null, lineInfo)
         {
         }
 
-        public IncompatibleDataException(string message, Exception innerException, LineInfo lineInfo)
+        public IncompatibleDataException(string message, Exception innerException, ILineInfo lineInfo)
             : base(message, innerException)
         {
             _lineInfo = EnsureArg.IsNotNull(lineInfo, nameof(lineInfo));
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             }
         }
 
-        public LineInfo GetLineInfo => _lineInfo;
+        public ILineInfo GetLineInfo => _lineInfo;
 
         public bool HasLineInfo => _lineInfo.HasLineInfo();
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IncompatibleDataException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IncompatibleDataException.cs
@@ -4,26 +4,30 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using EnsureThat;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class IncompatibleDataException : IomtTelemetryFormattableException
+    public class IncompatibleDataException : IomtTelemetryFormattableException, IExceptionWithLineInfo
     {
+        private readonly LineInfo _lineInfo;
+
         public IncompatibleDataException()
-            : base()
+            : this(null, new LineInfo())
         {
         }
 
-        public IncompatibleDataException(string message)
-            : base(message)
+        public IncompatibleDataException(string message, LineInfo lineInfo)
+            : this(message, null, lineInfo)
         {
         }
 
-        public IncompatibleDataException(string message, Exception innerException)
+        public IncompatibleDataException(string message, Exception innerException, LineInfo lineInfo)
             : base(message, innerException)
         {
+            _lineInfo = EnsureArg.IsNotNull(lineInfo, nameof(lineInfo));
         }
 
         public override string ErrName => nameof(IncompatibleDataException);
@@ -33,5 +37,17 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         public override string ErrSource => nameof(ErrorSource.User);
 
         public override string Operation => ConnectorOperation.Normalization;
+
+        public override string Message
+        {
+            get
+            {
+                return _lineInfo.HasLineInfo() ? $"Line Number: {_lineInfo.LineNumber}, Position: {_lineInfo.LinePosition}. {base.Message}" : base.Message;
+            }
+        }
+
+        public LineInfo GetLineInfo => _lineInfo;
+
+        public bool HasLineInfo => _lineInfo.HasLineInfo();
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/InvalidTemplateException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/InvalidTemplateException.cs
@@ -4,23 +4,40 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using EnsureThat;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class InvalidTemplateException : Exception
+    public class InvalidTemplateException : Exception, IExceptionWithLineInfo
     {
-        public InvalidTemplateException(string message)
-            : base(message)
+        private readonly ILineInfo _lineInfo;
+
+        public InvalidTemplateException(string message, ILineInfo lineInfo)
+            : this(message, null, lineInfo)
         {
         }
 
-        public InvalidTemplateException(string message, Exception innerException)
+        public InvalidTemplateException(string message, Exception innerException, ILineInfo lineInfo)
             : base(message, innerException)
         {
+            _lineInfo = EnsureArg.IsNotNull(lineInfo, nameof(lineInfo));
         }
 
         public InvalidTemplateException()
+            : this(null, new LineInfo())
         {
         }
+
+        public override string Message
+        {
+            get
+            {
+                return _lineInfo.HasLineInfo() ? $"Line Number: {_lineInfo.LineNumber}, Position: {_lineInfo.LinePosition}. {base.Message}" : base.Message;
+            }
+        }
+
+        public ILineInfo GetLineInfo => _lineInfo;
+
+        public bool HasLineInfo => _lineInfo.HasLineInfo();
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotCentralJsonPathContentTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotCentralJsonPathContentTemplateFactory.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
-using Microsoft.Health.Fhir.Ingest.Template;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
@@ -24,7 +23,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
             if (jsonTemplate.Template?.Type != JTokenType.Object)
             {
-                throw new InvalidTemplateException($"Expected an object for the template property value for template type {targetTypeName}.");
+                throw new InvalidTemplateException($"Expected an object for the template property value for template type {targetTypeName}.", jsonTemplate.GetLineInfoForProperty(nameof(jsonTemplate.Template)));
             }
 
             var facade = new JsonPathCalculatedFunctionContentTemplateAdapter<IotCentralJsonPathContentTemplate>(

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotJsonPathContentTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/IotJsonPathContentTemplateFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
             if (jsonTemplate.Template?.Type != JTokenType.Object)
             {
-                throw new InvalidTemplateException($"Expected an object for the template property value for template type {targetTypeName}.");
+                throw new InvalidTemplateException($"Expected an object for the template property value for template type {targetTypeName}.", jsonTemplate.GetLineInfoForProperty(nameof(jsonTemplate.Template)));
             }
 
             return new IotJsonPathLegacyMeasurementExtractor(jsonTemplate.Template.ToValidTemplate<IotJsonPathContentTemplate>());

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JmesPathExpressionEvaluator.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JmesPathExpressionEvaluator.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Health.Fhir.Ingest.Template
     public class JmesPathExpressionEvaluator : IExpressionEvaluator
     {
         private readonly JmesPath.Expression _jmespathExpression;
-        private readonly LineInfo _lineInfo;
+        private readonly ILineInfo _lineInfo;
 
-        public JmesPathExpressionEvaluator(JmesPath jmesPath, string expression, LineInfo lineInfo)
+        public JmesPathExpressionEvaluator(JmesPath jmesPath, string expression, ILineInfo lineInfo)
         {
             EnsureArg.IsNotNull(jmesPath, nameof(jmesPath));
             EnsureArg.IsNotNullOrWhiteSpace(expression, nameof(expression));

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JmesPathExpressionEvaluator.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JmesPathExpressionEvaluator.cs
@@ -13,12 +13,14 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 {
     public class JmesPathExpressionEvaluator : IExpressionEvaluator
     {
-        private JmesPath.Expression _jmespathExpression;
+        private readonly JmesPath.Expression _jmespathExpression;
+        private readonly LineInfo _lineInfo;
 
-        public JmesPathExpressionEvaluator(JmesPath jmesPath, string expression)
+        public JmesPathExpressionEvaluator(JmesPath jmesPath, string expression, LineInfo lineInfo)
         {
             EnsureArg.IsNotNull(jmesPath, nameof(jmesPath));
             EnsureArg.IsNotNullOrWhiteSpace(expression, nameof(expression));
+            _lineInfo = EnsureArg.IsNotNull(lineInfo, nameof(lineInfo));
 
             try
             {
@@ -26,7 +28,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             }
             catch (Exception e)
             {
-                throw new TemplateExpressionException($"The following JmesPath expression could not be parsed: {expression}. Cause: {e.Message}", e);
+                throw new TemplateExpressionException($"The following JmesPath expression could not be parsed: {expression}. Cause: {e.Message}", e, _lineInfo);
             }
         }
 
@@ -37,7 +39,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
             if (jmesPathArgument.IsProjection && jmesPathArgument.Projection.Length > 1)
             {
-                throw new TemplateExpressionException($"Multiple tokens were returned using expression ${_jmespathExpression}");
+                throw new TemplateExpressionException($"Multiple tokens were returned using expression ${_jmespathExpression}", _lineInfo);
             }
 
             var resultAsToken = jmesPathArgument.AsJToken();

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JmesPathExpressionEvaluator.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JmesPathExpressionEvaluator.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             }
             catch (Exception e)
             {
-                throw new TemplateExpressionException($"The following JmesPath expression could not be parsed: {expression}", e);
+                throw new TemplateExpressionException($"The following JmesPath expression could not be parsed: {expression}. Cause: {e.Message}", e);
             }
         }
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathCalculatedFunctionContentTemplateAdapter.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathCalculatedFunctionContentTemplateAdapter.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using System.Linq;
 using EnsureThat;
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathCalculatedFunctionContentTemplateAdapter.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathCalculatedFunctionContentTemplateAdapter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
         public TTemplate InnerTemplate { get; private set; }
 
-        private TemplateExpression CreateExpression(string value, LineInfo lineAwareJsonObject)
+        private TemplateExpression CreateExpression(string value, ILineInfo lineAwareJsonObject)
         {
             if (!string.IsNullOrWhiteSpace(value))
             {

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathContentTemplate.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathContentTemplate.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class JsonPathContentTemplate
+    public class JsonPathContentTemplate : LineAwareJsonObject
     {
         [JsonProperty(Required = Required.Always)]
         public virtual string TypeName { get; set; }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathContentTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathContentTemplateFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
             if (jsonTemplate.Template?.Type != JTokenType.Object)
             {
-                throw new InvalidTemplateException($"Expected an object for the template property value for template type {targetTypeName}.");
+                throw new InvalidTemplateException($"Expected an object for the template property value for template type {targetTypeName}.", jsonTemplate.GetLineInfoForProperty(nameof(jsonTemplate.Template)));
             }
 
             var facade = new JsonPathCalculatedFunctionContentTemplateAdapter<JsonPathContentTemplate>(

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathExpressionEvaluator.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathExpressionEvaluator.cs
@@ -13,10 +13,12 @@ namespace Microsoft.Health.Fhir.Ingest.Template
     public class JsonPathExpressionEvaluator : IExpressionEvaluator
     {
         private readonly string _jsonPathExpression;
+        private readonly LineInfo _lineInfo;
 
-        public JsonPathExpressionEvaluator(string jsonPathExpression)
+        public JsonPathExpressionEvaluator(string jsonPathExpression, LineInfo lineInfo)
         {
             _jsonPathExpression = EnsureArg.IsNotNullOrWhiteSpace(jsonPathExpression, nameof(jsonPathExpression));
+            _lineInfo = EnsureArg.IsNotNull(lineInfo, nameof(lineInfo));
         }
 
         public JToken SelectToken(JToken data)
@@ -28,7 +30,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             }
             catch (JsonException e)
             {
-                throw new TemplateExpressionException($"Unable to retrieve JsonToken using expression {_jsonPathExpression}", e);
+                throw new TemplateExpressionException($"Unable to retrieve JsonToken using expression {_jsonPathExpression}", e, _lineInfo);
             }
         }
 
@@ -41,7 +43,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             }
             catch (JsonException e)
             {
-                throw new TemplateExpressionException($"Unable to retrieve JsonTokens using expression {_jsonPathExpression}", e);
+                throw new TemplateExpressionException($"Unable to retrieve JsonTokens using expression {_jsonPathExpression}", e, _lineInfo);
             }
         }
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathExpressionEvaluator.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathExpressionEvaluator.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Health.Fhir.Ingest.Template
     public class JsonPathExpressionEvaluator : IExpressionEvaluator
     {
         private readonly string _jsonPathExpression;
-        private readonly LineInfo _lineInfo;
+        private readonly ILineInfo _lineInfo;
 
-        public JsonPathExpressionEvaluator(string jsonPathExpression, LineInfo lineInfo)
+        public JsonPathExpressionEvaluator(string jsonPathExpression, ILineInfo lineInfo)
         {
             _jsonPathExpression = EnsureArg.IsNotNullOrWhiteSpace(jsonPathExpression, nameof(jsonPathExpression));
             _lineInfo = EnsureArg.IsNotNull(lineInfo, nameof(lineInfo));

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathExpressionEvaluatorFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathExpressionEvaluatorFactory.cs
@@ -17,12 +17,14 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             EnsureArg.IsNotNullOrWhiteSpace(expression?.Value, nameof(expression.Value));
 
             var expressionLanguage = expression.Language ?? TemplateExpressionLanguage.JsonPath;
+            var languageLineInfo = expression.GetLineInfoForProperty(nameof(TemplateExpression.Language)) ?? expression;
+            var valueLineInfo = expression.GetLineInfoForProperty(nameof(TemplateExpression.Value)) ?? expression;
             if (expressionLanguage != TemplateExpressionLanguage.JsonPath)
             {
-                throw new TemplateExpressionException($"Unsupported Expression Language {expressionLanguage}. Only JsonPath is supported.");
+                throw new TemplateExpressionException($"Unsupported Expression Language {expressionLanguage}. Only JsonPath is supported.", languageLineInfo);
             }
 
-            return new JsonPathExpressionEvaluator(expression.Value);
+            return new JsonPathExpressionEvaluator(expression.Value, valueLineInfo);
         }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathValueExpression.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathValueExpression.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class JsonPathValueExpression
+    public class JsonPathValueExpression : LineAwareJsonObject
     {
         [JsonProperty(Required = Newtonsoft.Json.Required.Always)]
         public string ValueName { get; set; }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineAwareJsonObject.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineAwareJsonObject.cs
@@ -1,0 +1,17 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public class LineAwareJsonObject : LineInfo
+    {
+        [JsonIgnore]
+        public IDictionary<string, LineInfo> LineInfoForProperties { get; set; } = new Dictionary<string, LineInfo>(StringComparer.InvariantCultureIgnoreCase);
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineAwareJsonObject.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineAwareJsonObject.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class LineAwareJsonObject : LineInfo
+    public class LineAwareJsonObject : LineInfo, ILineAwareJsonObject
     {
         [JsonIgnore]
         public IDictionary<string, LineInfo> LineInfoForProperties { get; set; } = new Dictionary<string, LineInfo>(StringComparer.InvariantCultureIgnoreCase);

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineAwareJsonObjectExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineAwareJsonObjectExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 {
     public static class LineAwareJsonObjectExtensions
     {
-        public static LineInfo GetLineInfoForProperty(this LineAwareJsonObject lineAwareJsonObject, string property)
+        public static ILineInfo GetLineInfoForProperty(this ILineAwareJsonObject lineAwareJsonObject, string property, bool returnParentIfNotPresent = true)
         {
             EnsureArg.IsNotNull(lineAwareJsonObject, nameof(lineAwareJsonObject));
             EnsureArg.IsNotNullOrWhiteSpace(property, nameof(property));
@@ -20,6 +20,11 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                 lineAwareJsonObject.LineInfoForProperties.TryGetValue(property, out var lineInfo))
             {
                 return lineInfo;
+            }
+
+            if (returnParentIfNotPresent)
+            {
+                return lineAwareJsonObject;
             }
 
             return null;

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineAwareJsonObjectExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineAwareJsonObjectExtensions.cs
@@ -1,0 +1,52 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public static class LineAwareJsonObjectExtensions
+    {
+        public static LineInfo GetLineInfoForProperty(this LineAwareJsonObject lineAwareJsonObject, string property)
+        {
+            EnsureArg.IsNotNull(lineAwareJsonObject, nameof(lineAwareJsonObject));
+            EnsureArg.IsNotNullOrWhiteSpace(property, nameof(property));
+
+            if (lineAwareJsonObject.LineInfoForProperties != null &&
+                lineAwareJsonObject.LineInfoForProperties.TryGetValue(property, out var lineInfo))
+            {
+                return lineInfo;
+            }
+
+            return null;
+        }
+
+        public static T SetLineInfoProperties<T>(this T lineAwareJsonObject, JObject sourceObject)
+            where T : LineAwareJsonObject
+        {
+            EnsureArg.IsNotNull(lineAwareJsonObject, nameof(lineAwareJsonObject));
+            EnsureArg.IsNotNull(sourceObject, nameof(sourceObject));
+
+            foreach (var property in sourceObject.Properties())
+            {
+                if (property is IJsonLineInfo propertyLineInfo)
+                {
+                    if (propertyLineInfo != null)
+                    {
+                        lineAwareJsonObject.LineInfoForProperties[property.Name] = new LineInfo
+                        {
+                            LineNumber = propertyLineInfo.LineNumber,
+                            LinePosition = propertyLineInfo.LinePosition,
+                        };
+                    }
+                }
+            }
+
+            return lineAwareJsonObject;
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineInfo.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineInfo.cs
@@ -1,0 +1,23 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public class LineInfo : IJsonLineInfo
+    {
+        [JsonIgnore]
+        public int LineNumber { get; set; }
+
+        [JsonIgnore]
+        public int LinePosition { get; set; }
+
+        public bool HasLineInfo()
+        {
+            return true;
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineNumberJsonConverter.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineNumberJsonConverter.cs
@@ -35,8 +35,6 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                 var lineInfoObject = Activator.CreateInstance(objectType) as LineInfo;
                 var rawLineInfoObject = JObject.Load(reader, new JsonLoadSettings { LineInfoHandling = LineInfoHandling.Load });
 
-                // var lineInfoObject = rawLineInfoObject.ToObject(objectType, serializer) as LineInfo;
-
                 serializer.Populate(rawLineInfoObject.CreateReader(), lineInfoObject);
 
                 lineInfoObject.LineNumber = lineNumber;

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineNumberJsonConverter.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineNumberJsonConverter.cs
@@ -1,0 +1,61 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public class LineNumberJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType != null && typeof(LineInfo).IsAssignableFrom(objectType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType != JsonToken.Null)
+            {
+                var lineNumber = 0;
+                var linePosition = 0;
+
+                if (reader is IJsonLineInfo lineInfoReader && lineInfoReader != null)
+                {
+                    if (lineInfoReader.HasLineInfo())
+                    {
+                        lineNumber = lineInfoReader.LineNumber;
+                        linePosition = lineInfoReader.LinePosition;
+                    }
+                }
+
+                var lineInfoObject = Activator.CreateInstance(objectType) as LineInfo;
+                var rawLineInfoObject = JObject.Load(reader, new JsonLoadSettings { LineInfoHandling = LineInfoHandling.Load });
+
+                // var lineInfoObject = rawLineInfoObject.ToObject(objectType, serializer) as LineInfo;
+
+                serializer.Populate(rawLineInfoObject.CreateReader(), lineInfoObject);
+
+                lineInfoObject.LineNumber = lineNumber;
+                lineInfoObject.LinePosition = linePosition;
+
+                if (lineInfoObject is LineAwareJsonObject lineAwareJsonObject)
+                {
+                    lineAwareJsonObject.SetLineInfoProperties(rawLineInfoObject);
+                }
+
+                return lineInfoObject;
+            }
+
+            return null;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
                 if (isRequired)
                 {
-                    var lineInfo = expressions.First(e => e != null);
+                    var lineInfo = expressions.FirstOrDefault(e => e != null) ?? new LineInfo();
 
                     if (exceptions.Count > 0)
                     {

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateContainer.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateContainer.cs
@@ -10,26 +10,17 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
     [JsonConverter(typeof(TemplateContainerJsonConverter))]
-    public class TemplateContainer : IJsonLineInfo
+    public class TemplateContainer
     {
         public string TemplateType { get; set; }
 
         public JToken Template { get; set; }
-
-        public int LineNumber { get; set; }
-
-        public int LinePosition { get; set; }
 
         public bool MatchTemplateName(string expected)
         {
             const string TemplateSuffix = "Template";
             return StringComparer.InvariantCultureIgnoreCase.Equals(expected, TemplateType)
                 || StringComparer.InvariantCultureIgnoreCase.Equals(expected, TemplateType + TemplateSuffix);
-        }
-
-        bool IJsonLineInfo.HasLineInfo()
-        {
-            return true;
         }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateContainer.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateContainer.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
     [JsonConverter(typeof(TemplateContainerJsonConverter))]
-    public class TemplateContainer
+    public class TemplateContainer : LineAwareJsonObject
     {
         public string TemplateType { get; set; }
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateContainer.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateContainer.cs
@@ -4,21 +4,32 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class TemplateContainer
+    [JsonConverter(typeof(TemplateContainerJsonConverter))]
+    public class TemplateContainer : IJsonLineInfo
     {
         public string TemplateType { get; set; }
 
         public JToken Template { get; set; }
+
+        public int LineNumber { get; set; }
+
+        public int LinePosition { get; set; }
 
         public bool MatchTemplateName(string expected)
         {
             const string TemplateSuffix = "Template";
             return StringComparer.InvariantCultureIgnoreCase.Equals(expected, TemplateType)
                 || StringComparer.InvariantCultureIgnoreCase.Equals(expected, TemplateType + TemplateSuffix);
+        }
+
+        bool IJsonLineInfo.HasLineInfo()
+        {
+            return true;
         }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateContainerJsonConverter.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateContainerJsonConverter.cs
@@ -27,6 +27,18 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         {
             if (reader.TokenType != JsonToken.Null)
             {
+                var lineNumber = 0;
+                var linePosition = 0;
+
+                if (reader is IJsonLineInfo lineInfoReader && lineInfoReader != null)
+                {
+                    if (lineInfoReader.HasLineInfo())
+                    {
+                        lineNumber = lineInfoReader.LineNumber;
+                        linePosition = lineInfoReader.LinePosition;
+                    }
+                }
+
                 var templateContainerObject = JObject.Load(reader);
                 var innerTemplate = templateContainerObject.GetValue("template", StringComparison.InvariantCultureIgnoreCase);
 
@@ -38,6 +50,11 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                  * information
                  */
                 templateContainer.Template = innerTemplate;
+
+                // Set line number details
+                templateContainer.LineNumber = lineNumber;
+                templateContainer.LinePosition = linePosition;
+                templateContainer.SetLineInfoProperties(templateContainerObject);
 
                 return templateContainer;
             }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateContainerJsonConverter.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateContainerJsonConverter.cs
@@ -1,0 +1,57 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    /// <summary>
+    /// A JsonConverter to create a TemplateContainer and preserve line details inside of the inner Template.
+    ///
+    /// Normal deserialization (i.e. JsonConvert.Deserialize) correctly creates a TemplateContainer but
+    /// the inner 'Template' JToken does not preserve line numbers. This class manually creates the TemplateContainer
+    /// and insures that line numbers are preserved.
+    /// </summary>
+    public class TemplateContainerJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(TemplateContainer) == objectType;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType != JsonToken.Null)
+            {
+                var templateContainerObject = JObject.Load(reader);
+                var innerTemplate = templateContainerObject.GetValue("template", StringComparison.InvariantCultureIgnoreCase);
+
+                var templateContainer = new TemplateContainer();
+                serializer.Populate(templateContainerObject.CreateReader(), templateContainer);
+                /**
+                 * At this point the TemplateConainer is fully populated but the inner 'Template' contains no line numbers.
+                 * Replace the 'Template' property with that of the templateContainerObject, which will contain line
+                 * information
+                 */
+                templateContainer.Template = innerTemplate;
+
+                return templateContainer;
+            }
+
+            return null;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value != null)
+            {
+                var templateContainerObject = JObject.FromObject(value, serializer);
+                templateContainerObject.WriteTo(writer);
+            }
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateError.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateError.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using EnsureThat;
+
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
     public class TemplateError
@@ -10,8 +12,17 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         public TemplateError(string message)
         {
             Message = message;
+            LineInfo = new LineInfo();
+        }
+
+        public TemplateError(string message, ILineInfo lineInfo)
+        {
+            Message = message;
+            LineInfo = EnsureArg.IsNotNull(lineInfo, nameof(lineInfo));
         }
 
         public string Message { get; }
+
+        public ILineInfo LineInfo { get; }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateErrorExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateErrorExtensions.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using EnsureThat;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public static class TemplateErrorExtensions
+    {
+        public static IEnumerable<TemplateError> ConvertExceptionToTemplateErrors(this AggregateException exception)
+        {
+            EnsureArg.IsNotNull(exception, nameof(exception));
+
+            yield return new TemplateError(exception.Message);
+
+            foreach (var innerException in exception.InnerExceptions)
+            {
+                if (innerException is InvalidTemplateException ite)
+                {
+                    yield return new TemplateError(ite.Message, ite.GetLineInfo);
+                }
+                else
+                {
+                    yield return new TemplateError(innerException.Message);
+                }
+            }
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExpression.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExpression.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class TemplateExpression
+    public class TemplateExpression : LineAwareJsonObject
     {
         public TemplateExpression()
         {

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExpressionEvaluatorFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExpressionEvaluatorFactory.cs
@@ -27,11 +27,12 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             EnsureArg.IsNotNullOrWhiteSpace(expression?.Value, nameof(expression.Value));
             EnsureArg.IsNotNull(expression?.Language, nameof(expression.Language));
 
+            var lineInfo = expression.GetLineInfoForProperty("value") ?? expression;
             return expression.Language switch
             {
-                TemplateExpressionLanguage.JsonPath => new JsonPathExpressionEvaluator(expression.Value),
-                TemplateExpressionLanguage.JmesPath => new JmesPathExpressionEvaluator(_jmesPath, expression.Value),
-                _ => throw new TemplateExpressionException($"Unsupported Expression Language: {expression?.Language}")
+                TemplateExpressionLanguage.JsonPath => new JsonPathExpressionEvaluator(expression.Value, lineInfo),
+                TemplateExpressionLanguage.JmesPath => new JmesPathExpressionEvaluator(_jmesPath, expression.Value, lineInfo),
+                _ => throw new TemplateExpressionException($"Unsupported Expression Language: {expression?.Language}", lineInfo)
             };
         }
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExpressionException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExpressionException.cs
@@ -4,41 +4,23 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using EnsureThat;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class TemplateExpressionException : InvalidTemplateException, IExceptionWithLineInfo
+    public class TemplateExpressionException : InvalidTemplateException
     {
-        private readonly LineInfo _lineInfo;
-
-        public TemplateExpressionException(string message, LineInfo lineInfo)
-             : this(message, null, lineInfo)
+        public TemplateExpressionException(string message, ILineInfo lineInfo)
+             : base(message, lineInfo)
         {
         }
 
-        public TemplateExpressionException(string message, Exception innerException, LineInfo lineInfo)
-            : base(message, innerException)
+        public TemplateExpressionException(string message, Exception innerException, ILineInfo lineInfo)
+            : base(message, innerException, lineInfo)
         {
-            EnsureArg.IsNotNull(lineInfo, nameof(lineInfo));
-            _lineInfo = lineInfo;
         }
 
         public TemplateExpressionException()
-            : this(null, new LineInfo())
         {
         }
-
-        public override string Message
-        {
-            get
-            {
-                return _lineInfo.HasLineInfo() ? $"Line Number: {_lineInfo.LineNumber}, Position: {_lineInfo.LinePosition}. {base.Message}" : base.Message;
-            }
-        }
-
-        public LineInfo GetLineInfo => _lineInfo;
-
-        public bool HasLineInfo => _lineInfo.HasLineInfo();
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExpressionException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExpressionException.cs
@@ -4,23 +4,41 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using EnsureThat;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class TemplateExpressionException : InvalidTemplateException
+    public class TemplateExpressionException : InvalidTemplateException, IExceptionWithLineInfo
     {
-        public TemplateExpressionException(string message)
-            : base(message)
+        private readonly LineInfo _lineInfo;
+
+        public TemplateExpressionException(string message, LineInfo lineInfo)
+             : this(message, null, lineInfo)
         {
         }
 
-        public TemplateExpressionException(string message, Exception innerException)
+        public TemplateExpressionException(string message, Exception innerException, LineInfo lineInfo)
             : base(message, innerException)
         {
+            EnsureArg.IsNotNull(lineInfo, nameof(lineInfo));
+            _lineInfo = lineInfo;
         }
 
         public TemplateExpressionException()
+            : this(null, new LineInfo())
         {
         }
+
+        public override string Message
+        {
+            get
+            {
+                return _lineInfo.HasLineInfo() ? $"Line Number: {_lineInfo.LineNumber}, Position: {_lineInfo.LinePosition}. {base.Message}" : base.Message;
+            }
+        }
+
+        public LineInfo GetLineInfo => _lineInfo;
+
+        public bool HasLineInfo => _lineInfo.HasLineInfo();
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExtensions.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
             var jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
             {
+                Converters = new List<JsonConverter>() { new LineNumberJsonConverter() },
                 MissingMemberHandling = MissingMemberHandling.Error,
                 Error = (sender, args) =>
                 {

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateExtensions.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             if (errors.Any())
             {
                 string errorMessage = string.Join(string.Empty, errors.Select(e => FormatErrorMessage(e.Message)));
+
+                // TODO Store message, lineinfo for each error inside of the exception.
                 throw new InvalidTemplateException($"Failed to deserialize the {typeof(T).Name} content: {errorMessage}");
             }
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateNotFoundHandler.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateNotFoundHandler.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Health.Fhir.Ingest.Template
     internal class TemplateNotFoundHandler<TTemplate> : IResponsibilityHandler<TemplateContainer, TTemplate>
             where TTemplate : class
     {
-        public TTemplate Evaluate(TemplateContainer request) => throw new InvalidTemplateException($"No match found for template type {request.TemplateType}.");
+        public TTemplate Evaluate(TemplateContainer request) => throw new InvalidTemplateException($"No match found for template type {request.TemplateType}.", request.GetLineInfoForProperty(nameof(TemplateContainer.Template), true));
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Extensions/IResultExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Extensions/IResultExtensions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Health.Fhir.Ingest.Validation.Extensions
             EnsureArg.IsNotNull(validationResult, nameof(validationResult));
             EnsureArg.IsNotNull(exception, nameof(exception));
 
+            // Collect messages from inner exceptions as well
             validationResult.Exceptions.Add(new ValidationError(exception.Message, category));
         }
 

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CodeValueFhirTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CodeValueFhirTemplateFactoryTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using Microsoft.Health.Tests.Common;
 using Newtonsoft.Json;
 using Xunit;
@@ -288,9 +289,15 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
             var factory = new CodeValueFhirTemplateFactory();
 
-            var ex = Assert.Throws<InvalidTemplateException>(() => factory.Create(templateContainer));
+            var ex = Assert.Throws<AggregateException>(() => factory.Create(templateContainer));
             Assert.NotNull(ex);
-            Assert.Contains("TypeName", ex.Message);
+            Assert.Collection(
+                ex.InnerExceptions,
+                p =>
+                {
+                    Assert.IsType<InvalidTemplateException>(p);
+                    Assert.Contains("TypeName", ex.Message);
+                });
         }
 
         [Theory]
@@ -301,9 +308,15 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
             var factory = new CodeValueFhirTemplateFactory();
 
-            var ex = Assert.Throws<InvalidTemplateException>(() => factory.Create(templateContainer));
+            var ex = Assert.Throws<AggregateException>(() => factory.Create(templateContainer));
             Assert.NotNull(ex);
-            Assert.Contains("Codes", ex.Message);
+            Assert.Collection(
+                ex.InnerExceptions,
+                p =>
+                {
+                    Assert.IsType<InvalidTemplateException>(p);
+                    Assert.Contains("Codes", ex.Message);
+                });
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CollectionContentTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/CollectionContentTemplateFactoryTests.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             CheckLineInfo(calcFunctionValueExpression.GetLineInfoForProperty(nameof(CalculatedFunctionValueExpression.ValueName)), 61);
         }
 
-        private void CheckLineInfo(LineInfo lineInfo, int expectedLine, int expectedPos = -1)
+        private void CheckLineInfo(ILineInfo lineInfo, int expectedLine, int expectedPos = -1)
         {
             Assert.NotNull(lineInfo);
             Assert.True(lineInfo.HasLineInfo());

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/IotCentralJsonPathContentTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/IotCentralJsonPathContentTemplateFactoryTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using Microsoft.Health.Tests.Common;
 using Newtonsoft.Json;
 using Xunit;
@@ -92,10 +93,20 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
             var factory = new IotCentralJsonPathContentTemplateFactory();
 
-            var ex = Assert.Throws<InvalidTemplateException>(() => factory.Create(templateContainer));
+            var ex = Assert.Throws<AggregateException>(() => factory.Create(templateContainer));
             Assert.NotNull(ex);
-            Assert.Contains("TypeName", ex.Message);
-            Assert.Contains("TypeMatchExpression", ex.Message);
+            Assert.Collection(
+                ex.InnerExceptions,
+                p =>
+                {
+                    Assert.IsType<InvalidTemplateException>(p);
+                    Assert.Contains("TypeName", ex.Message);
+                },
+                p =>
+                {
+                    Assert.IsType<InvalidTemplateException>(p);
+                    Assert.Contains("TypeMatchExpression", ex.Message);
+                });
         }
 
         [Theory]
@@ -105,9 +116,15 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
             var factory = new IotCentralJsonPathContentTemplateFactory();
 
-            var ex = Assert.Throws<InvalidTemplateException>(() => factory.Create(templateContainer));
+            var ex = Assert.Throws<AggregateException>(() => factory.Create(templateContainer));
             Assert.NotNull(ex);
-            Assert.Contains("ValueName", ex.Message);
+            Assert.Collection(
+                ex.InnerExceptions,
+                p =>
+                {
+                    Assert.IsType<InvalidTemplateException>(p);
+                    Assert.Contains("ValueName", ex.Message);
+                });
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/IotCentralJsonPathContentTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/IotCentralJsonPathContentTemplateFactoryTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Tests.Common;
 using Newtonsoft.Json;
 using Xunit;

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/IotJsonPathContentTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/IotJsonPathContentTemplateFactoryTests.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Microsoft.Health.Fhir.Ingest.Template;
+using System;
 using Microsoft.Health.Tests.Common;
 using Newtonsoft.Json;
 using Xunit;
@@ -77,10 +77,20 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
             var factory = new IotJsonPathContentTemplateFactory();
 
-            var ex = Assert.Throws<InvalidTemplateException>(() => factory.Create(templateContainer));
+            var ex = Assert.Throws<AggregateException>(() => factory.Create(templateContainer));
             Assert.NotNull(ex);
-            Assert.Contains("TypeName", ex.Message);
-            Assert.Contains("TypeMatchExpression", ex.Message);
+            Assert.Collection(
+                ex.InnerExceptions,
+                p =>
+                {
+                    Assert.IsType<InvalidTemplateException>(p);
+                    Assert.Contains("TypeName", ex.Message);
+                },
+                p =>
+                {
+                    Assert.IsType<InvalidTemplateException>(p);
+                    Assert.Contains("TypeMatchExpression", ex.Message);
+                });
         }
 
         [Theory]
@@ -90,9 +100,15 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json);
             var factory = new IotJsonPathContentTemplateFactory();
 
-            var ex = Assert.Throws<InvalidTemplateException>(() => factory.Create(templateContainer));
+            var ex = Assert.Throws<AggregateException>(() => factory.Create(templateContainer));
             Assert.NotNull(ex);
-            Assert.Contains("ValueName", ex.Message);
+            Assert.Collection(
+                ex.InnerExceptions,
+                p =>
+                {
+                    Assert.IsType<InvalidTemplateException>(p);
+                    Assert.Contains("ValueName", ex.Message);
+                });
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/JsonContentTemplateFactoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/JsonContentTemplateFactoryTests.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Microsoft.Health.Fhir.Ingest.Template;
+using System;
 using Microsoft.Health.Tests.Common;
 using Newtonsoft.Json;
 using Xunit;
@@ -80,10 +80,20 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
             var factory = new JsonPathContentTemplateFactory();
 
-            var ex = Assert.Throws<InvalidTemplateException>(() => factory.Create(templateContainer));
+            var ex = Assert.Throws<AggregateException>(() => factory.Create(templateContainer));
             Assert.NotNull(ex);
-            Assert.Contains("DeviceIdExpression", ex.Message);
-            Assert.Contains("TimestampExpression", ex.Message);
+            Assert.Collection(
+                ex.InnerExceptions,
+                p =>
+                {
+                    Assert.IsType<InvalidTemplateException>(p);
+                    Assert.Contains("DeviceIdExpression", ex.Message);
+                },
+                p =>
+                {
+                    Assert.IsType<InvalidTemplateException>(p);
+                    Assert.Contains("TimestampExpression", ex.Message);
+                });
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/JsonPathExpressionEvaluatorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/JsonPathExpressionEvaluatorTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Microsoft.Health.Fhir.Ingest.Template;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -16,9 +15,9 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 
         public JsonPathExpressionEvaluatorTests()
         {
-            _singleValueExpressionEvaluator = new JsonPathExpressionEvaluator("testProperty");
+            _singleValueExpressionEvaluator = new JsonPathExpressionEvaluator("testProperty", new LineInfo());
 
-            _projectedExpressionEvaluator = new JsonPathExpressionEvaluator("property[*].name");
+            _projectedExpressionEvaluator = new JsonPathExpressionEvaluator("property[*].name", new LineInfo());
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TemplateExpressionExceptionTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TemplateExpressionExceptionTests.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public class TemplateExpressionExceptionTests
+    {
+        [Fact]
+        public void When_ExceptionIsCreatedWithNoParams_AppropriateMessageIsProduced()
+        {
+            var exception = new TemplateExpressionException();
+            Assert.NotEmpty(exception.Message);
+        }
+
+        [Fact]
+        public void When_ExceptionIsCreatedWithEmptyLineInfo_AppropriateMessageIsProduced()
+        {
+            var exception = new TemplateExpressionException("test", new LineInfo());
+            Assert.Equal("test", exception.Message);
+        }
+
+        [Fact]
+        public void When_ExceptionIsCreatedWithLineInfo_AppropriateMessageIsProduced()
+        {
+            var exception = new TemplateExpressionException("test", new LineInfo() { LineNumber = 1, LinePosition = 1, });
+            Assert.Equal("Line Number: 1, Position: 1. test", exception.Message);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TemplateExtensionsTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TemplateExtensionsTests.cs
@@ -1,0 +1,60 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Tests.Common;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Ingest.Template
+{
+    public class TemplateExtensionsTests
+    {
+        [Theory]
+        [FileData(@"TestInput/data_CalculatedFunctionContentTemplateValid.json")]
+        public void When_ValidateCalculatedContentTemplateContent_Is_ConvertedToTemplateObject_LineNumbersAreAdded(string json)
+        {
+            var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json, new TemplateContainerJsonConverter());
+            var template = templateContainer.Template.ToValidTemplate<CalculatedFunctionContentTemplate>();
+            Assert.NotNull(template);
+            Assert.True(template.HasLineInfo());
+            Assert.Equal(4, template.GetLineInfoForProperty(nameof(template.TypeName)).LineNumber);
+        }
+
+        [Theory]
+        [FileData(@"TestInput/data_CalculatedFunctionContentTemplateValidInvalidAndMissingMembers.json")]
+        public void When_InValidateCalculatedContentTemplateContent_Is_ConvertedToTemplateObject_AggregateExceptionIsThrown(string json)
+        {
+            var templateContainer = JsonConvert.DeserializeObject<TemplateContainer>(json, new TemplateContainerJsonConverter());
+            var exception = Assert.Throws<AggregateException>(() => templateContainer.Template.ToValidTemplate<CalculatedFunctionContentTemplate>());
+            Assert.Collection(
+                exception.InnerExceptions,
+                p =>
+                {
+                    var ite = Assert.IsType<InvalidTemplateException>(p);
+                    Assert.True(ite.HasLineInfo);
+                    Assert.Equal(5, ite.GetLineInfo.LineNumber);
+                },
+                p =>
+                {
+                    var ite = Assert.IsType<InvalidTemplateException>(p);
+                    Assert.True(ite.HasLineInfo);
+                    Assert.Equal(6, ite.GetLineInfo.LineNumber);
+                },
+                p =>
+                {
+                    var ite = Assert.IsType<InvalidTemplateException>(p);
+                    Assert.True(ite.HasLineInfo);
+                    Assert.Equal(3, ite.GetLineInfo.LineNumber);
+                },
+                p =>
+                {
+                    var ite = Assert.IsType<InvalidTemplateException>(p);
+                    Assert.True(ite.HasLineInfo);
+                    Assert.Equal(3, ite.GetLineInfo.LineNumber);
+                });
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CalculatedFunctionContentTemplateValidInvalidAndMissingMembers.json
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CalculatedFunctionContentTemplateValidInvalidAndMissingMembers.json
@@ -1,0 +1,16 @@
+{
+  "templateType": "CalculatedContent",
+  "template": {
+    "typeName": "heartrate",
+    "typeMatchExpressionFake": "$..[?(@heartrate)]",
+    "deviceIdExpressionFake": "$.device",
+    "timestampExpression": "$.date",
+    "values": [
+      {
+        "required": "true",
+        "valueExpression": "$.heartrate",
+        "valueName": "hr"
+      }
+    ]
+  }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CollectionContentTemplateMixedValidity.json
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/TestInput/data_CollectionContentTemplateMixedValidity.json
@@ -2,6 +2,25 @@
   "templateType": "CollectionContent",
   "template": [
     {
+      "templateType": "CalculatedContent",
+      "template": {
+        "typeName": "heartrate",
+        "typeMatchExpression": "$..[?(@heartrate)]",
+        "timestampExpression": {
+          "value": "$.date",
+          "language": "JsonPath"
+        },
+        "deviceIdExpression": "$.device",
+        "values": [
+          {
+            "required": "true",
+            "valueExpression": "$.heartrate",
+            "valueName": "hr-calc-content"
+          }
+        ]
+      }
+    },
+    {
       "templateType": "JsonPathContent",
       "template": {
         "typeName": "heartrate",


### PR DESCRIPTION
This PR lays the groundwork to store line numbers inside of POCO objects that are created from user mapping files. These line numbers will then be added to exceptions/telemetry. This allows us to associate errors with the position within a template where they occurred.

Several areas of Normalization are updated to take advantage of line numbers. Additional work for other areas within Normalization and Fhir Transformation will occur in subsequent PRs.

Also, this PR adjusts how errors are captured during deserialization of the initial JSON object. Line numbers are now stored when available. This information will be used in a later PR when sending details back to the Health Portal.