### PR TITLE
fix - Duplicate logging of unhandled/retryable exceptions.

### DIFF
--- a/src/console/MeasurementCollectionToFhir/Processor.cs
+++ b/src/console/MeasurementCollectionToFhir/Processor.cs
@@ -16,6 +16,7 @@ using Microsoft.Health.Events.Model;
 using Microsoft.Health.Events.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Host;
 using Microsoft.Health.Fhir.Ingest.Service;
+using Microsoft.Health.Fhir.Ingest.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Logging.Telemetry;
 using Polly;
@@ -97,8 +98,7 @@ namespace Microsoft.Health.Fhir.Ingest.Console.MeasurementCollectionToFhir
 
         private static void TrackExceptionMetric(Exception exception, ITelemetryLogger logger)
         {
-            var type = exception.GetType().ToString();
-            var metric = type.ToErrorMetric(ConnectorOperation.FHIRConversion, ErrorType.GeneralError, ErrorSeverity.Warning);
+            var metric = IomtMetrics.UnhandledException(exception.GetType().ToString(), ConnectorOperation.FHIRConversion, ErrorType.GeneralError, ErrorSeverity.Warning);
             logger.LogMetric(metric, 1);
         }
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationEventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationEventConsumerService.cs
@@ -257,8 +257,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
         private static void TrackExceptionMetric(Exception exception, ITelemetryLogger logger)
         {
-            var type = exception.GetType().ToString();
-            var metric = type.ToErrorMetric(ConnectorOperation.Normalization, ErrorType.DeviceMessageError, ErrorSeverity.Warning);
+            var metric = IomtMetrics.UnhandledException(exception.GetType().ToString(), ConnectorOperation.Normalization, ErrorType.DeviceMessageError, ErrorSeverity.Warning);
             logger.LogMetric(metric, 1);
         }
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationEventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationEventConsumerService.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
         private static void TrackExceptionMetric(Exception exception, ITelemetryLogger logger)
         {
-            var metric = IomtMetrics.UnhandledException(exception.GetType().ToString(), ConnectorOperation.Normalization, ErrorType.DeviceMessageError, ErrorSeverity.Warning);
+            var metric = IomtMetrics.UnhandledException(exception.GetType().ToString(), ConnectorOperation.Normalization, ErrorType.GeneralError, ErrorSeverity.Warning);
             logger.LogMetric(metric, 1);
         }
     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/FhirExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/FhirExceptionTelemetryProcessor.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
             var exceptionTypeName = ex.GetType().Name;
 
             var handledExceptionMetric = ex is NotSupportedException ? IomtMetrics.NotSupported() : IomtMetrics.HandledException(exceptionTypeName, _connectorStage);
-            var handledException = HandleException(ex, logger, handledExceptionMetric, IomtMetrics.UnhandledException(exceptionTypeName, _connectorStage));
+            var handledException = HandleException(ex, logger, handledExceptionMetric);
 
             if (handledException && _errorMessageService != null)
             {

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
@@ -159,11 +159,11 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
                 });
         }
 
-        public static Metric UnhandledException(string exceptionName, string connectorStage)
+        public static Metric UnhandledException(string exceptionName, string connectorStage, string errorType = null, string errorSeverity = null)
         {
             EnsureArg.IsNotNullOrWhiteSpace(exceptionName);
 
-            return nameof(UnhandledException).ToErrorMetric(connectorStage, ErrorType.GeneralError, ErrorSeverity.Critical, errorName: exceptionName);
+            return nameof(UnhandledException).ToErrorMetric(connectorStage, errorType ?? ErrorType.GeneralError, errorSeverity ?? ErrorSeverity.Critical, errorName: exceptionName);
         }
 
         public static Metric HandledException(string exceptionName, string connectorStage)

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/NormalizationExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/NormalizationExceptionTelemetryProcessor.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             var exceptionTypeName = ex.GetType().Name;
-            var handledException = HandleException(ex, logger, IomtMetrics.HandledException(exceptionTypeName, _connectorStage), IomtMetrics.UnhandledException(exceptionTypeName, _connectorStage));
+            var handledException = HandleException(ex, logger, IomtMetrics.HandledException(exceptionTypeName, _connectorStage));
 
             if (handledException && _errorMessageService != null)
             {

--- a/src/lib/Microsoft.Health.Logger/Telemetry/ExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Logger/Telemetry/ExceptionTelemetryProcessor.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Logging.Telemetry
             Exception ex,
             ITelemetryLogger logger)
         {
-            return HandleException(ex, logger, handledExceptionMetric: null, unhandledExceptionMetric: null);
+            return HandleException(ex, logger, handledExceptionMetric: null);
         }
 
         public virtual void LogExceptionMetric(
@@ -50,13 +50,11 @@ namespace Microsoft.Health.Logging.Telemetry
         /// <param name="ex">Exception that is to be evaluated as handleable or not.</param>
         /// <param name="logger">Telemetry logger used to log the exception/metric.</param>
         /// <param name="handledExceptionMetric">Exception metric that is to be logged if the passed in exception is handled and not of type ITelemetryFormattable.</param>
-        /// <param name="unhandledExceptionMetric">Exception metric that is to be logged if the passed in exception is unhandled and not of type ITelemetryFormattable.</param>
         /// <returns>Returns true if the exception is handleable, i.e., can be continued upon. False otherwise.</returns>
         protected bool HandleException(
             Exception ex,
             ITelemetryLogger logger,
-            Metric handledExceptionMetric = null,
-            Metric unhandledExceptionMetric = null)
+            Metric handledExceptionMetric = null)
         {
             EnsureArg.IsNotNull(ex, nameof(ex));
             EnsureArg.IsNotNull(logger, nameof(logger));
@@ -66,12 +64,10 @@ namespace Microsoft.Health.Logging.Telemetry
 
             if (_handledExceptions.Contains(lookupType))
             {
+                logger.LogError(ex);
                 LogExceptionMetric(ex, logger, handledExceptionMetric);
                 return true;
             }
-
-            logger.LogError(ex);
-            LogExceptionMetric(ex, logger, unhandledExceptionMetric);
 
             return false;
         }

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/FhirExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/FhirExceptionTelemetryProcessorTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
 
         [Theory]
         [InlineData(typeof(Exception))]
-        public void GivenUnhandledExceptionTypes_WhenHandleExpection_ThenMetricLoggedAndFalseReturned_Test(System.Type exType)
+        public void GivenUnhandledExceptionTypes_WhenHandleExpection_ThenFalseReturned_Test(System.Type exType)
         {
             var log = Substitute.For<ITelemetryLogger>();
             var ex = Activator.CreateInstance(exType) as Exception;

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/FhirExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/FhirExceptionTelemetryProcessorTests.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
     public class FhirExceptionTelemetryProcessorTests
     {
         [Theory]
-        [InlineData(typeof(MultipleResourceFoundException<object>))]
-        [InlineData(typeof(PatientDeviceMismatchException))]
-        [InlineData(typeof(NotSupportedException))]
-        [InlineData(typeof(FhirResourceNotFoundException))]
-        [InlineData(typeof(ResourceIdentityNotDefinedException))]
-        [InlineData(typeof(TemplateNotFoundException))]
-        [InlineData(typeof(InvalidQuantityFhirValueException))]
-        public void GivenHandledExceptionTypes_WhenHandleExpection_ThenMetricLoggedAndTrueReturned_Test(System.Type exType)
+        [InlineData(typeof(MultipleResourceFoundException<object>), "MultipleObjectFoundException")]
+        [InlineData(typeof(PatientDeviceMismatchException), nameof(PatientDeviceMismatchException))]
+        [InlineData(typeof(NotSupportedException), nameof(NotSupportedException))]
+        [InlineData(typeof(FhirResourceNotFoundException), "DeviceNotFoundException")]
+        [InlineData(typeof(ResourceIdentityNotDefinedException), "DeviceIdentityNotDefinedException")]
+        [InlineData(typeof(TemplateNotFoundException), nameof(TemplateNotFoundException))]
+        [InlineData(typeof(InvalidQuantityFhirValueException), nameof(InvalidQuantityFhirValueException))]
+        public void GivenHandledExceptionTypes_WhenHandleExpection_ThenMetricLoggedAndTrueReturned_Test(System.Type exType, string metricName)
         {
             var log = Substitute.For<ITelemetryLogger>();
             var ex = Activator.CreateInstance(exType) as Exception;
@@ -33,7 +33,12 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
             var handled = exProcessor.HandleException(ex, log);
             Assert.True(handled);
 
-            log.ReceivedWithAnyArgs(1).LogMetric(null, default(double));
+            log.Received(1).LogError(ex);
+            log.Received(1).LogMetric(
+                Arg.Is<Metric>(m =>
+                string.Equals(m.Name, metricName) &&
+                string.Equals(m.Dimensions[DimensionNames.Name], metricName)),
+                1);
         }
 
         [Theory]
@@ -46,13 +51,6 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
             var exProcessor = new FhirExceptionTelemetryProcessor();
             var handled = exProcessor.HandleException(ex, log);
             Assert.False(handled);
-
-            log.Received(1).LogError(ex);
-            log.Received(1).LogMetric(
-                Arg.Is<Metric>(m =>
-                string.Equals(m.Name, nameof(IomtMetrics.UnhandledException)) &&
-                string.Equals(m.Dimensions[DimensionNames.Name], exType.Name)),
-                1);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/NormalizationExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/NormalizationExceptionTelemetryProcessorTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
 
         [Theory]
         [InlineData(typeof(Exception))]
-        public void GivenUnhandledExceptionTypes_WhenHandleExpection_ThenMetricLoggedAndFalseReturned_Test(System.Type exType)
+        public void GivenUnhandledExceptionTypes_WhenHandleExpection_ThenFalseReturned_Test(System.Type exType)
         {
             var log = Substitute.For<ITelemetryLogger>();
             var ex = Activator.CreateInstance(exType) as Exception;

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/NormalizationExceptionTelemetryProcessorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Telemetry/NormalizationExceptionTelemetryProcessorTests.cs
@@ -29,7 +29,12 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
             var handled = exProcessor.HandleException(ex, log);
             Assert.True(handled);
 
-            log.ReceivedWithAnyArgs(1).LogMetric(null, default(double));
+            log.Received(1).LogError(ex);
+            log.Received(1).LogMetric(
+                Arg.Is<Metric>(m =>
+                string.Equals(m.Name, exType.Name) &&
+                string.Equals(m.Dimensions[DimensionNames.Name], exType.Name)),
+                1);
         }
 
         [Theory]
@@ -43,13 +48,6 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
             var exProcessor = new NormalizationExceptionTelemetryProcessor(exceptionConfig);
             var handled = exProcessor.HandleException(ex, log);
             Assert.False(handled);
-
-            log.Received(1).LogError(ex);
-            log.Received(1).LogMetric(
-                Arg.Is<Metric>(m =>
-                string.Equals(m.Name, nameof(IomtMetrics.UnhandledException)) &&
-                string.Equals(m.Dimensions[DimensionNames.Name], exType.Name)),
-                1);
         }
     }
 }


### PR DESCRIPTION
Bug: Unhandled exceptions and associated error metrics were being logged by the ExceptionTelemetryProcessor in addition to the logging done in the retry policy created for these operations.
Fix: Removed the logging from ExceptionTelemetryProcessor since the retry policy handles logging for a set of operations in addition to the event processing.