### PR TITLE
Add normalization error policy

### DIFF
--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/IomtConnectorFunctions.cs
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/IomtConnectorFunctions.cs
@@ -30,9 +30,11 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         private readonly CollectionContentTemplateFactory _collectionContentTemplateFactory;
         private readonly IExceptionTelemetryProcessor _exceptionTelemetryProcessor;
 
-        public IomtConnectorFunctions(ITelemetryLogger logger)
+        public IomtConnectorFunctions(ITelemetryLogger logger, NormalizationExceptionTelemetryProcessor telemetryProcessor)
         {
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+            _exceptionTelemetryProcessor = EnsureArg.IsNotNull(telemetryProcessor, nameof(telemetryProcessor));
+
             var expressionRegister = new AssemblyExpressionRegister(typeof(IExpressionRegister).Assembly, _logger);
             var jmesPath = new JmesPath();
             expressionRegister.RegisterExpressions(jmesPath.FunctionRepository);
@@ -42,7 +44,6 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 new IotCentralJsonPathContentTemplateFactory(),
                 new CalculatedFunctionContentTemplateFactory(
                     new TemplateExpressionEvaluatorFactory(jmesPath), _logger));
-            _exceptionTelemetryProcessor = new NormalizationExceptionTelemetryProcessor();
         }
 
         [FunctionName("MeasurementCollectionToFhir")]

--- a/src/lib/Microsoft.Health.Extensions.Host/ConfigurationExtensions.cs
+++ b/src/lib/Microsoft.Health.Extensions.Host/ConfigurationExtensions.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Health.Extensions.Host
+{
+    public static class ConfigurationExtensions
+    {
+        public static IConfiguration GetConfiguration(this IWebJobsBuilder builder)
+        {
+            var serviceProvider = builder.Services.BuildServiceProvider();
+            IConfiguration config = serviceProvider.GetService<IConfiguration>();
+
+            return config;
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathExpressionEvaluator.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/JsonPathExpressionEvaluator.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             }
             catch (JsonException e)
             {
-                throw new TemplateExpressionException($"Unable to retrieve JsonToken using expression ${_jsonPathExpression}", e);
+                throw new TemplateExpressionException($"Unable to retrieve JsonToken using expression {_jsonPathExpression}", e);
             }
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             }
             catch (JsonException e)
             {
-                throw new TemplateExpressionException($"Unable to retrieve JsonTokens using expression ${_jsonPathExpression}", e);
+                throw new TemplateExpressionException($"Unable to retrieve JsonTokens using expression {_jsonPathExpression}", e);
             }
         }
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Host/DeviceDataNormalizationExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Host/DeviceDataNormalizationExtensions.cs
@@ -3,12 +3,16 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using EnsureThat;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Extensions.Host;
 using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Service;
+using Microsoft.Health.Fhir.Ingest.Telemetry;
 
 namespace Microsoft.Health.Fhir.Ingest.Host
 {
@@ -21,20 +25,24 @@ namespace Microsoft.Health.Fhir.Ingest.Host
             builder.AddExtension<EventHubMeasurementCollectorProvider>()
                 .BindOptions<EventHubMeasurementCollectorOptions>();
 
-            return builder;
-        }
-
-        public static IWebJobsBuilder AddDeviceIngressLogging(this IWebJobsBuilder builder)
-        {
-            EnsureArg.IsNotNull(builder, nameof(builder));
-
-            var serviceProvider = builder.Services.BuildServiceProvider();
-            IConfiguration config = serviceProvider.GetService<IConfiguration>();
+            IConfiguration config = builder.GetConfiguration();
 
             builder.Services.Configure<NormalizationServiceOptions>(config.GetSection(NormalizationServiceOptions.Settings));
+            builder.Services.AddSingleton(TelemetryProcessorFactory);
             builder.AddExtension<DeviceDataNormalizationSettingsProvider>();
 
             return builder;
+        }
+
+        private static NormalizationExceptionTelemetryProcessor TelemetryProcessorFactory(IServiceProvider serviceProvider)
+        {
+            var options = serviceProvider.GetRequiredService<IOptions<NormalizationServiceOptions>>();
+
+            return options.Value.ErrorHandlingPolicy switch
+            {
+                NormalizationErrorHandlingPolicy.DiscardMatchAndExtractErrors => new NormalizationExceptionTelemetryProcessor(typeof(NormalizationDataMappingException)),
+                _ => new NormalizationExceptionTelemetryProcessor(),
+            };
         }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Host/IngestWebJobsStartup.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Host/IngestWebJobsStartup.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Health.Fhir.Ingest.Host
         public void Configure(IWebJobsBuilder builder)
         {
             builder.AddDeviceNormalization();
-            builder.AddDeviceIngressLogging();
         }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
@@ -115,10 +115,18 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
                         var token = _converter.Convert(evt);
 
-                        foreach (var measurement in _contentTemplate.GetMeasurements(token))
+                        try
                         {
-                            measurement.IngestionTimeUtc = evt.SystemProperties.EnqueuedTimeUtc;
-                            createdMeasurements.Add((partitionId, measurement));
+                            foreach (var measurement in _contentTemplate.GetMeasurements(token))
+                            {
+                                measurement.IngestionTimeUtc = evt.SystemProperties.EnqueuedTimeUtc;
+                                createdMeasurements.Add((partitionId, measurement));
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            // Translate all Normalization Mapping exceptions into a common type for easy identification.
+                            throw new NormalizationDataMappingException(ex);
                         }
                     }
                     catch (Exception ex)

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationDataMappingException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationDataMappingException.cs
@@ -1,0 +1,37 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text;
+using EnsureThat;
+
+namespace Microsoft.Health.Fhir.Ingest.Service
+{
+    public class NormalizationDataMappingException : Exception
+    {
+        public NormalizationDataMappingException(Exception ex)
+            : base(BuildMessage(ex), ex)
+        {
+            EnsureArg.IsNotNull(ex, nameof(ex));
+        }
+
+        private static string BuildMessage(Exception ex)
+        {
+            EnsureArg.IsNotNull(ex, nameof(ex));
+
+            StringBuilder sb = new (ex.Message);
+
+            Exception innerException = ex.InnerException;
+            int exceptionCount = 0;
+            while (innerException != null)
+            {
+                sb.Append($"\n{++exceptionCount}:{innerException.Message}");
+                innerException = innerException.InnerException;
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationErrorHandlingPolicy.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationErrorHandlingPolicy.cs
@@ -1,0 +1,20 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Ingest.Service
+{
+    public enum NormalizationErrorHandlingPolicy
+    {
+        /// <summary>
+        /// Retry mapping errors infinitely.
+        /// </summary>
+        Retry = 0,
+
+        /// <summary>
+        /// Ignore errors during mapping match and extract phase.
+        /// </summary>
+        DiscardMatchAndExtractErrors = 1,
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationServiceOptions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationServiceOptions.cs
@@ -10,5 +10,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         public const string Settings = "NormalizationService";
 
         public bool LogDeviceIngressSizeBytes { get; set; } = false;
+
+        public NormalizationErrorHandlingPolicy ErrorHandlingPolicy { get; set; } = NormalizationErrorHandlingPolicy.Retry;
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/NormalizationExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/NormalizationExceptionTelemetryProcessor.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using EnsureThat;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Template;
@@ -14,9 +15,10 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
     public class NormalizationExceptionTelemetryProcessor : ExceptionTelemetryProcessor
     {
         private readonly string _connectorStage = ConnectorOperation.Normalization;
+        private static readonly Type[] DefaultExceptions = new[] { typeof(IncompatibleDataException) };
 
-        public NormalizationExceptionTelemetryProcessor()
-            : base(typeof(IncompatibleDataException))
+        public NormalizationExceptionTelemetryProcessor(params Type[] handledExceptionTypes)
+            : base(handledExceptionTypes.Union(DefaultExceptions).ToArray())
         {
         }
 

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/NormalizationDataMappingExceptionTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/NormalizationDataMappingExceptionTests.cs
@@ -1,0 +1,45 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Ingest.Service
+{
+    public class NormalizationDataMappingExceptionTests
+    {
+        [Fact]
+        public void GivenNullException_WhenCtor_ThenNullArgumentExceptionThrown_Test()
+        {
+            Assert.Throws<ArgumentNullException>(() => new NormalizationDataMappingException(null));
+        }
+
+        [Fact]
+        public void GivenSingleException_WhenCtor_ThenMessageSet_Test()
+        {
+            var ex = new Exception("message");
+            var ndmex = new NormalizationDataMappingException(ex);
+
+            Assert.Equal(ex.Message, ndmex.Message);
+        }
+
+        [Fact]
+        public void GivenMultipleExceptions_WhenCtor_ThenEachMessageSet_Test()
+        {
+            var ex2 = new Exception("nested b");
+            var ex1 = new Exception("nested a", ex2);
+            var ex = new Exception("message", ex1);
+
+            var ndmex = new NormalizationDataMappingException(ex);
+
+            var messages = ndmex.Message.Split('\n');
+
+            Assert.Equal(3, messages.Length);
+            Assert.Equal(ex.Message, messages[0]);
+            Assert.Equal($"1:{ex1.Message}", messages[1]);
+            Assert.Equal($"2:{ex2.Message}", messages[2]);
+        }
+    }
+}


### PR DESCRIPTION
- Add normalization error policy to control how exceptions during match & extract are handled
* Default is existing behavior, retry
* New option DiscardMatchAndExtractErrors, will emit errors as telemetry and continue.
- Errors during match & extract will be wrapped in a common exception type, NormalizationDataMappingException.
- Fixed minor formatting issue in JsonPathExpressionEvaluator leading to an extra $ in the exception messages.
- Added NormalizationErrorHandlingPolicy property to NormalizationServiceOptions.
- Updated DeviceDataNormalizationExtensions to include a factory for creating the NormalizationExceptionTelemetryProcessor based on the supplied settings (default is retry if none are configured).