### PR TITLE
Add compression support

### DIFF
--- a/src/console/Startup.cs
+++ b/src/console/Startup.cs
@@ -29,6 +29,8 @@ using IEventProcessingMeter = Microsoft.Health.Events.Common.IEventProcessingMet
 using Microsoft.Health.Fhir.Ingest.Telemetry;
 using Azure.Messaging.EventHubs.Producer;
 using Microsoft.Health.Events.Errors;
+using Microsoft.Health.Fhir.Ingest.Config;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Health.Fhir.Ingest.Console
 {
@@ -161,8 +163,8 @@ namespace Microsoft.Health.Fhir.Ingest.Console
             var eventHubProducerFactory = serviceProvider.GetRequiredService<IEventProducerClientFactory>();
             var eventHubProducerClient = eventHubProducerFactory.GetEventHubProducerClient(eventHubClientOptions);
             var logger = serviceProvider.GetRequiredService<ITelemetryLogger>();
-
-            return new MeasurementToEventMessageAsyncCollector(new EventHubProducerService(eventHubProducerClient, logger), new HashCodeFactory(), logger);
+            var options = Options.Create(new MeasurementToEventMessageAsyncCollectorOptions());
+            return new MeasurementToEventMessageAsyncCollector(new EventHubProducerService(eventHubProducerClient, logger), new HashCodeFactory(), logger, options);
         }
 
         public virtual EventProcessorClient ResolveEventProcessorClient(IServiceProvider serviceProvider)

--- a/src/lib/Microsoft.Health.Common/IO/Compression.cs
+++ b/src/lib/Microsoft.Health.Common/IO/Compression.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Health.Common.IO
 {
     public static class Compression
     {
+        public static string GzipContentType { get; } = "application/gzip";
+
         public static byte[] CompressWithGzip(byte[] bytes)
         {
             using (var memoryStream = new MemoryStream())
@@ -23,19 +25,31 @@ namespace Microsoft.Health.Common.IO
             }
         }
 
+        public static Stream DecompressWithGzip(Stream compressedStream)
+        {
+            var decompressedStream = new MemoryStream();
+
+            using (var gzip = new GZipStream(compressedStream, CompressionMode.Decompress))
+            {
+                gzip.CopyTo(decompressedStream);
+                decompressedStream.Position = 0;
+                return decompressedStream;
+            }
+        }
+
         public static byte[] DecompressWithGzip(byte[] bytes)
         {
             using (var compressedStream = new MemoryStream(bytes))
             {
-                var decompressedStream = new MemoryStream();
+                using (var decompressedStream = new MemoryStream())
                 {
                     using (var gzip = new GZipStream(compressedStream, CompressionMode.Decompress))
                     {
                         gzip.CopyTo(decompressedStream);
                     }
-                }
 
-                return decompressedStream.ToArray();
+                    return decompressedStream.ToArray();
+                }
             }
         }
     }

--- a/src/lib/Microsoft.Health.Common/IO/Compression.cs
+++ b/src/lib/Microsoft.Health.Common/IO/Compression.cs
@@ -1,0 +1,42 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.IO.Compression;
+
+namespace Microsoft.Health.Common.IO
+{
+    public static class Compression
+    {
+        public static byte[] CompressWithGzip(byte[] bytes)
+        {
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var gzipStream = new GZipStream(memoryStream, CompressionLevel.Fastest))
+                {
+                    gzipStream.Write(bytes, 0, bytes.Length);
+                }
+
+                return memoryStream.ToArray();
+            }
+        }
+
+        public static byte[] DecompressWithGzip(byte[] bytes)
+        {
+            using (var compressedStream = new MemoryStream(bytes))
+            {
+                var decompressedStream = new MemoryStream();
+                {
+                    using (var gzip = new GZipStream(compressedStream, CompressionMode.Decompress))
+                    {
+                        gzip.CopyTo(decompressedStream);
+                    }
+                }
+
+                return decompressedStream.ToArray();
+            }
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Events/Model/EventMessage.cs
+++ b/src/lib/Microsoft.Health.Events/Model/EventMessage.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Health.Events.Model
         public EventMessage(
             string partitionId,
             ReadOnlyMemory<byte> body,
+            string bodyContentType,
             long sequenceNumber,
             long offset,
             DateTimeOffset enqueuedTime,
@@ -28,6 +29,7 @@ namespace Microsoft.Health.Events.Model
         {
             PartitionId = partitionId;
             Body = body;
+            BodyContentType = bodyContentType;
             SequenceNumber = sequenceNumber;
             Offset = offset;
             EnqueuedTime = enqueuedTime;
@@ -37,7 +39,9 @@ namespace Microsoft.Health.Events.Model
 
         public string PartitionId { get; }
 
-        public ReadOnlyMemory<byte> Body { get; }
+        public ReadOnlyMemory<byte> Body { get; set; }
+
+        public string BodyContentType { get; }
 
         public long SequenceNumber { get; }
 

--- a/src/lib/Microsoft.Health.Events/Model/EventMessageFactory.cs
+++ b/src/lib/Microsoft.Health.Events/Model/EventMessageFactory.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Health.Events.Model
             var eventMessage = new EventMessage(
                 eventArgs.Partition.PartitionId,
                 eventArgs.Data.Body,
+                eventArgs.Data.ContentType,
                 eventArgs.Data.Offset,
                 eventArgs.Data.SequenceNumber,
                 eventArgs.Data.EnqueuedTime.UtcDateTime,

--- a/src/lib/Microsoft.Health.Events/Model/IEventMessage.cs
+++ b/src/lib/Microsoft.Health.Events/Model/IEventMessage.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Health.Events.Model
     {
         string PartitionId { get; }
 
-        ReadOnlyMemory<byte> Body { get; }
+        ReadOnlyMemory<byte> Body { get; set; }
+
+        string BodyContentType { get; }
 
         long SequenceNumber { get; }
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Config/MeasurementToEventMessageAsyncCollectorOptions.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Config/MeasurementToEventMessageAsyncCollectorOptions.cs
@@ -1,0 +1,14 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Ingest.Config
+{
+    public class MeasurementToEventMessageAsyncCollectorOptions
+    {
+        public const string Settings = "CollectorOptions";
+
+        public bool UseCompressionOnSend { get; set; } = false;
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Data/MeasurementToEventMessageAsyncCollector.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Data/MeasurementToEventMessageAsyncCollector.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Health.Fhir.Ingest.Data
         private readonly IEventHubMessageService _eventHubService;
         private readonly IHashCodeFactory _hashCodeFactory;
         private readonly ITelemetryLogger _telemetryLogger;
+        private readonly string _compressionEnabled;
 
         public MeasurementToEventMessageAsyncCollector(
             IEventHubMessageService eventHubService,
@@ -32,6 +33,7 @@ namespace Microsoft.Health.Fhir.Ingest.Data
             _eventHubService = EnsureArg.IsNotNull(eventHubService, nameof(eventHubService));
             _hashCodeFactory = EnsureArg.IsNotNull(hashCodeFactory, nameof(hashCodeFactory));
             _telemetryLogger = EnsureArg.IsNotNull(telemetryLogger, nameof(telemetryLogger));
+            _compressionEnabled = Environment.GetEnvironmentVariable("CompressionEnabled");
         }
 
         public async Task AddAsync(IMeasurement item, CancellationToken cancellationToken = default(CancellationToken))
@@ -66,30 +68,53 @@ namespace Microsoft.Health.Fhir.Ingest.Data
                     var partitionKey = grp.Key;
                     var currentEventDataBatch = await _eventHubService.CreateEventDataBatchAsync(partitionKey);
 
-                    foreach (var m in grp)
+                    // Compression enhancement (off by default)
+                    // Behavior is to compress the entire measurement group and send it
+                    // When decompression is supported on the fhirtransformation side,
+                    // the compression enhancement will be changed to be on by default.
+                    if (_compressionEnabled != null && _compressionEnabled == "True")
                     {
-                        var measurementContent = JsonConvert.SerializeObject(m, Formatting.None);
-                        var contentBytes = Encoding.UTF8.GetBytes(measurementContent);
-                        var eventData = new EventData(contentBytes);
+                        var measurementGroupContent = JsonConvert.SerializeObject(grp, Formatting.None);
+                        var contentBytes = Encoding.UTF8.GetBytes(measurementGroupContent);
+                        var compressedBytes = Common.IO.Compression.CompressWithGzip(contentBytes);
+                        var eventData = new EventData(compressedBytes);
+                        eventData.ContentType = "application/gzip";
+                        eventData.Properties["IsMeasurementGroup"] = true;
 
                         if (!currentEventDataBatch.TryAdd(eventData))
                         {
-                            // The current EventDataBatch cannot hold any more events. Create a new EventDataBatch and add this new message to it.
-                            var newEventDataBatch = await _eventHubService.CreateEventDataBatchAsync(partitionKey);
+                            _telemetryLogger.LogError(new ArgumentOutOfRangeException($"A measurement group exceeded the maximum message batch size of {currentEventDataBatch.MaximumSizeInBytes} bytes. It will be skipped."));
 
-                            if (!newEventDataBatch.TryAdd(eventData))
+                            // consider sending to error message service
+                        }
+                    }
+                    else
+                    {
+                        foreach (var m in grp)
+                        {
+                            var measurementContent = JsonConvert.SerializeObject(m, Formatting.None);
+                            var contentBytes = Encoding.UTF8.GetBytes(measurementContent);
+                            var eventData = new EventData(contentBytes);
+
+                            if (!currentEventDataBatch.TryAdd(eventData))
                             {
-                                // The measurement event is greater than the size allowed by EventHub. Log and discard. Keep the existing batch as there may
-                                // be room for more events.
-                                // TODO in this case we should send this to a dead letter queue. We'd need to see how we can send it, as it is too big for EventHub...
-                                _telemetryLogger.LogError(new ArgumentOutOfRangeException($"A measurement event exceeded the maximum message batch size of {newEventDataBatch.MaximumSizeInBytes} bytes. It will be skipped."));
-                            }
-                            else
-                            {
-                                // Submit the current batch, and replace the currentEventDataBatch with newEventDataBatch
-                                await _eventHubService.SendAsync(currentEventDataBatch, cancellationToken);
-                                currentEventDataBatch.Dispose();
-                                currentEventDataBatch = newEventDataBatch;
+                                // The current EventDataBatch cannot hold any more events. Create a new EventDataBatch and add this new message to it.
+                                var newEventDataBatch = await _eventHubService.CreateEventDataBatchAsync(partitionKey);
+
+                                if (!newEventDataBatch.TryAdd(eventData))
+                                {
+                                    // The measurement event is greater than the size allowed by EventHub. Log and discard. Keep the existing batch as there may
+                                    // be room for more events.
+                                    // TODO in this case we should send this to a dead letter queue. We'd need to see how we can send it, as it is too big for EventHub...
+                                    _telemetryLogger.LogError(new ArgumentOutOfRangeException($"A measurement event exceeded the maximum message batch size of {newEventDataBatch.MaximumSizeInBytes} bytes. It will be skipped."));
+                                }
+                                else
+                                {
+                                    // Submit the current batch, and replace the currentEventDataBatch with newEventDataBatch
+                                    await _eventHubService.SendAsync(currentEventDataBatch, cancellationToken);
+                                    currentEventDataBatch.Dispose();
+                                    currentEventDataBatch = newEventDataBatch;
+                                }
                             }
                         }
                     }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementGroupProcessingException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementGroupProcessingException.cs
@@ -1,0 +1,34 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Common.Telemetry;
+using Microsoft.Health.Common.Telemetry.Exceptions;
+
+namespace Microsoft.Health.Fhir.Ingest.Service
+{
+    public class MeasurementGroupProcessingException : IomtTelemetryFormattableException
+    {
+        private static readonly string _errorType = ErrorType.FHIRConversionError;
+
+        public MeasurementGroupProcessingException(
+            string message,
+            Exception innerException,
+            string errorName)
+            : base(
+                  message,
+                  innerException,
+                  name: $"{_errorType}{errorName}",
+                  operation: ConnectorOperation.Grouping)
+        {
+        }
+
+        public override string ErrType => _errorType;
+
+        public override string ErrSeverity => ErrorSeverity.Critical;
+
+        public override string ErrSource => nameof(ErrorSource.Service);
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/FhirExceptionTelemetryProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/FhirExceptionTelemetryProcessor.cs
@@ -39,11 +39,13 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
         // The following additional exceptions logged to the error message service immediately and are not retried:
         // - ValidationException (Template validation errors)
         // - MeasurementProcessingException (Could not convert event to measurement)
+        // - MeasurementGroupProcessingException (Could not process measurement group)
         // - FhirDataMappingException (FHIR mapping template exception)
         public FhirExceptionTelemetryProcessor(IErrorMessageService errorMessageService)
             : base(
                 typeof(ValidationException),
                 typeof(MeasurementProcessingException),
+                typeof(MeasurementGroupProcessingException),
                 typeof(FhirDataMappingException),
                 typeof(PatientDeviceMismatchException),
                 typeof(ResourceIdentityNotDefinedException),

--- a/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
+++ b/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
@@ -18,6 +18,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="2.0.55" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />

--- a/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
+++ b/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
@@ -30,7 +30,6 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />

--- a/test/Microsoft.Health.Events.UnitTest/EventBatchingTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventBatchingTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Events.UnitTest
 
             var enqueuedTime = DateTime.UtcNow;
 
-            var event1 = new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, enqueuedTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            var event1 = new EventMessage("0", new ReadOnlyMemory<byte>(), null, 1, 1, enqueuedTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
 
             await eventReader.ConsumeEvent(event1);
 
@@ -50,14 +50,14 @@ namespace Microsoft.Health.Events.UnitTest
             var eventReader = new EventBatchingService(_eventConsumerService, _options, _checkpointClient, _logger);
 
             var firstEventTime = DateTime.UtcNow.AddSeconds(-901);
-            var firstEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, firstEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            var firstEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), null, 1, 1, firstEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
             await eventReader.ConsumeEvent(firstEvent);
 
             var endWindow = firstEventTime.Add(TimeSpan.FromSeconds(_options.FlushTimespan));
             Assert.Equal(endWindow, eventReader.GetPartition("0").GetPartitionWindow());
 
             var nextEventTime = DateTime.UtcNow;
-            var nextEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), 2, 2, nextEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            var nextEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), null, 2, 2, nextEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
             await eventReader.ConsumeEvent(nextEvent);
 
             // check that the window is incremented up until next event is included in the current window
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Events.UnitTest
             var eventReader = new EventBatchingService(_eventConsumerService, _options, _checkpointClient, _logger);
 
             var firstEventTime = DateTime.UtcNow.AddSeconds(-301);
-            var firstEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, firstEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            var firstEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), null, 1, 1, firstEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
             await eventReader.ConsumeEvent(firstEvent);
 
             // first window end is: utc - 1 second
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Events.UnitTest
             Assert.Equal(endWindow, eventReader.GetPartition(firstEvent.PartitionId).GetPartitionWindow());
 
             var nextEventTime = DateTime.UtcNow;
-            var nextEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), 2, 2, nextEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            var nextEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), null, 2, 2, nextEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
             await eventReader.ConsumeEvent(nextEvent);
 
             // flush the 1 event that exists within the first window, verify event outside of window is in queue
@@ -103,7 +103,7 @@ namespace Microsoft.Health.Events.UnitTest
             var eventReader = new EventBatchingService(_eventConsumerService, _options, _checkpointClient, _logger);
 
             var newEventTime = DateTime.UtcNow;
-            var newEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, newEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            var newEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), null, 1, 1, newEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
             await eventReader.ConsumeEvent(newEvent);
             await eventReader.ConsumeEvent(newEvent);
 
@@ -124,7 +124,7 @@ namespace Microsoft.Health.Events.UnitTest
             var eventReader = new EventBatchingService(_eventConsumerService, _options, _checkpointClient, _logger);
 
             var firstEventTime = DateTime.UtcNow.AddSeconds(-400);
-            var firstEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, firstEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            var firstEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), null, 1, 1, firstEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
             await eventReader.ConsumeEvent(firstEvent);
 
             var maxWaitEvent = new MaximumWaitEvent("0", DateTime.UtcNow.AddSeconds(-10));
@@ -138,7 +138,7 @@ namespace Microsoft.Health.Events.UnitTest
             var eventReader = new EventBatchingService(_eventConsumerService, _options, _checkpointClient, _logger);
 
             var firstEventTime = DateTime.UtcNow.AddSeconds(-30);
-            var firstEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, firstEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            var firstEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), null, 1, 1, firstEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
             await eventReader.ConsumeEvent(firstEvent);
 
             var maxWaitEvent = new MaximumWaitEvent("0", DateTime.UtcNow.AddSeconds(-10));
@@ -154,7 +154,7 @@ namespace Microsoft.Health.Events.UnitTest
             var eventReader = new EventBatchingService(_eventConsumerService, _options, _checkpointClient, _logger);
 
             var firstEventTime = DateTime.UtcNow.AddSeconds(-301);
-            var firstEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, firstEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            var firstEvent = new EventMessage("0", new ReadOnlyMemory<byte>(), null, 1, 1, firstEventTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
             await eventReader.ConsumeEvent(firstEvent);
 
             await _checkpointClient.Received(1).SetCheckpointAsync(firstEvent);

--- a/test/Microsoft.Health.Events.UnitTest/EventConsumerServiceTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventConsumerServiceTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Events.UnitTest
         {
             var initialBatch = new List<EventMessage>()
             {
-                new EventMessage("0", new ReadOnlyMemory<byte>(), 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()))
+                new EventMessage("0", new ReadOnlyMemory<byte>(), null, 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()))
             };
 
             var logger = Substitute.For<ITelemetryLogger>();

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/MeasurementToEventMessageAsyncCollectorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/MeasurementToEventMessageAsyncCollectorTests.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Service;
 using Microsoft.Health.Logging.Telemetry;
 using NSubstitute;
@@ -22,14 +24,16 @@ namespace Microsoft.Health.Fhir.Ingest.Data
         private IHashCodeGenerator _hashCodeGenerator;
         private ITelemetryLogger _telemetryLogger;
         private IEnumerableAsyncCollector<IMeasurement> _measurementCollector;
+        private IOptions<MeasurementToEventMessageAsyncCollectorOptions> _options;
 
         public MeasurementToEventMessageAsyncCollectorTests()
         {
             _eventHubService = Substitute.For<IEventHubMessageService>();
             _hashCodeFactory = Substitute.For<IHashCodeFactory>();
             _telemetryLogger = Substitute.For<ITelemetryLogger>();
+            _options = Substitute.For<IOptions<MeasurementToEventMessageAsyncCollectorOptions>>();
 
-            _measurementCollector = new MeasurementToEventMessageAsyncCollector(_eventHubService, _hashCodeFactory, _telemetryLogger);
+            _measurementCollector = new MeasurementToEventMessageAsyncCollector(_eventHubService, _hashCodeFactory, _telemetryLogger, _options);
             _hashCodeGenerator = Substitute.For<IHashCodeGenerator>();
             _hashCodeGenerator.GenerateHashCode(Arg.Any<string>()).Returns("123");
             _hashCodeFactory.CreateDeterministicHashCodeGenerator().Returns(_hashCodeGenerator);

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/MeasurementToEventMessageAsyncCollectorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/MeasurementToEventMessageAsyncCollectorTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Ingest.Data
             _eventHubService = Substitute.For<IEventHubMessageService>();
             _hashCodeFactory = Substitute.For<IHashCodeFactory>();
             _telemetryLogger = Substitute.For<ITelemetryLogger>();
-            _options = Substitute.For<IOptions<MeasurementToEventMessageAsyncCollectorOptions>>();
+            _options = Options.Create(new MeasurementToEventMessageAsyncCollectorOptions());
 
             _measurementCollector = new MeasurementToEventMessageAsyncCollector(_eventHubService, _hashCodeFactory, _telemetryLogger, _options);
             _hashCodeGenerator = Substitute.For<IHashCodeGenerator>();

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
@@ -18,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
@@ -18,7 +18,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Microsoft.Health.Fhir.Ingest.UnitTests.csproj
@@ -30,7 +30,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
@@ -208,8 +208,8 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
             var fhirImport = new MeasurementFhirImportService(fhirService, options, exceptionTelemetryProcessor);
 
-            JArray o = JArray.Parse(
-            @"[{
+            JObject o = JObject.Parse(
+            @"{
                 'Type': 'summary',
                 'OccurrenceTimeUtc': '2020-08-10T00:15:00Z',
                 'IngestionTimeUtc': '2022-08-10T19:29:56.993Z',
@@ -221,7 +221,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                     { 'Name': 'testdata1','Value':'1'},
                     { 'Name': 'testdata2','Value':'2'}
                 ]
-            }]");
+            }");
 
             var jsonString = JsonConvert.SerializeObject(o, Formatting.None);
             var contentBytes = Encoding.UTF8.GetBytes(jsonString);

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
@@ -208,20 +208,20 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
             var fhirImport = new MeasurementFhirImportService(fhirService, options, exceptionTelemetryProcessor);
 
-            JObject o = JObject.Parse(
-            @"{
-		        'Type': 'summary',
+            JArray o = JArray.Parse(
+            @"[{
+                'Type': 'summary',
                 'OccurrenceTimeUtc': '2020-08-10T00:15:00Z',
-		        'IngestionTimeUtc': '2022-08-10T19:29:56.993Z',
-		        'DeviceId': 'ABC',
-		        'PatientId': '123',
-		        'EncounterId': null,
-		        'CorrelationId': null,
-		        'Properties': [
+                'IngestionTimeUtc': '2022-08-10T19:29:56.993Z',
+                'DeviceId': 'ABC',
+                'PatientId': '123',
+                'EncounterId': null,
+                'CorrelationId': null,
+                'Properties': [
                     { 'Name': 'testdata1','Value':'1'},
-			        { 'Name': 'testdata2','Value':'2'}
-		        ]
-	         }");
+                    { 'Name': 'testdata2','Value':'2'}
+                ]
+            }]");
 
             var jsonString = JsonConvert.SerializeObject(o, Formatting.None);
             var contentBytes = Encoding.UTF8.GetBytes(jsonString);
@@ -249,18 +249,18 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
             JArray o = JArray.Parse(
             @"[{
-		        'Type': 'summary',
+                'Type': 'summary',
                 'OccurrenceTimeUtc': '2020-08-10T00:15:00Z',
-		        'IngestionTimeUtc': '2022-08-10T19:29:56.993Z',
-		        'DeviceId': 'ABC',
-		        'PatientId': '123',
-		        'EncounterId': null,
-		        'CorrelationId': null,
-		        'Properties': [
+                'IngestionTimeUtc': '2022-08-10T19:29:56.993Z',
+                'DeviceId': 'ABC',
+                'PatientId': '123',
+                'EncounterId': null,
+                'CorrelationId': null,
+                'Properties': [
                     { 'Name': 'testdata1','Value':'1'},
-			        { 'Name': 'testdata2','Value':'2'}
-		        ]
-	         }]");
+                    { 'Name': 'testdata2','Value':'2'}
+                ]
+            }]");
 
             var jsonString = JsonConvert.SerializeObject(o, Formatting.None);
             var contentBytes = Encoding.UTF8.GetBytes(jsonString);
@@ -289,18 +289,18 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
             JArray o = JArray.Parse(
             @"[{
-		        'Type': 'summary',
+                'Type': 'summary',
                 'OccurrenceTimeUtc': '2020-08-10T00:15:00Z',
-		        'IngestionTimeUtc': '2022-08-10T19:29:56.993Z',
-		        'DeviceId': 'ABC',
-		        'PatientId': '123',
-		        'EncounterId': null,
-		        'CorrelationId': null,
-		        'Properties': [
+                'IngestionTimeUtc': '2022-08-10T19:29:56.993Z',
+                'DeviceId': 'ABC',
+                'PatientId': '123',
+                'EncounterId': null,
+                'CorrelationId': null,
+                'Properties': [
                     { 'Name': 'testdata1','Value':'1'},
-			        { 'Name': 'testdata2','Value':'2'}
-		        ]
-	         }]");
+                    { 'Name': 'testdata2','Value':'2'}
+                ]
+            }]");
 
             var jsonString = JsonConvert.SerializeObject(o, Formatting.None);
             var contentBytes = Encoding.UTF8.GetBytes(jsonString);

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
@@ -5,10 +5,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Health.Common.Config;
+using Microsoft.Health.Events.Model;
 using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Telemetry;
@@ -16,6 +19,7 @@ using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Logging.Telemetry;
 using Microsoft.Health.Tests.Common;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NSubstitute;
 using Xunit;
 
@@ -192,6 +196,130 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             // Telemetry logging is async/non-blocking. Ensure enough time has pass so section is hit.
             await Task.Delay(1000);
             log.ReceivedWithAnyArgs(6).LogMetric(null, 0d);
+        }
+
+        [Fact]
+        public async void GivenMeasurementEvent_WhenProcessEventsAsync_ThenProcessAsyncInvokedAndCompleteSuccessfully_Test()
+        {
+            var log = Substitute.For<ITelemetryLogger>();
+            var options = BuildMockOptions();
+            var fhirService = Substitute.For<FhirImportService>();
+            var exceptionTelemetryProcessor = Substitute.For<IExceptionTelemetryProcessor>();
+
+            var fhirImport = new MeasurementFhirImportService(fhirService, options, exceptionTelemetryProcessor);
+
+            JObject o = JObject.Parse(
+            @"{
+		        'Type': 'summary',
+                'OccurrenceTimeUtc': '2020-08-10T00:15:00Z',
+		        'IngestionTimeUtc': '2022-08-10T19:29:56.993Z',
+		        'DeviceId': 'ABC',
+		        'PatientId': '123',
+		        'EncounterId': null,
+		        'CorrelationId': null,
+		        'Properties': [
+                    { 'Name': 'testdata1','Value':'1'},
+			        { 'Name': 'testdata2','Value':'2'}
+		        ]
+	         }");
+
+            var jsonString = JsonConvert.SerializeObject(o, Formatting.None);
+            var contentBytes = Encoding.UTF8.GetBytes(jsonString);
+
+            var events = new List<EventMessage>()
+            {
+                new EventMessage("0", contentBytes, null, 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>())),
+            };
+
+            await fhirImport.ProcessEventsAsync(events, string.Empty, log);
+
+            options.TemplateFactory.Received(1).Create(string.Empty);
+            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default);
+        }
+
+        [Fact]
+        public async void GivenMeasurementGroupEvent_WhenProcessEventsAsync_ThenProcessAsyncInvokedAndCompleteSuccessfully_Test()
+        {
+            var log = Substitute.For<ITelemetryLogger>();
+            var options = BuildMockOptions();
+            var fhirService = Substitute.For<FhirImportService>();
+            var exceptionTelemetryProcessor = Substitute.For<IExceptionTelemetryProcessor>();
+
+            var fhirImport = new MeasurementFhirImportService(fhirService, options, exceptionTelemetryProcessor);
+
+            JArray o = JArray.Parse(
+            @"[{
+		        'Type': 'summary',
+                'OccurrenceTimeUtc': '2020-08-10T00:15:00Z',
+		        'IngestionTimeUtc': '2022-08-10T19:29:56.993Z',
+		        'DeviceId': 'ABC',
+		        'PatientId': '123',
+		        'EncounterId': null,
+		        'CorrelationId': null,
+		        'Properties': [
+                    { 'Name': 'testdata1','Value':'1'},
+			        { 'Name': 'testdata2','Value':'2'}
+		        ]
+	         }]");
+
+            var jsonString = JsonConvert.SerializeObject(o, Formatting.None);
+            var contentBytes = Encoding.UTF8.GetBytes(jsonString);
+
+            // set IsMeasurementGroup property
+            var events = new List<EventMessage>()
+            {
+                new EventMessage("0", contentBytes, null, 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>() { { "IsMeasurementGroup", true } }, new ReadOnlyDictionary<string, object>(new Dictionary<string, object>())),
+            };
+
+            await fhirImport.ProcessEventsAsync(events, string.Empty, log);
+
+            options.TemplateFactory.Received(1).Create(string.Empty);
+            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default);
+        }
+
+        [Fact]
+        public async void GivenCompressedMeasurementGroupEvent_WhenProcessEventsAsync_ThenProcessAsyncInvokedAndCompleteSuccessfully_Test()
+        {
+            var log = Substitute.For<ITelemetryLogger>();
+            var options = BuildMockOptions();
+            var fhirService = Substitute.For<FhirImportService>();
+            var exceptionTelemetryProcessor = Substitute.For<IExceptionTelemetryProcessor>();
+
+            var fhirImport = new MeasurementFhirImportService(fhirService, options, exceptionTelemetryProcessor);
+
+            JArray o = JArray.Parse(
+            @"[{
+		        'Type': 'summary',
+                'OccurrenceTimeUtc': '2020-08-10T00:15:00Z',
+		        'IngestionTimeUtc': '2022-08-10T19:29:56.993Z',
+		        'DeviceId': 'ABC',
+		        'PatientId': '123',
+		        'EncounterId': null,
+		        'CorrelationId': null,
+		        'Properties': [
+                    { 'Name': 'testdata1','Value':'1'},
+			        { 'Name': 'testdata2','Value':'2'}
+		        ]
+	         }]");
+
+            var jsonString = JsonConvert.SerializeObject(o, Formatting.None);
+            var contentBytes = Encoding.UTF8.GetBytes(jsonString);
+
+            // compress the bytes
+            var compressedBytes = Common.IO.Compression.CompressWithGzip(contentBytes);
+
+            // set IsMeasurementGroup property
+            // set ContentType to application/gzip
+            // set Body to be the compressed bytes
+            var events = new List<EventMessage>()
+            {
+                new EventMessage("0", compressedBytes, Common.IO.Compression.GzipContentType, 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>() { { "IsMeasurementGroup", true } }, new ReadOnlyDictionary<string, object>(new Dictionary<string, object>())),
+            };
+
+            await fhirImport.ProcessEventsAsync(events, string.Empty, log);
+
+            options.TemplateFactory.Received(1).Create(string.Empty);
+            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default);
         }
 
         private static Stream ToStream(object obj)

--- a/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj
@@ -18,7 +18,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Microsoft.Health.Fhir.R4.Ingest.UnitTests.csproj
@@ -18,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
@@ -30,7 +31,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />

--- a/test/Microsoft.Health.Tests.Common/Microsoft.Health.Tests.Common.csproj
+++ b/test/Microsoft.Health.Tests.Common/Microsoft.Health.Tests.Common.csproj
@@ -27,7 +27,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />


### PR DESCRIPTION
Summary of changes

Normalization
- Add ability to compress the measurementGroup and send the compressed measurementGroup.
- Add way to flag if we are sending a measurement or measurementGroup (set IsMeasurementGroup property)
- Add way to flag if we are sending a compressed event payload (set ContentType to application/gzip)
- The compression on the normalization side is off by default, since we would like to first support it on the MeasurementToFhir side first

MeasurementToFhir
- Detect if event batch contains measurements, measurementGroups, or both
- Add ability to process any of the above, or combinations of the above
- Add ability to decompress event payload if it is compressed
