### PR TITLE
Enhance data returned in Validation Results

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/CollectionTemplateFactory.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/CollectionTemplateFactory.cs
@@ -68,13 +68,13 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         {
             if (!rootContainer.MatchTemplateName(TargetTemplateTypeName))
             {
-                errors.Add(new TemplateError($"Expected {nameof(rootContainer.TemplateType)} value {TargetTemplateTypeName}, actual {rootContainer.TemplateType ?? "Not Found"}."));
+                errors.Add(new TemplateError($"Expected {nameof(rootContainer.TemplateType)} value {TargetTemplateTypeName}, actual {rootContainer.TemplateType ?? "Not Found"}.", rootContainer.GetLineInfoForProperty(nameof(TemplateContainer.TemplateType))));
                 return false;
             }
 
             if (rootContainer.Template?.Type != JTokenType.Array)
             {
-                errors.Add(new TemplateError($"Expected an array for the template property value for template type {TargetTemplateTypeName}."));
+                errors.Add(new TemplateError($"Expected an array for the template property value for template type {TargetTemplateTypeName}.", rootContainer.GetLineInfoForProperty(nameof(TemplateContainer.Template))));
                 return false;
             }
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineInfo.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/LineInfo.cs
@@ -7,13 +7,27 @@ namespace Microsoft.Health.Fhir.Ingest.Template
 {
     public class LineInfo : ILineInfo
     {
-        public int LineNumber { get; set; } = -1;
+        /// <summary>
+        /// Returns a default, empty ILineInfo singleton.
+        /// </summary>
+        public static readonly ILineInfo Default = new EmptyLineInfo();
 
-        public int LinePosition { get; set; } = -1;
+        public virtual int LineNumber { get; set; } = -1;
+
+        public virtual int LinePosition { get; set; } = -1;
 
         public bool HasLineInfo()
         {
             return LineNumber >= 0 && LinePosition >= 0;
+        }
+
+        private class EmptyLineInfo : ILineInfo
+        {
+            public int LineNumber { get => -1; set => throw new System.NotImplementedException(); }
+
+            public int LinePosition { get => -1; set => throw new System.NotImplementedException(); }
+
+            public bool HasLineInfo() => false;
         }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateErrorExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateErrorExtensions.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Health.Fhir.Ingest.Template
         {
             EnsureArg.IsNotNull(exception, nameof(exception));
 
-            yield return new TemplateError(exception.Message);
-
             foreach (var innerException in exception.InnerExceptions)
             {
                 if (innerException is InvalidTemplateException ite)

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Extensions/IResultExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Extensions/IResultExtensions.cs
@@ -7,18 +7,19 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EnsureThat;
+using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Fhir.Ingest.Validation.Models;
 
 namespace Microsoft.Health.Fhir.Ingest.Validation.Extensions
 {
     public static class IResultExtensions
     {
-        public static void CaptureError(this IResult validationResult, string message, ErrorLevel errorLevel, ValidationCategory category)
+        public static void CaptureError(this IResult validationResult, string message, ErrorLevel errorLevel, ValidationCategory category, ILineInfo lineInfo)
         {
             EnsureArg.IsNotNull(validationResult, nameof(validationResult));
             EnsureArg.IsNotNullOrWhiteSpace(message, nameof(message));
 
-            validationResult.Exceptions.Add(new ValidationError(message, category, errorLevel));
+            validationResult.Exceptions.Add(new ValidationError(message, category, lineInfo, errorLevel));
         }
 
         public static void CaptureException(this IResult validationResult, Exception exception, ValidationCategory category)
@@ -26,16 +27,23 @@ namespace Microsoft.Health.Fhir.Ingest.Validation.Extensions
             EnsureArg.IsNotNull(validationResult, nameof(validationResult));
             EnsureArg.IsNotNull(exception, nameof(exception));
 
+            var lineInfo = LineInfo.Default;
+
+            if (exception is IExceptionWithLineInfo exceptionWithLineInfo)
+            {
+                lineInfo = exceptionWithLineInfo.GetLineInfo;
+            }
+
             // Collect messages from inner exceptions as well
-            validationResult.Exceptions.Add(new ValidationError(exception.Message, category));
+            validationResult.Exceptions.Add(new ValidationError(exception.Message, category, lineInfo));
         }
 
-        public static void CaptureWarning(this IResult validationResult, string warning, ValidationCategory category)
+        public static void CaptureWarning(this IResult validationResult, string warning, ValidationCategory category, ILineInfo lineInfo)
         {
             EnsureArg.IsNotNull(validationResult, nameof(validationResult));
             EnsureArg.IsNotNullOrWhiteSpace(warning, nameof(warning));
 
-            validationResult.Exceptions.Add(new ValidationError(warning, category, ErrorLevel.WARN));
+            validationResult.Exceptions.Add(new ValidationError(warning, category, lineInfo, ErrorLevel.WARN));
         }
 
         public static IEnumerable<ValidationError> GetErrors(this IResult validationResult, ErrorLevel errorLevel)

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Extensions/IResultExtensions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Extensions/IResultExtensions.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using EnsureThat;
 using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Fhir.Ingest.Validation.Models;
+using Microsoft.Health.Logging;
 
 namespace Microsoft.Health.Fhir.Ingest.Validation.Extensions
 {
@@ -27,15 +28,14 @@ namespace Microsoft.Health.Fhir.Ingest.Validation.Extensions
             EnsureArg.IsNotNull(validationResult, nameof(validationResult));
             EnsureArg.IsNotNull(exception, nameof(exception));
 
-            var lineInfo = LineInfo.Default;
-
             if (exception is IExceptionWithLineInfo exceptionWithLineInfo)
             {
-                lineInfo = exceptionWithLineInfo.GetLineInfo;
+                validationResult.Exceptions.Add(new ValidationError(exception.JoinInnerMessages(), category, exceptionWithLineInfo.GetLineInfo));
             }
-
-            // Collect messages from inner exceptions as well
-            validationResult.Exceptions.Add(new ValidationError(exception.Message, category, lineInfo));
+            else
+            {
+                validationResult.Exceptions.Add(new ValidationError(exception.JoinInnerMessages(), category));
+            }
         }
 
         public static void CaptureWarning(this IResult validationResult, string warning, ValidationCategory category, ILineInfo lineInfo)

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Models/ValidationError.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Models/ValidationError.cs
@@ -10,12 +10,7 @@ namespace Microsoft.Health.Fhir.Ingest.Validation.Models
 {
     public class ValidationError
     {
-        public ValidationError(string message, ValidationCategory category, ErrorLevel errorLevel = ErrorLevel.ERROR)
-            : this(message, category, Microsoft.Health.Fhir.Ingest.Template.LineInfo.Default, errorLevel)
-        {
-        }
-
-        public ValidationError(string message, ValidationCategory category, ILineInfo lineInfo, ErrorLevel errorLevel = ErrorLevel.ERROR)
+        public ValidationError(string message, ValidationCategory category, ILineInfo lineInfo = null, ErrorLevel errorLevel = ErrorLevel.ERROR)
         {
             Message = EnsureArg.IsNotNullOrWhiteSpace(message, nameof(message));
             Level = errorLevel;

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Models/ValidationError.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Models/ValidationError.cs
@@ -4,16 +4,23 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
+using Microsoft.Health.Fhir.Ingest.Template;
 
 namespace Microsoft.Health.Fhir.Ingest.Validation.Models
 {
     public class ValidationError
     {
         public ValidationError(string message, ValidationCategory category, ErrorLevel errorLevel = ErrorLevel.ERROR)
+            : this(message, category, Microsoft.Health.Fhir.Ingest.Template.LineInfo.Default, errorLevel)
+        {
+        }
+
+        public ValidationError(string message, ValidationCategory category, ILineInfo lineInfo, ErrorLevel errorLevel = ErrorLevel.ERROR)
         {
             Message = EnsureArg.IsNotNullOrWhiteSpace(message, nameof(message));
             Level = errorLevel;
             Category = category;
+            LineInfo = lineInfo;
         }
 
         public string Message { get; }
@@ -21,5 +28,7 @@ namespace Microsoft.Health.Fhir.Ingest.Validation.Models
         public ErrorLevel Level { get; }
 
         public ValidationCategory Category { get; }
+
+        public ILineInfo LineInfo { get; }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
@@ -91,45 +91,6 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             return producer;
         }
 
-        private IEnumerable<(string, IMeasurement)> Iter(JToken token, string partitionId, ConcurrentBag<Exception> exceptions, Func<Exception, EventData, Task<bool>> errorConsumer, EventData evt)
-        {
-            var enumerable = _contentTemplate.GetMeasurements(token).GetEnumerator();
-            (string, IMeasurement) currentValue = (partitionId, null);
-            var shouldLoop = true;
-
-            while (shouldLoop)
-            {
-                try
-                {
-                    shouldLoop = enumerable.MoveNext();
-
-                    if (shouldLoop)
-                    {
-                        currentValue = (partitionId, enumerable.Current);
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    // Translate all Normalization Mapping exceptions into a common type for easy identification.
-                    if (errorConsumer(new NormalizationDataMappingException(ex), evt).ConfigureAwait(false).GetAwaiter().GetResult())
-                    {
-                        exceptions.Add(ex);
-                    }
-
-                    shouldLoop = false;
-                }
-
-                if (shouldLoop)
-                {
-                    yield return currentValue;
-                }
-            }
-        }
-
         private async Task StartConsumer(ISourceBlock<EventData> producer, IEnumerableAsyncCollector<IMeasurement> collector, Func<Exception, EventData, Task<bool>> errorConsumer)
         {
             // Collect non operation canceled exceptions as they occur to ensure the entire data stream is processed
@@ -138,6 +99,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             var transformingConsumer = new TransformManyBlock<EventData, (string, IMeasurement)>(
                 async evt =>
                 {
+                    var createdMeasurements = new List<(string, IMeasurement)>();
                     try
                     {
                         string partitionId = evt.SystemProperties.PartitionKey;
@@ -153,7 +115,19 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
                         var token = _converter.Convert(evt);
 
-                        return Iter(token, partitionId, exceptions, errorConsumer, evt);
+                        try
+                        {
+                            foreach (var measurement in _contentTemplate.GetMeasurements(token))
+                            {
+                                measurement.IngestionTimeUtc = evt.SystemProperties.EnqueuedTimeUtc;
+                                createdMeasurements.Add((partitionId, measurement));
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            // Translate all Normalization Mapping exceptions into a common type for easy identification.
+                            throw new NormalizationDataMappingException(ex);
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -163,7 +137,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                         }
                     }
 
-                    return new List<(string, IMeasurement)>();
+                    return createdMeasurements;
                 });
 
             var asyncCollectorConsumer = new ActionBlock<(string, IMeasurement)[]>(

--- a/src/lib/Microsoft.Health.Logger/ExceptionExtensions.cs
+++ b/src/lib/Microsoft.Health.Logger/ExceptionExtensions.cs
@@ -1,0 +1,38 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text;
+using EnsureThat;
+
+namespace Microsoft.Health.Logging
+{
+	public static class ExceptionExtensions
+	{
+        /// <summary>
+        /// Returns a concatenation of this Exceptions message along with the messages of all Inner Exceptions.
+        /// </summary>
+        /// <param name="ex">The root exception</param>
+        /// <returns>A concatenation of the root and inner exceptions</returns>
+        public static string JoinInnerMessages(this Exception ex)
+        {
+            EnsureArg.IsNotNull(ex, nameof(ex));
+
+            var sb = new StringBuilder(ex.Message);
+
+            var innerException = ex.InnerException;
+            int exceptionCount = 1;
+
+            while (innerException != null)
+            {
+                sb.Append($"\n{++exceptionCount}:{innerException.Message}");
+                innerException = innerException.InnerException;
+            }
+
+            return sb.ToString();
+        }
+    }
+}
+

--- a/test/Microsoft.Health.Fhir.Ingest.Validation.UnitTests/MappingValidatorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.Validation.UnitTests/MappingValidatorTests.cs
@@ -125,6 +125,19 @@ namespace Microsoft.Health.Fhir.Ingest.Validation.UnitTests
                 {
                     Assert.Contains("Required property 'DeviceIdExpression' not found in JSON", error.Message);
                     Assert.Equal(ValidationCategory.NORMALIZATION, error.Category);
+                    Assert.Equal(6, error.LineInfo.LineNumber);
+                },
+                (error) =>
+                {
+                    Assert.Contains("Required property 'TimestampExpression' not found in JSON", error.Message);
+                    Assert.Equal(ValidationCategory.NORMALIZATION, error.Category);
+                    Assert.Equal(6, error.LineInfo.LineNumber);
+                },
+                (error) =>
+                {
+                    Assert.Contains("Required property 'TypeMatchExpression' not found in JSON", error.Message);
+                    Assert.Equal(ValidationCategory.NORMALIZATION, error.Category);
+                    Assert.Equal(20, error.LineInfo.LineNumber);
                 });
             Assert.Empty(result.DeviceResults);
         }
@@ -155,13 +168,27 @@ namespace Microsoft.Health.Fhir.Ingest.Validation.UnitTests
                 result.TemplateResult.GetErrors(ErrorLevel.ERROR),
                 (error) =>
                 {
-                    Assert.Contains("Required property 'DeviceIdExpression' not found in JSON", error.Message);
+                Assert.Contains("Required property 'DeviceIdExpression' not found in JSON", error.Message);
+                Assert.Equal(ValidationCategory.NORMALIZATION, error.Category);
+                Assert.Equal(6, error.LineInfo.LineNumber);
+                },
+                (error) =>
+                {
+                    Assert.Contains("Required property 'TimestampExpression' not found in JSON", error.Message);
                     Assert.Equal(ValidationCategory.NORMALIZATION, error.Category);
+                    Assert.Equal(6, error.LineInfo.LineNumber);
+                },
+                (error) =>
+                {
+                    Assert.Contains("Required property 'TypeMatchExpression' not found in JSON", error.Message);
+                    Assert.Equal(ValidationCategory.NORMALIZATION, error.Category);
+                    Assert.Equal(20, error.LineInfo.LineNumber);
                 },
                 (error) =>
                 {
                     Assert.Contains("Expected TemplateType value CollectionFhirTemplate, actual CodeValueFhir", error.Message);
                     Assert.Equal(ValidationCategory.FHIRTRANSFORMATION, error.Category);
+                    Assert.Equal(2, error.LineInfo.LineNumber);
                 });
             Assert.Empty(result.DeviceResults);
         }


### PR DESCRIPTION
This PR makes several updates the Validation Result object returned during a mapping validation:

- Line numbers are returned when available
- Exceptions are split and returned as individual validation errors.