### PR TITLE
Update solution nugets to latest where possible

### DIFF
--- a/Microsoft.Health.Fhir.Ingest.sln
+++ b/Microsoft.Health.Fhir.Ingest.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29009.5
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.Ingest", "src\lib\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj", "{269436ED-1F69-4A83-A2EB-FBE82233472F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest", "src\lib\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj", "{269436ED-1F69-4A83-A2EB-FBE82233472F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lib", "lib", "{513D67B4-80E1-476D-955F-E7E7C79D144A}"
 EndProject
@@ -13,14 +13,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{FAF8B402-8
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Host", "src\func\Microsoft.Health.Fhir.Ingest.Host\Microsoft.Health.Fhir.Ingest.Host.csproj", "{11F6C10F-483A-4DD7-99A3-14FDD5CCA3F1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.Ingest.UnitTests", "test\Microsoft.Health.Fhir.Ingest.UnitTests\Microsoft.Health.Fhir.Ingest.UnitTests.csproj", "{F6422A39-DC02-436B-AC1F-82CC9CF75E73}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.UnitTests", "test\Microsoft.Health.Fhir.Ingest.UnitTests\Microsoft.Health.Fhir.Ingest.UnitTests.csproj", "{F6422A39-DC02-436B-AC1F-82CC9CF75E73}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.R4.Ingest", "src\lib\Microsoft.Health.Fhir.R4.Ingest\Microsoft.Health.Fhir.R4.Ingest.csproj", "{98D001A4-3B1B-4E60-9148-71881A0D457D}"
 	ProjectSection(ProjectDependencies) = postProject
 		{11032625-0B2B-4468-B1F1-431B5682DB7A} = {11032625-0B2B-4468-B1F1-431B5682DB7A}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.R4.Ingest.UnitTests", "test\Microsoft.Health.Fhir.R4.Ingest.UnitTests\Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj", "{10E71A88-CC24-4DFA-92F3-18E47D42E985}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.R4.Ingest.UnitTests", "test\Microsoft.Health.Fhir.R4.Ingest.UnitTests\Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj", "{10E71A88-CC24-4DFA-92F3-18E47D42E985}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "deploy", "deploy", "{AC515DEF-E7DA-4D6C-8EBC-0F17DE83E400}"
 EndProject
@@ -42,7 +42,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "basic", "basic", "{81D325F3
 		sample\templates\basic\fhirmapping.json = sample\templates\basic\fhirmapping.json
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Extensions.Fhir", "src\lib\Microsoft.Health.Extensions.Fhir\Microsoft.Health.Extensions.Fhir.csproj", "{11032625-0B2B-4468-B1F1-431B5682DB7A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Extensions.Fhir", "src\lib\Microsoft.Health.Extensions.Fhir\Microsoft.Health.Extensions.Fhir.csproj", "{11032625-0B2B-4468-B1F1-431B5682DB7A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Extensions.Fhir.R4", "src\lib\Microsoft.Health.Extensions.Fhir.R4\Microsoft.Health.Extensions.Fhir.R4.csproj", "{124A0B74-0FED-473A-86FA-1806B07FF64C}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -51,15 +51,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Extensions
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Common", "src\lib\Microsoft.Health.Common\Microsoft.Health.Common.csproj", "{B5BDAF20-DA88-47AF-94C2-33789479DF99}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Tests.Common", "test\Microsoft.Health.Tests.Common\Microsoft.Health.Tests.Common.csproj", "{9779F9F5-1F23-48B5-B271-0497D9ECE956}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Tests.Common", "test\Microsoft.Health.Tests.Common\Microsoft.Health.Tests.Common.csproj", "{9779F9F5-1F23-48B5-B271-0497D9ECE956}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Common.UnitTests", "test\Microsoft.Health.Common.UnitTests\Microsoft.Health.Common.UnitTests.csproj", "{F8F17DE0-1A3D-4E08-98C0-7EF9AD1E98B0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Common.UnitTests", "test\Microsoft.Health.Common.UnitTests\Microsoft.Health.Common.UnitTests.csproj", "{F8F17DE0-1A3D-4E08-98C0-7EF9AD1E98B0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Extensions.Fhir.UnitTests", "test\Microsoft.Health.Extensions.Fhir.UnitTests\Microsoft.Health.Extensions.Fhir.UnitTests.csproj", "{73C97786-1CC7-4CF9-A420-8AB66D0BD731}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Extensions.Fhir.UnitTests", "test\Microsoft.Health.Extensions.Fhir.UnitTests\Microsoft.Health.Extensions.Fhir.UnitTests.csproj", "{73C97786-1CC7-4CF9-A420-8AB66D0BD731}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Extensions.Fhir.R4.UnitTests", "test\Microsoft.Health.Extensions.Fhir.R4.UnitTests\Microsoft.Health.Extensions.Fhir.R4.UnitTests.csproj", "{90402958-43C6-43E8-A22A-1B1469A4FCC5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Extensions.Fhir.R4.UnitTests", "test\Microsoft.Health.Extensions.Fhir.R4.UnitTests\Microsoft.Health.Extensions.Fhir.R4.UnitTests.csproj", "{90402958-43C6-43E8-A22A-1B1469A4FCC5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Extensions.Host", "src\lib\Microsoft.Health.Extensions.Host\Microsoft.Health.Extensions.Host.csproj", "{9110663E-BFA0-4082-B1BE-F85D91DEFCA2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Extensions.Host", "src\lib\Microsoft.Health.Extensions.Host\Microsoft.Health.Extensions.Host.csproj", "{9110663E-BFA0-4082-B1BE-F85D91DEFCA2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "healthkitOnFhir", "healthkitOnFhir", "{31F33751-AA52-4B4C-816B-31B69913B346}"
 	ProjectSection(SolutionItems) = preProject
@@ -67,15 +67,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "healthkitOnFhir", "healthki
 		sample\templates\healthkitOnFhir\fhirmapping.json = sample\templates\healthkitOnFhir\fhirmapping.json
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.Ingest.Template", "src\lib\Microsoft.Health.Fhir.Ingest.Template\Microsoft.Health.Fhir.Ingest.Template.csproj", "{85D653A7-0E63-4751-8904-728156807A14}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Template", "src\lib\Microsoft.Health.Fhir.Ingest.Template\Microsoft.Health.Fhir.Ingest.Template.csproj", "{85D653A7-0E63-4751-8904-728156807A14}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Schema", "src\lib\Microsoft.Health.Fhir.Ingest.Schema\Microsoft.Health.Fhir.Ingest.Schema.csproj", "{A85AB6BC-698C-460F-81D4-9D1D2BD14B71}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.Ingest.Template.UnitTests", "test\Microsoft.Health.Fhir.Ingest.Template.UnitTests\Microsoft.Health.Fhir.Ingest.Template.UnitTests.csproj", "{EE072537-807D-4FE2-BFEB-424B64DCD7F9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Template.UnitTests", "test\Microsoft.Health.Fhir.Ingest.Template.UnitTests\Microsoft.Health.Fhir.Ingest.Template.UnitTests.csproj", "{EE072537-807D-4FE2-BFEB-424B64DCD7F9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Tests.Common.R4", "test\Microsoft.Health.Tests.Common.R4\Microsoft.Health.Tests.Common.R4.csproj", "{0B0F4BCE-E439-47AB-A67A-8B3778407339}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Tests.Common.R4", "test\Microsoft.Health.Tests.Common.R4\Microsoft.Health.Tests.Common.R4.csproj", "{0B0F4BCE-E439-47AB-A67A-8B3778407339}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Events", "src\lib\Microsoft.Health.Events\Microsoft.Health.Events.csproj", "{22275DE3-859D-40F0-9547-7711568164C0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Events", "src\lib\Microsoft.Health.Events\Microsoft.Health.Events.csproj", "{22275DE3-859D-40F0-9547-7711568164C0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "console", "console", "{1EF3584A-C437-4B45-8BF8-1597D5A8DBC7}"
 EndProject
@@ -96,15 +96,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "legacy", "legacy", "{657FB6
 		sample\templates\sandbox\legacy\devicecontent.json = sample\templates\sandbox\legacy\devicecontent.json
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Expressions", "src\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj", "{0BC152B5-DF88-4750-A7CC-1B7429D879F6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Expressions", "src\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj", "{0BC152B5-DF88-4750-A7CC-1B7429D879F6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Expressions.UnitTests", "test\Microsoft.Health.Expressions.UnitTests\Microsoft.Health.Expressions.UnitTests.csproj", "{9BF918FE-E09B-4072-8CC5-2BE479230719}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Expressions.UnitTests", "test\Microsoft.Health.Expressions.UnitTests\Microsoft.Health.Expressions.UnitTests.csproj", "{9BF918FE-E09B-4072-8CC5-2BE479230719}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.Ingest.Validation", "src\lib\Microsoft.Health.Fhir.Ingest.Validation\Microsoft.Health.Fhir.Ingest.Validation.csproj", "{7F507901-30BD-41CD-99B8-FD8FA103D70A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Validation", "src\lib\Microsoft.Health.Fhir.Ingest.Validation\Microsoft.Health.Fhir.Ingest.Validation.csproj", "{7F507901-30BD-41CD-99B8-FD8FA103D70A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.Ingest.Validation.UnitTests", "test\Microsoft.Health.Fhir.Ingest.Validation.UnitTests\Microsoft.Health.Fhir.Ingest.Validation.UnitTests.csproj", "{34B7EABB-DC53-47AC-86E0-35596FF18312}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Validation.UnitTests", "test\Microsoft.Health.Fhir.Ingest.Validation.UnitTests\Microsoft.Health.Fhir.Ingest.Validation.UnitTests.csproj", "{34B7EABB-DC53-47AC-86E0-35596FF18312}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.R4.Ingest.Templates", "src\lib\Microsoft.Health.Fhir.R4.Ingest.Templates\Microsoft.Health.Fhir.R4.Ingest.Templates.csproj", "{90B4DFD0-D039-438D-9541-A12482C2D9BE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.R4.Ingest.Templates", "src\lib\Microsoft.Health.Fhir.R4.Ingest.Templates\Microsoft.Health.Fhir.R4.Ingest.Templates.csproj", "{90B4DFD0-D039-438D-9541-A12482C2D9BE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
+++ b/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
@@ -7,8 +7,8 @@
 		<IsPackable>true</IsPackable>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -20,7 +20,7 @@
 		<ProjectReference Include="..\lib\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />
 		<ProjectReference Include="..\lib\Microsoft.Health.Fhir.R4.Ingest\Microsoft.Health.Fhir.R4.Ingest.csproj" />
 		<ProjectReference Include="..\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj" />
-		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="2.0.55" />
+		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="3.0.32" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/console/Program.cs
+++ b/src/console/Program.cs
@@ -93,7 +93,10 @@ namespace Microsoft.Health.Fhir.Ingest.Console
             }
             else
             {
-                telemetryConfig = new TelemetryConfiguration(instrumentationKey);
+                telemetryConfig = new TelemetryConfiguration()
+                {
+                    ConnectionString = $"InstrumentationKey={instrumentationKey}",
+                };
                 telemetryClient = new TelemetryClient(telemetryConfig);
             }
 

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/IomtConnectorFunctions.cs
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/IomtConnectorFunctions.cs
@@ -6,11 +6,11 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs;
 using DevLab.JmesPath;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Options;

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -19,6 +19,7 @@
 		<FhirVersion Condition="'$(FhirVersion)' == ''">R4</FhirVersion>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
 		<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
 		<PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
 		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.0.1" />
@@ -28,7 +29,6 @@
 		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
 		<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.30" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.12" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -20,27 +20,27 @@
   </PropertyGroup>  
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.1.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.27" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.12" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.33" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -1,68 +1,70 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-    <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
-    <HighEntropyVA>true</HighEntropyVA>
-    <AssemblyName>Microsoft.Health.Fhir.Ingest.Host</AssemblyName>
-    <RootNamespace>Microsoft.Health.Fhir.Ingest.Host</RootNamespace>
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsAsErrors />
-  </PropertyGroup>
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
-  <PropertyGroup>
-    <FhirVersion Condition="'$(FhirVersion)' == ''">R4</FhirVersion>
-  </PropertyGroup>  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.1.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.33" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
-    <PackageReference Include="Ensure.That" Version="10.1.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="host.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-    <None Update="template_fhirmapping.json">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </None>
-    <None Update="template_content.json">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\lib\Microsoft.Health.Fhir.$(FhirVersion).Ingest\Microsoft.Health.Fhir.$(FhirVersion).Ingest.csproj" />
-    <ProjectReference Include="..\..\lib\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />
-    <ProjectReference Include="..\..\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<AzureFunctionsVersion>v4</AzureFunctionsVersion>
+		<CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
+		<HighEntropyVA>true</HighEntropyVA>
+		<AssemblyName>Microsoft.Health.Fhir.Ingest.Host</AssemblyName>
+		<RootNamespace>Microsoft.Health.Fhir.Ingest.Host</RootNamespace>
+		<LangVersion>10.0</LangVersion>
+	</PropertyGroup>
+	<PropertyGroup>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<WarningsAsErrors />
+	</PropertyGroup>
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+	</PropertyGroup>
+	<PropertyGroup>
+		<FhirVersion Condition="'$(FhirVersion)' == ''">R4</FhirVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
+		<PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.0.1" />
+		<PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.2" />
+		<PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.6.2" />
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
+		<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.30" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.12" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
+		<PackageReference Include="Ensure.That" Version="10.1.0" />
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="host.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="local.settings.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</None>
+		<None Update="template_fhirmapping.json">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</None>
+		<None Update="template_content.json">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
+		<AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\lib\Microsoft.Health.Fhir.$(FhirVersion).Ingest\Microsoft.Health.Fhir.$(FhirVersion).Ingest.csproj" />
+		<ProjectReference Include="..\..\lib\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />
+		<ProjectReference Include="..\..\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/Microsoft.Health.Fhir.Ingest.Host.csproj
@@ -19,7 +19,6 @@
     <FhirVersion Condition="'$(FhirVersion)' == ''">R4</FhirVersion>
   </PropertyGroup>  
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.1.1" />

--- a/src/func/Microsoft.Health.Fhir.Ingest.Host/host.json
+++ b/src/func/Microsoft.Health.Fhir.Ingest.Host/host.json
@@ -15,11 +15,21 @@
   },
   "extensions": {
     "eventHubs": {
-      "batchCheckpointFrequency": 1,
-      "eventProcessorOptions": {
-        "maxBatchSize": 1024,
-        "prefetchCount": 2048
-      }
+      "maxEventBatchSize": 1024,
+      "prefetchCount": 2048,
+      "transportType": "amqpTcp",
+      "batchCheckpointFrequency": 1
+    },
+    "initialOffsetOptions": {
+      "type": "fromStart",
+      "enqueuedTimeUtc": ""
+    },
+    "clientRetryOptions": {
+      "mode": "exponential",
+      "tryTimeout": "00:01:00",
+      "delay": "00:00:00.80",
+      "maximumDelay": "00:01:00",
+      "maximumRetries": 3
     }
   },
   "version": "2.0"

--- a/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
+++ b/src/lib/Microsoft.Health.Common/Microsoft.Health.Common.csproj
@@ -16,12 +16,12 @@
     <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -30,10 +30,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Azure.Core" Version="1.22.0" />
-    <PackageReference Include="Azure.Identity" Version="1.3.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Identity" Version="1.6.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/lib/Microsoft.Health.Events/Errors/ExceptionContextExtensions.cs
+++ b/src/lib/Microsoft.Health.Events/Errors/ExceptionContextExtensions.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Microsoft.Health.Events.Model;
 
 namespace Microsoft.Health.Events.Errors

--- a/src/lib/Microsoft.Health.Events/Errors/IErrorMessageWithEvents.cs
+++ b/src/lib/Microsoft.Health.Events/Errors/IErrorMessageWithEvents.cs
@@ -4,7 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Microsoft.Health.Events.Model;
 
 namespace Microsoft.Health.Events.Errors

--- a/src/lib/Microsoft.Health.Events/Errors/IomtErrorMessage.cs
+++ b/src/lib/Microsoft.Health.Events/Errors/IomtErrorMessage.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Microsoft.Health.Events.Model;
 
 namespace Microsoft.Health.Events.Errors

--- a/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
+++ b/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
@@ -16,17 +16,17 @@
     <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.3.0" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.2" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.6.2" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.1" />
+    <PackageReference Include="Azure.Identity" Version="1.6.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.1" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.37.1" />
+    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.38.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.12" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Common\Microsoft.Health.Common.csproj" />

--- a/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
+++ b/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
@@ -17,13 +17,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.6.0" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.1" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.1" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.2" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.6.2" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.38.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
+++ b/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.38.1" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/lib/Microsoft.Health.Expressions/Microsoft.Health.Expressions.csproj
+++ b/src/lib/Microsoft.Health.Expressions/Microsoft.Health.Expressions.csproj
@@ -15,7 +15,7 @@
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="Ensure.That" Version="10.1.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -23,7 +23,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="JmesPath.Net" Version="1.0.204" />
+		<PackageReference Include="JmesPath.Net" Version="1.0.205" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Microsoft.Health.Logger\Microsoft.Health.Logging.csproj" />

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
@@ -18,13 +18,13 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Ensure.That" Version="10.1.0" />
-		<PackageReference Include="Azure.Identity" Version="1.3.0" />
-		<PackageReference Include="Hl7.Fhir.R4" Version="3.2.0" />
+		<PackageReference Include="Azure.Identity" Version="1.6.0" />
+		<PackageReference Include="Hl7.Fhir.R4" Version="4.1.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.2" />
-		<PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="4.0.20" />
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.7" />
+		<PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="6.1.77" />
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -39,6 +39,6 @@
 		<ProjectReference Include="..\Microsoft.Health.Extensions.Fhir\Microsoft.Health.Extensions.Fhir.csproj" />
 		<ProjectReference Include="..\Microsoft.Health.Extensions.Host\Microsoft.Health.Extensions.Host.csproj" />
 		<ProjectReference Include="..\Microsoft.Health.Logger\Microsoft.Health.Logging.csproj" />
-		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="2.0.55" />
+		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="3.0.32" />
 	</ItemGroup>
 </Project>

--- a/src/lib/Microsoft.Health.Extensions.Fhir/Microsoft.Health.Extensions.Fhir.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/Microsoft.Health.Extensions.Fhir.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
@@ -13,10 +13,11 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Azure.Identity" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.0.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Host/Microsoft.Health.Extensions.Host.csproj
@@ -13,12 +13,12 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
-    <PackageReference Include="Azure.Identity" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
+    <PackageReference Include="Azure.Identity" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Schema/Microsoft.Health.Fhir.Ingest.Schema.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Schema/Microsoft.Health.Fhir.Ingest.Schema.csproj
@@ -17,7 +17,7 @@
     <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/Microsoft.Health.Fhir.Ingest.Template.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/Microsoft.Health.Fhir.Ingest.Template.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -27,9 +27,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="JmesPath.Net" Version="1.0.204" />
+    <PackageReference Include="JmesPath.Net" Version="1.0.205" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Microsoft.Health.Fhir.Ingest.Validation.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Validation/Microsoft.Health.Fhir.Ingest.Validation.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -30,8 +30,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="Hl7.Fhir.R4" Version="3.2.0" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Data/EventDataWithJsonBodyToJTokenConverter.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Data/EventDataWithJsonBodyToJTokenConverter.cs
@@ -4,8 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Text;
+using Azure.Messaging.EventHubs;
 using EnsureThat;
-using Microsoft.Azure.EventHubs;
 using Microsoft.Health.Fhir.Ingest.Service;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -21,8 +21,8 @@ namespace Microsoft.Health.Fhir.Ingest.Data
 
             try
             {
-                var body = input.Body.Count > 0
-                    ? JToken.Parse(Encoding.UTF8.GetString(input.Body.Array, input.Body.Offset, input.Body.Count))
+                var body = input.Body.Length > 0
+                    ? JToken.Parse(Encoding.UTF8.GetString(input.Body.ToArray()))
                     : null;
                 var data = new { Body = body, input.Properties, input.SystemProperties };
                 token = JToken.FromObject(data);

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Data/MeasurementToEventAsyncCollector.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Data/MeasurementToEventAsyncCollector.cs
@@ -3,11 +3,10 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs;
 using EnsureThat;
-using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Health.Fhir.Ingest.Service;
 using Newtonsoft.Json;
@@ -30,12 +29,9 @@ namespace Microsoft.Health.Fhir.Ingest.Data
 
             var partitionKey = Ensure.String.IsNotNullOrWhiteSpace(item.DeviceId, nameof(item.DeviceId));
             var measurementContent = JsonConvert.SerializeObject(item, Formatting.None);
-            var contentBytes = Encoding.UTF8.GetBytes(measurementContent);
 
-            using (var eventData = new EventData(contentBytes))
-            {
-                await _eventHubService.SendAsync(eventData, partitionKey).ConfigureAwait(false);
-            }
+            var eventData = new EventData(measurementContent);
+            await _eventHubService.SendAsync(eventData, partitionKey).ConfigureAwait(false);
         }
 
         public async Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
@@ -19,28 +19,28 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.17.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.12" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Polly" Version="7.2.2" />
+    <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Microsoft.Health.Fhir.Ingest.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/IEventHubService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/IEventHubService.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/IEventProcessingMeter.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/IEventProcessingMeter.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementEventNormalizationService.cs
@@ -11,8 +11,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
+using Azure.Messaging.EventHubs;
 using EnsureThat;
-using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Health.Events.Errors;
 using Microsoft.Health.Fhir.Ingest.Data;
@@ -104,8 +104,8 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                     var createdMeasurements = new List<(string, IMeasurement)>();
                     try
                     {
-                        string partitionId = evt.SystemProperties.PartitionKey;
-                        var deviceEventProcessingLatency = DateTime.UtcNow - evt.SystemProperties.EnqueuedTimeUtc;
+                        string partitionId = evt.PartitionKey;
+                        var deviceEventProcessingLatency = DateTime.UtcNow - evt.EnqueuedTime.ToUniversalTime();
 
                         _log.LogMetric(
                             IomtMetrics.DeviceEventProcessingLatency(partitionId),
@@ -124,7 +124,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
                             foreach (var measurement in _contentTemplate.GetMeasurements(token))
                             {
-                                measurement.IngestionTimeUtc = evt.SystemProperties.EnqueuedTimeUtc;
+                                measurement.IngestionTimeUtc = evt.EnqueuedTime.ToUniversalTime().DateTime;
                                 createdMeasurements.Add((partitionId, measurement));
 
                                 stopWatch.Stop();

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest.Templates/Microsoft.Health.Fhir.R4.Ingest.Templates.csproj
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest.Templates/Microsoft.Health.Fhir.R4.Ingest.Templates.csproj
@@ -28,7 +28,7 @@
 		<None Remove="Extensions\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Hl7.Fhir.R4" Version="3.2.0" />
+		<PackageReference Include="Hl7.Fhir.R4" Version="4.1.0" />
     </ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Microsoft.Health.Fhir.R4.Ingest.csproj
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Microsoft.Health.Fhir.R4.Ingest.csproj
@@ -27,21 +27,21 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
-    <PackageReference Include="Hl7.Fhir.R4" Version="3.2.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Polly" Version="7.2.2" />
+    <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\..\stylecop.json" Link="stylecop.json" />

--- a/src/lib/Microsoft.Health.Logger/Microsoft.Health.Logging.csproj
+++ b/src/lib/Microsoft.Health.Logger/Microsoft.Health.Logging.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.17.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
+++ b/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
@@ -12,20 +12,20 @@
 		<WarningsAsErrors />
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="2.0.55" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="3.0.32" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="NSubstitute" Version="4.2.2" />
+		<PackageReference Include="NSubstitute" Version="4.4.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Microsoft.Health.Events.UnitTest/Microsoft.Health.Events.UnitTest.csproj
+++ b/test/Microsoft.Health.Events.UnitTest/Microsoft.Health.Events.UnitTest.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Expressions.UnitTests/Microsoft.Health.Expressions.UnitTests.csproj
+++ b/test/Microsoft.Health.Expressions.UnitTests/Microsoft.Health.Expressions.UnitTests.csproj
@@ -13,19 +13,19 @@
 		<WarningsAsErrors />
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="NSubstitute" Version="4.2.2" />
+		<PackageReference Include="NSubstitute" Version="4.4.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/Microsoft.Health.Extensions.Fhir.R4.UnitTests.csproj
+++ b/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/Microsoft.Health.Extensions.Fhir.R4.UnitTests.csproj
@@ -11,15 +11,15 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -27,8 +27,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hl7.Fhir.R4" Version="3.2.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />

--- a/test/Microsoft.Health.Extensions.Fhir.UnitTests/Microsoft.Health.Extensions.Fhir.UnitTests.csproj
+++ b/test/Microsoft.Health.Extensions.Fhir.UnitTests/Microsoft.Health.Extensions.Fhir.UnitTests.csproj
@@ -11,16 +11,16 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/Microsoft.Health.Fhir.Ingest.Template.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.Template.UnitTests/Microsoft.Health.Fhir.Ingest.Template.UnitTests.csproj
@@ -13,19 +13,19 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Config/EventHubMeasurementCollectorOptionsTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Config/EventHubMeasurementCollectorOptionsTests.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using Microsoft.Azure.EventHubs;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Ingest.Config
@@ -85,8 +84,7 @@ namespace Microsoft.Health.Fhir.Ingest.Config
 
         private static string CreateTestConnectionString()
         {
-            return new EventHubsConnectionStringBuilder(endpointAddress: new System.Uri("https://test"), entityPath: "test", sharedAccessKeyName: "name", sharedAccessKey: "key")
-                .ToString();
+            return "Endpoint=https://test;SharedAccessKeyName=name;SharedAccessKey=key;EntityPath=test";
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/EventDataWithJsonBodyToJTokenConverterTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/EventDataWithJsonBodyToJTokenConverterTests.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Text;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Microsoft.Health.Fhir.Ingest.Service;
 using Microsoft.Health.Tests.Common;
 using Newtonsoft.Json;
@@ -33,12 +33,11 @@ namespace Microsoft.Health.Fhir.Ingest.Data
         {
             var bodyObj = new { p1 = 1, p2 = "a", p3 = new DateTime(2019, 01, 01, 12, 30, 20) };
             var currentTime = DateTime.UtcNow;
-            var offset = Guid.NewGuid().ToString();
+            var offset = 1000;
             var partitionKey = Guid.NewGuid().ToString();
 
-            var evt = new EventData(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(bodyObj)));
+            var evt = new MockEventData(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(bodyObj)), systemProperties: new MockEventSystemProperties(100, currentTime, offset, partitionKey));
             evt.Properties.Add("a", 10);
-            evt.SystemProperties = new EventData.SystemPropertiesCollection(100, currentTime, offset, partitionKey);
             var token = new EventDataWithJsonBodyToJTokenConverter().Convert(evt);
 
             Assert.NotNull(token);
@@ -63,7 +62,7 @@ namespace Microsoft.Health.Fhir.Ingest.Data
 
         [Theory]
         [FileData(@"TestInput/data_IotHubPayloadExample.json")]
-        public void GivenIoTCentralPopulatedEvent_WhenConvert_ThenTokenWithNonSerializedBodyAndPropertiesReturned_Test(string json)
+        public void GivenIotCentralPopulatedEvent_WhenConvert_ThenTokenWithNonSerializedBodyAndPropertiesReturned_Test(string json)
         {
             var evt = EventDataTestHelper.BuildEventFromJson(json);
 

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/MeasurementToEventAsyncCollectorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/MeasurementToEventAsyncCollectorTests.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Text;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Microsoft.Health.Fhir.Ingest.Service;
 using Microsoft.Health.Tests.Common;
 using Newtonsoft.Json;
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.Ingest.Data
             await collector.AddAsync(measurement).ConfigureAwait(false);
 
             await eh.Received(1)
-                .SendAsync(Arg.Is<EventData>(evt => JsonConvert.DeserializeObject<Measurement>(Encoding.UTF8.GetString(evt.Body.Array, evt.Body.Offset, evt.Body.Count)).DeviceId == measurement.DeviceId), "1");
+                .SendAsync(Arg.Is<EventData>(evt => JsonConvert.DeserializeObject<Measurement>(Encoding.UTF8.GetString(evt.Body.ToArray())).DeviceId == measurement.DeviceId), "1");
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/EventDataTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/EventDataTestHelper.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Health.Fhir.Ingest
@@ -20,22 +20,13 @@ namespace Microsoft.Health.Fhir.Ingest
             var propContent = JToken.Parse(token["Properties"].Value<string>());
             var syspContent = JToken.Parse(token["SystemProperties"].Value<string>());
 
-            var eventData = new EventData(Convert.FromBase64String(bodyContent.Value<string>()));
             var properties = propContent.ToObject<Dictionary<string, object>>();
+            var sysProperties = new MockEventSystemProperties(syspContent);
 
-            foreach (var p in properties)
-            {
-                eventData.Properties.Add(p);
-            }
-
-            eventData.SystemProperties = new EventData.SystemPropertiesCollection(0, default(DateTime), null, null);
-            eventData.SystemProperties.Clear();
-            var sysProperties = syspContent.ToObject<Dictionary<string, object>>();
-
-            foreach (var sp in sysProperties)
-            {
-                eventData.SystemProperties.Add(sp.Key, sp.Value);
-            }
+            var eventData = new MockEventData(
+                eventBody: Convert.FromBase64String(bodyContent.Value<string>()),
+                properties: properties,
+                systemProperties: sysProperties);
 
             return eventData;
         }

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
@@ -13,20 +13,20 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/MockEventData.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/MockEventData.cs
@@ -1,0 +1,38 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Azure.Messaging.EventHubs;
+
+namespace Microsoft.Health.Fhir.Ingest
+{
+    internal class MockEventData : EventData
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="MockEventData"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventBody">The raw data to use as the body of the event.</param>
+        /// <param name="properties">The set of free-form event properties to send with the event.</param>
+        /// <param name="systemProperties">The set of system properties received from the Event Hubs service.</param>
+        /// <param name="sequenceNumber">The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.</param>
+        /// <param name="offset">The offset of the event when it was received from the associated Event Hub partition.</param>
+        /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
+        /// <param name="partitionKey">The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.</param>
+        ///
+        public MockEventData(
+            ReadOnlyMemory<byte> eventBody,
+            IDictionary<string, object> properties = null,
+            IReadOnlyDictionary<string, object> systemProperties = null,
+            long sequenceNumber = long.MinValue,
+            long offset = long.MinValue,
+            DateTimeOffset enqueuedTime = default,
+            string partitionKey = null)
+            : base(eventBody, properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey)
+        {
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/MockEventSystemProperties.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/MockEventSystemProperties.cs
@@ -1,0 +1,69 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Health.Fhir.Ingest
+{
+    internal class MockEventSystemProperties : IReadOnlyDictionary<string, object>
+    {
+        private readonly Dictionary<string, object> _properties;
+
+        public MockEventSystemProperties(JToken properties)
+        {
+            _properties = properties.ToObject<Dictionary<string, object>>();
+        }
+
+        public MockEventSystemProperties(long sequenceNumber, DateTime enqueueTime, long offset, string partitionKey)
+        {
+            _properties = new Dictionary<string, object>
+                {
+                    { "x-opt-sequence-number", sequenceNumber },
+                    { "x-opt-enqueued-time", enqueueTime },
+                    { "x-opt-offset", offset },
+                    { "x-opt-partition-key", partitionKey },
+                };
+        }
+
+        public IEnumerable<string> Keys => _properties.Keys;
+
+        public IEnumerable<object> Values => _properties.Values;
+
+        public int Count => _properties.Count();
+
+        public object this[string key]
+        {
+            get
+            {
+                return _properties[key];
+            }
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return _properties.ContainsKey(key);
+        }
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            return _properties.GetEnumerator();
+        }
+
+        public bool TryGetValue(string key, [MaybeNullWhen(false)] out object value)
+        {
+            return _properties.TryGetValue(key, out value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _properties.GetEnumerator();
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/EventProcessingMeterTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/EventProcessingMeterTests.cs
@@ -6,9 +6,8 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Xunit;
-using static Microsoft.Azure.EventHubs.EventData;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
@@ -19,16 +18,10 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         {
             // 22 bytes
             var body = Encoding.UTF8.GetBytes("22 characters to bytes");
-            var evt = new EventData(body);
-
-            // 93 bytes on Linux, 94 bytes on Windows
-            evt.SystemProperties = new SystemPropertiesCollection(1, DateTime.MinValue, "1", "1");
+            var evt = new MockEventData(body);
 
             // 14 bytes
             evt.Properties["7 chars"] = "7 chars";
-
-            // 14 bytes
-            evt.SystemProperties.TryAdd("7 chars", "7 chars");
 
             var evtBatch = new EventData[] { evt };
             IEventProcessingMeter meter = new EventProcessingMeter();
@@ -38,11 +31,11 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             // DateTime.MinValue = "1/1/0001 12:00:00 AM" on Windows
             if (DateTime.MinValue.ToString() == "01/01/0001 00:00:00")
             {
-                Assert.Equal(143, stats.TotalEventsProcessedBytes); // 22 + 93 + 14 + 14 = 143
+                Assert.Equal(154, stats.TotalEventsProcessedBytes); // 22 + 118 + 14 = 154
             }
             else
             {
-                Assert.Equal(144, stats.TotalEventsProcessedBytes); // 22 + 94 + 14 + 14 = 144
+                Assert.Equal(155, stats.TotalEventsProcessedBytes); // 22 + 119 + 14 = 155
             }
         }
     }

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementEventNormalizationServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementEventNormalizationServiceTests.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Template;
@@ -116,7 +116,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 Arg.Is<IEnumerable<IMeasurement>>(
                     measurements =>
                         measurements.Count() == 10 &&
-                        measurements.Where(m => events.Any(e => m.IngestionTimeUtc == e.SystemProperties.EnqueuedTimeUtc)).Count() == 10),
+                        measurements.Where(m => events.Any(e => m.IngestionTimeUtc == e.EnqueuedTime.ToUniversalTime().DateTime)).Count() == 10),
                 Arg.Any<CancellationToken>());
         }
 
@@ -229,10 +229,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
         private static EventData BuildEvent(int? sequence = 0)
         {
-            return new EventData(Array.Empty<byte>())
-            {
-                SystemProperties = new EventData.SystemPropertiesCollection(sequence.Value, DateTime.UtcNow.AddSeconds(sequence.Value - 10), sequence?.ToString(), 0.ToString()),
-            };
+            return new EventData(Array.Empty<byte>());
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Ingest.Validation.UnitTests/Microsoft.Health.Fhir.Ingest.Validation.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.Validation.UnitTests/Microsoft.Health.Fhir.Ingest.Validation.UnitTests.csproj
@@ -15,15 +15,15 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj
@@ -13,20 +13,20 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4FhirHealthServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4FhirHealthServiceTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             var response = await service.CheckHealth();
 
             Assert.Equal(401, response.StatusCode);
-            Assert.Equal("Unauthorized: ", response.Message);
+            Assert.StartsWith("Unauthorized:", response.Message);
         }
 
         [Fact]

--- a/test/Microsoft.Health.Tests.Common.R4/Microsoft.Health.Tests.Common.R4.csproj
+++ b/test/Microsoft.Health.Tests.Common.R4/Microsoft.Health.Tests.Common.R4.csproj
@@ -13,17 +13,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Hl7.Fhir.R4" Version="3.2.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Microsoft.Health.Tests.Common/Microsoft.Health.Tests.Common.csproj
+++ b/test/Microsoft.Health.Tests.Common/Microsoft.Health.Tests.Common.csproj
@@ -13,16 +13,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="10.1.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Update to latest Nuget package versions where applicable.
- Address after package upgrade: 'TelemetryConfiguration.InstrumentationKey.set' is obsolete: 'InstrumentationKey based global ingestion is being deprecated. Use TelemetryConfiguration.ConnectionString. See https://github.com/microsoft/ApplicationInsights-dotnet/issues/2560
- Update unit test for new packages