### PR TITLE
Add error reporting triggers, include payload of message that triggered the error

### DIFF
--- a/src/console/MeasurementCollectionToFhir/ProcessorStartup.cs
+++ b/src/console/MeasurementCollectionToFhir/ProcessorStartup.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Common;
 using Microsoft.Health.Extensions.Fhir;
 using Microsoft.Health.Extensions.Fhir.Config;
 using Microsoft.Health.Extensions.Fhir.Service;

--- a/src/lib/Microsoft.Health.Common/Errors/ErrorMessage.cs
+++ b/src/lib/Microsoft.Health.Common/Errors/ErrorMessage.cs
@@ -1,0 +1,42 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Health.Common.Errors
+{
+    public class ErrorMessage : Exception
+    {
+        /// <summary>
+        /// A unique identifier for the ErrorMessage
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The type of error.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// A string describing the error that occurred.
+        /// </summary>
+        public string Details { get; set; }
+
+        /// <summary>
+        /// The time when the error occurred.
+        /// </summary>
+        public DateTimeOffset ErrorTimestamp { get; set; }
+
+        /// <summary>
+        /// The message payload that led to an error to be thrown.
+        /// </summary>
+        /// <remarks>
+        /// This property provides the input message payload so the user can determine
+        /// what message was correlated with the error.
+        /// </remarks>
+        public JToken InputMessage { get; set; }
+    }
+}

--- a/src/lib/Microsoft.Health.Common/Errors/IErrorMessageService.cs
+++ b/src/lib/Microsoft.Health.Common/Errors/IErrorMessageService.cs
@@ -1,0 +1,39 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.Common.Errors
+{
+    public interface IErrorMessageService
+    {
+        /// <summary>
+        /// Writes an ErrorMessage to a destination
+        /// </summary>
+        /// <remarks>
+        /// The ErrorMessage Type property will be the ExceptionType.
+        /// and Details property will be the Exception Message.
+        /// </remarks>
+        /// <param name="exception">An Exception.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns><see cref="Task"/>Returns the successfully stored error message.</returns>
+        Task ReportError(Exception exception, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Writes an IEnumerable of ErrorMessage to a destination.
+        /// </summary>
+        /// <remarks>
+        /// The ErrorMessage Type property will be the ExceptionType.
+        /// and Details property will be the Exception Message.
+        /// </remarks>
+        /// <param name="exceptions">A collection of exceptions.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns><see cref="Task"/>Returns the successfully stored error message.</returns>
+        Task<IEnumerable<ErrorMessage>> ReportError(IEnumerable<Exception> exceptions, CancellationToken cancellationToken);
+    }
+}

--- a/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
+++ b/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
@@ -25,11 +25,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Azure.Core" Version="1.11.0" />
+    <PackageReference Include="Azure.Core" Version="1.22.0" />
     <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Schema/IMeasurement.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Schema/IMeasurement.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Health.Fhir.Ingest.Data
 {
     public interface IMeasurement
     {
+        ReadOnlyMemory<byte> Payload { get; set; }
+
         string Type { get; }
 
         DateTime OccurrenceTimeUtc { get; }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Schema/Measurement.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Schema/Measurement.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Health.Fhir.Ingest.Data
             Properties = new List<MeasurementProperty>();
         }
 
+        public ReadOnlyMemory<byte> Payload { get; set; }
+
         public string Type { get; set; }
 
         public DateTime OccurrenceTimeUtc { get; set; }

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Schema/Microsoft.Health.Fhir.Ingest.Schema.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Schema/Microsoft.Health.Fhir.Ingest.Schema.csproj
@@ -25,6 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Config/MeasurementFhirImportOptions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Config/MeasurementFhirImportOptions.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Microsoft.Health.Common.Config;
+using Microsoft.Health.Common.Errors;
 using Microsoft.Health.Fhir.Ingest.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Logging.Telemetry;
@@ -12,10 +13,24 @@ namespace Microsoft.Health.Fhir.Ingest.Config
 {
     public class MeasurementFhirImportOptions
     {
-        public virtual ParallelTaskOptions ParallelTaskOptions { get; } = new ParallelTaskOptions { MaxConcurrency = 10 };
+        public MeasurementFhirImportOptions()
+        {
+            ParallelTaskOptions = new ParallelTaskOptions { MaxConcurrency = 10 };
+            TemplateFactory = CollectionFhirTemplateFactory.Default;
+            ExceptionService = new FhirExceptionTelemetryProcessor();
+        }
 
-        public virtual IExceptionTelemetryProcessor ExceptionService { get; } = new FhirExceptionTelemetryProcessor();
+        public MeasurementFhirImportOptions(IErrorMessageService errorMessageService)
+        {
+            ParallelTaskOptions = new ParallelTaskOptions { MaxConcurrency = 10 };
+            TemplateFactory = CollectionFhirTemplateFactory.Default;
+            ExceptionService = new FhirExceptionTelemetryProcessor(errorMessageService);
+        }
 
-        public virtual ITemplateFactory<string, ITemplateContext<ILookupTemplate<IFhirTemplate>>> TemplateFactory { get; } = CollectionFhirTemplateFactory.Default;
+        public virtual ParallelTaskOptions ParallelTaskOptions { get; }
+
+        public virtual IExceptionTelemetryProcessor ExceptionService { get; }
+
+        public virtual ITemplateFactory<string, ITemplateContext<ILookupTemplate<IFhirTemplate>>> TemplateFactory { get; }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
@@ -198,7 +198,22 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         /// <returns>Returns true if the exception is handled and false otherwise.</returns>
         private Task<bool> ProcessErrorAsync(Exception ex, EventData data)
         {
-            var handled = _exceptionTelemetryProcessor.HandleException(ex, _log);
+            JObject request = new JObject();
+            request["Properties"] = new JObject();
+            request["SystemProperties"] = new JObject();
+
+            foreach (var prop in data.Properties)
+            {
+                request["Properties"][prop.Key] = prop.Value.ToString();
+            }
+
+            foreach (var prop in data.SystemProperties)
+            {
+                request["SystemProperties"][prop.Key] = prop.Value.ToString();
+            }
+
+            request["Body"] = JObject.Parse(System.Text.Encoding.Default.GetString(data.Body.ToArray()));
+            var handled = _exceptionTelemetryProcessor.HandleException(ex, request, _log);
             return Task.FromResult(!handled);
         }
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/FhirExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/FhirExceptionTelemetryProcessor.cs
@@ -5,12 +5,14 @@
 
 using System;
 using EnsureThat;
+using Microsoft.Health.Common.Errors;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Extensions.Fhir;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Service;
 using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Logging.Telemetry;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Health.Fhir.Ingest.Telemetry
 {
@@ -18,7 +20,9 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
     {
         private readonly string _connectorStage = ConnectorOperation.FHIRConversion;
 
-        public FhirExceptionTelemetryProcessor()
+        private IErrorMessageService _errorMessageService;
+
+        public FhirExceptionTelemetryProcessor(IErrorMessageService errorMessageService = null)
             : base (
                 typeof(PatientDeviceMismatchException),
                 typeof(ResourceIdentityNotDefinedException),
@@ -29,14 +33,26 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
                 typeof(CorrelationIdNotDefinedException),
                 typeof(InvalidQuantityFhirValueException))
         {
+            _errorMessageService = errorMessageService;
         }
 
-        public override bool HandleException(Exception ex, ITelemetryLogger logger)
+        public override bool HandleException(Exception ex, JToken message, ITelemetryLogger logger)
         {
             EnsureArg.IsNotNull(ex, nameof(ex));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             var exceptionTypeName = ex.GetType().Name;
+
+            // send to error message service
+            if (_errorMessageService != null)
+            {
+                var errorMessage = new ErrorMessage();
+                errorMessage.InputMessage = message;
+                errorMessage.Details = ex.Message;
+                errorMessage.Type = exceptionTypeName;
+                _errorMessageService.ReportError(errorMessage, default);
+             }
+
             var handledExceptionMetric = ex is NotSupportedException ? IomtMetrics.NotSupported() : IomtMetrics.HandledException(exceptionTypeName, _connectorStage);
             return HandleException(ex, logger, handledExceptionMetric, IomtMetrics.UnhandledException(exceptionTypeName, _connectorStage));
         }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/NormalizationExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/NormalizationExceptionTelemetryProcessor.cs
@@ -6,9 +6,11 @@
 using System;
 using System.Linq;
 using EnsureThat;
+using Microsoft.Health.Common.Errors;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Logging.Telemetry;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Health.Fhir.Ingest.Telemetry
 {
@@ -16,19 +18,37 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
     {
         private readonly string _connectorStage = ConnectorOperation.Normalization;
         private static readonly Type[] DefaultExceptions = new[] { typeof(IncompatibleDataException) };
+        private IErrorMessageService _errorMessageService;
 
         public NormalizationExceptionTelemetryProcessor(params Type[] handledExceptionTypes)
             : base(handledExceptionTypes.Union(DefaultExceptions).ToArray())
         {
         }
 
-        public override bool HandleException(Exception ex, ITelemetryLogger logger)
+        public NormalizationExceptionTelemetryProcessor(IErrorMessageService errorMessageService, params Type[] handledExceptionTypes)
+            : base(handledExceptionTypes.Union(DefaultExceptions).ToArray())
+        {
+            _errorMessageService = errorMessageService;
+        }
+
+        public override bool HandleException(Exception ex, JToken message, ITelemetryLogger logger)
         {
             EnsureArg.IsNotNull(ex, nameof(ex));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             var exceptionTypeName = ex.GetType().Name;
-            return HandleException(ex, logger, IomtMetrics.HandledException(exceptionTypeName, _connectorStage), IomtMetrics.UnhandledException(exceptionTypeName, _connectorStage));
+            var shouldContinue = HandleException(ex, logger, IomtMetrics.HandledException(exceptionTypeName, _connectorStage), IomtMetrics.UnhandledException(exceptionTypeName, _connectorStage));
+
+            if (_errorMessageService != null)
+            {
+                var errorMessage = new ErrorMessage();
+                errorMessage.InputMessage = message;
+                errorMessage.Details = ex.Message;
+                errorMessage.Type = exceptionTypeName;
+                _errorMessageService.ReportError(errorMessage, default);
+            }
+
+            return shouldContinue;
         }
     }
 }

--- a/src/lib/Microsoft.Health.Logger/Telemetry/ExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Logger/Telemetry/ExceptionTelemetryProcessor.cs
@@ -5,6 +5,7 @@
 
 using EnsureThat;
 using Microsoft.Health.Common.Telemetry;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 
@@ -26,6 +27,7 @@ namespace Microsoft.Health.Logging.Telemetry
 
         public virtual bool HandleException(
             Exception ex,
+            JToken message,
             ITelemetryLogger logger)
         {
             return HandleException(ex, logger);

--- a/src/lib/Microsoft.Health.Logger/Telemetry/IExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Logger/Telemetry/IExceptionTelemetryProcessor.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Microsoft.Health.Common.Telemetry;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Health.Logging.Telemetry
 {
@@ -15,9 +16,10 @@ namespace Microsoft.Health.Logging.Telemetry
         /// The associated exception metric is logged.
         /// </summary>
         /// <param name="ex">Exception that is to be evaluated as handleable or not.</param>
+        /// <param name="message">The message payload that the exception was triggered for.</param>
         /// <param name="logger">Telemetry logger used to log the exception/metric.</param>
         /// <returns>Returns true if the exception is handleable, i.e., can be continued upon. False otherwise.</returns>
-        bool HandleException(Exception ex, ITelemetryLogger logger);
+        bool HandleException(Exception ex, JToken message, ITelemetryLogger logger);
 
         /// <summary>
         /// Logs the exception metric for the supplied exception.

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Logging.Telemetry;
 using Microsoft.Health.Tests.Common;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NSubstitute;
 using Xunit;
 
@@ -92,7 +93,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         {
             var log = Substitute.For<ITelemetryLogger>();
             var options = BuildMockOptions();
-            options.ExceptionService.HandleException(null, null).ReturnsForAnyArgs(true);
+            options.ExceptionService.HandleException(null, new JArray(), null).ReturnsForAnyArgs(true);
 
             var exception = new InvalidOperationException();
 
@@ -107,7 +108,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
             options.TemplateFactory.Received(1).Create(string.Empty);
             await fhirService.ReceivedWithAnyArgs(2).ProcessAsync(default, default);
-            options.ExceptionService.Received(2).HandleException(exception, log);
+            options.ExceptionService.Received(2).HandleException(exception, new JArray(), log);
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/FhirExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/FhirExceptionTelemetryProcessorTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Health.Extensions.Fhir;
 using Microsoft.Health.Fhir.Ingest.Service;
 using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Logging.Telemetry;
+using Newtonsoft.Json.Linq;
 using NSubstitute;
 using Xunit;
 
@@ -30,7 +31,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
             var ex = Activator.CreateInstance(exType) as Exception;
 
             var exProcessor = new FhirExceptionTelemetryProcessor();
-            var handled = exProcessor.HandleException(ex, log);
+            var handled = exProcessor.HandleException(ex, new JArray(), log);
             Assert.True(handled);
 
             log.ReceivedWithAnyArgs(1).LogMetric(null, default(double));
@@ -44,7 +45,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
             var ex = Activator.CreateInstance(exType) as Exception;
 
             var exProcessor = new FhirExceptionTelemetryProcessor();
-            var handled = exProcessor.HandleException(ex, log);
+            var handled = exProcessor.HandleException(ex, new JArray(), log);
             Assert.False(handled);
 
             log.Received(1).LogError(ex);

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/NormalizationExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/NormalizationExceptionTelemetryProcessorTests.cs
@@ -7,6 +7,7 @@ using System;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Logging.Telemetry;
+using Newtonsoft.Json.Linq;
 using NSubstitute;
 using Xunit;
 
@@ -22,7 +23,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
             var ex = Activator.CreateInstance(exType) as Exception;
 
             var exProcessor = new NormalizationExceptionTelemetryProcessor();
-            var handled = exProcessor.HandleException(ex, log);
+            var handled = exProcessor.HandleException(ex, new JObject(), log);
             Assert.True(handled);
 
             log.ReceivedWithAnyArgs(1).LogMetric(null, default(double));
@@ -36,7 +37,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
             var ex = Activator.CreateInstance(exType) as Exception;
 
             var exProcessor = new NormalizationExceptionTelemetryProcessor();
-            var handled = exProcessor.HandleException(ex, log);
+            var handled = exProcessor.HandleException(ex, new JObject(), log);
             Assert.False(handled);
 
             log.Received(1).LogError(ex);


### PR DESCRIPTION
When we encounter an exception during Normalization or MeasurementToFhir, we now have the ability to send the exception to a destination (IErrorMessageService) if it is supplied at startup. The exception will include the message payload. Note: for MeasurementToFhir the payload is the normalized payload and not the original device data payload.

There is not implementation of IErrorMessageService included in this PR. However, if one is injected then it will be used.