### PR TITLE
Update how measurements are processed

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
@@ -126,16 +126,12 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             EnsureArg.IsNotNull(token, nameof(token));
             var evaluator = CreateRequiredExpressionEvaluator(Template.TypeMatchExpression, nameof(Template.TypeMatchExpression));
 
-            var counter = 0;
-
             JObject tokenClone = null;
 
             foreach (var extractedToken in evaluator.SelectTokens(token))
             {
                 // Add the extracted data as an element of the original data.
                 // This allows subsequent expressions access to data from the original event data
-                counter++;
-
                 if (tokenClone == null)
                 {
                     tokenClone = new JObject(token);
@@ -146,7 +142,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                 tokenClone.Remove(MatchedToken);
             }
 
-            // return Enumerable.Empty<JToken>();
+            tokenClone = null;
         }
 
         protected IExpressionEvaluator CreateRequiredExpressionEvaluator(TemplateExpression expression, string expressionName)

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.Ingest.Template
                 // Add the extracted data as an element of the original data.
                 // This allows subsequent expressions access to data from the original event data
 
-                var tokenClone = token.DeepClone() as JObject;
+                var tokenClone = new JObject(token);
                 tokenClone.Add(MatchedToken, extractedToken);
                 yield return tokenClone;
             }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/MeasurementExtractor.cs
@@ -126,15 +126,27 @@ namespace Microsoft.Health.Fhir.Ingest.Template
             EnsureArg.IsNotNull(token, nameof(token));
             var evaluator = CreateRequiredExpressionEvaluator(Template.TypeMatchExpression, nameof(Template.TypeMatchExpression));
 
+            var counter = 0;
+
+            JObject tokenClone = null;
+
             foreach (var extractedToken in evaluator.SelectTokens(token))
             {
                 // Add the extracted data as an element of the original data.
                 // This allows subsequent expressions access to data from the original event data
+                counter++;
 
-                var tokenClone = new JObject(token);
+                if (tokenClone == null)
+                {
+                    tokenClone = new JObject(token);
+                }
+
                 tokenClone.Add(MatchedToken, extractedToken);
                 yield return tokenClone;
+                tokenClone.Remove(MatchedToken);
             }
+
+            // return Enumerable.Empty<JToken>();
         }
 
         protected IExpressionEvaluator CreateRequiredExpressionEvaluator(TemplateExpression expression, string expressionName)

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Data/EventDataWithJsonBodyToJTokenConverter.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Data/EventDataWithJsonBodyToJTokenConverter.cs
@@ -3,9 +3,11 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.IO;
 using System.Text;
 using EnsureThat;
 using Microsoft.Azure.EventHubs;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Health.Fhir.Ingest.Data
@@ -15,10 +17,18 @@ namespace Microsoft.Health.Fhir.Ingest.Data
         public JToken Convert(EventData input)
         {
             EnsureArg.IsNotNull(input, nameof(input));
+            var body = null as JToken;
 
-            var body = input.Body.Count > 0
-                ? JToken.Parse(Encoding.UTF8.GetString(input.Body.Array, input.Body.Offset, input.Body.Count))
-                : null;
+            if (input.Body.Count > 0)
+            {
+                using (var stream = new MemoryStream(input.Body.Array))
+                using (StreamReader sr = new StreamReader(stream, Encoding.UTF8))
+                using (JsonReader reader = new JsonTextReader(sr))
+                {
+                    body = JToken.ReadFrom(reader);
+                }
+            }
+
             var data = new { Body = body, input.Properties, input.SystemProperties };
             var token = JToken.FromObject(data);
             return token;

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Data/EventDataWithJsonBodyToJTokenConverter.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Data/EventDataWithJsonBodyToJTokenConverter.cs
@@ -14,10 +14,16 @@ namespace Microsoft.Health.Fhir.Ingest.Data
 {
     public class EventDataWithJsonBodyToJTokenConverter : IConverter<EventData, JToken>
     {
+        private const string BodyAttr = "Body";
+        private const string PropertiesAttr = "Properties";
+        private const string SystemPropertiesAttr = "SystemProperties";
+        private readonly JsonSerializer jsonSerializer = JsonSerializer.CreateDefault();
+
         public JToken Convert(EventData input)
         {
             EnsureArg.IsNotNull(input, nameof(input));
-            var body = null as JToken;
+            JToken token = new JObject();
+            JToken body = null;
 
             if (input.Body.Count > 0)
             {
@@ -29,8 +35,10 @@ namespace Microsoft.Health.Fhir.Ingest.Data
                 }
             }
 
-            var data = new { Body = body, input.Properties, input.SystemProperties };
-            var token = JToken.FromObject(data);
+            token[BodyAttr] = body;
+            token[PropertiesAttr] = JToken.FromObject(input.Properties, jsonSerializer);
+            token[SystemPropertiesAttr] = JToken.FromObject(input.SystemProperties, jsonSerializer);
+
             return token;
         }
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
@@ -91,6 +91,47 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             return producer;
         }
 
+        private IEnumerable<(string, IMeasurement)> Iter(JToken token, string partitionId, ConcurrentBag<Exception> exceptions, Func<Exception, EventData, Task<bool>> errorConsumer, EventData evt)
+        {
+            var enumerable = _contentTemplate.GetMeasurements(token).GetEnumerator();
+            (string, IMeasurement) currentValue = (partitionId, null);
+            var shouldLoop = true;
+
+            while (shouldLoop)
+            {
+                try
+                {
+                    shouldLoop = enumerable.MoveNext();
+
+                    if (shouldLoop)
+                    {
+                        currentValue = (partitionId, enumerable.Current);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // TODO: Do we skip processing the entire DeviceEvent now that one Measurement produced an Exception? Or do
+                    // we simply skip this Measurement, and allow other Measurements to be generated?
+                    // Translate all Normalization Mapping exceptions into a common type for easy identification.
+                    if (errorConsumer(new NormalizationDataMappingException(ex), evt).ConfigureAwait(false).GetAwaiter().GetResult())
+                    {
+                        exceptions.Add(ex);
+                    }
+
+                    shouldLoop = false;
+                }
+
+                if (shouldLoop)
+                {
+                    yield return currentValue;
+                }
+            }
+        }
+
         private async Task StartConsumer(ISourceBlock<EventData> producer, IEnumerableAsyncCollector<IMeasurement> collector, Func<Exception, EventData, Task<bool>> errorConsumer)
         {
             // Collect non operation canceled exceptions as they occur to ensure the entire data stream is processed
@@ -99,7 +140,6 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             var transformingConsumer = new TransformManyBlock<EventData, (string, IMeasurement)>(
                 async evt =>
                 {
-                    var createdMeasurements = new List<(string, IMeasurement)>();
                     try
                     {
                         string partitionId = evt.SystemProperties.PartitionKey;
@@ -115,19 +155,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
                         var token = _converter.Convert(evt);
 
-                        try
-                        {
-                            foreach (var measurement in _contentTemplate.GetMeasurements(token))
-                            {
-                                measurement.IngestionTimeUtc = evt.SystemProperties.EnqueuedTimeUtc;
-                                createdMeasurements.Add((partitionId, measurement));
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            // Translate all Normalization Mapping exceptions into a common type for easy identification.
-                            throw new NormalizationDataMappingException(ex);
-                        }
+                        return Iter(token, partitionId, exceptions, errorConsumer, evt);
                     }
                     catch (Exception ex)
                     {
@@ -137,7 +165,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                         }
                     }
 
-                    return createdMeasurements;
+                    return Enumerable.Empty<(string, IMeasurement)>();
                 });
 
             var asyncCollectorConsumer = new ActionBlock<(string, IMeasurement)[]>(

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
@@ -243,8 +243,6 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 }
                 catch (Exception ex)
                 {
-                    // TODO: Do we skip processing the remainder of the DeviceEvent now that one Measurement produced an Exception? Or do
-                    // we simply skip this Measurement, and allow the remaining Measurements to be generated?
                     // Translate all Normalization Mapping exceptions into a common type for easy identification.
                     storeNormalizedException(ex);
                     shouldLoop = false;

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetricDefinition.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetricDefinition.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
 
         public static IomtMetricDefinition NormalizedEvent { get; } = new IomtMetricDefinition(nameof(NormalizedEvent));
 
+        public static IomtMetricDefinition NormalizedEventGenerationTimeMs { get; } = new IomtMetricDefinition(nameof(NormalizedEventGenerationTimeMs));
+
         public static IomtMetricDefinition Measurement { get; } = new IomtMetricDefinition(nameof(Measurement));
 
         public static IomtMetricDefinition MeasurementGroup { get; } = new IomtMetricDefinition(nameof(MeasurementGroup));

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
@@ -159,5 +159,16 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
         {
             return exceptionName.ToErrorMetric(connectorStage, ErrorType.GeneralError, ErrorSeverity.Critical);
         }
+
+        /// <summary>
+        /// The time it takes to generate a Normalized Event.
+        /// </summary>
+        /// <param name="partitionId">The partition id of the events being consumed from the event hub partition </param>
+        public static Metric NormalizedEventGenerationTimeMs(string partitionId = null)
+        {
+            return IomtMetricDefinition.NormalizedEventGenerationTimeMs
+                .CreateBaseMetric(Category.Traffic, ConnectorOperation.Normalization)
+                .AddDimension(_partitionDimension, partitionId);
+        }
     }
 }

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
@@ -36,6 +36,7 @@
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj" />
     <ProjectReference Include="..\..\src\lib\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />
     <ProjectReference Include="..\Microsoft.Health.Tests.Common\Microsoft.Health.Tests.Common.csproj" />
   </ItemGroup>

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementEventNormalizationServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementEventNormalizationServiceTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             _template.GetMeasurements(null).ReturnsForAnyArgs(new[] { Substitute.For<Measurement>() });
             var events = Enumerable.Range(0, 10).Select(i => BuildEvent(i)).ToArray();
 
-            var srv = new MeasurementEventNormalizationService(_logger, _template, _exceptionTelemetryProcessor);
+            var srv = new MeasurementEventNormalizationService(_logger, _template, _converter, _exceptionTelemetryProcessor, 3, 25);
             await srv.ProcessAsync(events, _consumer);
 
             _template.ReceivedWithAnyArgs(events.Length).GetMeasurements(null);


### PR DESCRIPTION
This PR makes several enhancements to how Measurements are produced from DeviceEvents:

- NormalizedEvents are emitted to the processing pipeline as soon as they are created. Previously, all NormalizedEvents for a single DeviceEvent were added to a collection before being emitted to the processing pipeline
- Reusing a single JObject clone during template evaluation 
- Added a metric to capture processing time per NormalizedEvent