### PR TITLE
Revert previous package upgrade of the FhirClient library.  Latest ve…

### DIFF
--- a/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
+++ b/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
@@ -22,7 +22,7 @@
 		<ProjectReference Include="..\lib\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />
 		<ProjectReference Include="..\lib\Microsoft.Health.Fhir.R4.Ingest\Microsoft.Health.Fhir.R4.Ingest.csproj" />
 		<ProjectReference Include="..\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj" />
-		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="3.0.36" />
+		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="2.0.55" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/console/Startup.cs
+++ b/src/console/Startup.cs
@@ -27,7 +27,6 @@ using Microsoft.Health.Events.Telemetry;
 using Microsoft.Health.Common.Telemetry;
 using IEventProcessingMeter = Microsoft.Health.Events.Common.IEventProcessingMeter;
 using Microsoft.Health.Fhir.Ingest.Telemetry;
-using Azure.Messaging.EventHubs.Producer;
 using Microsoft.Health.Events.Errors;
 
 namespace Microsoft.Health.Fhir.Ingest.Console

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
@@ -39,6 +39,6 @@
 		<ProjectReference Include="..\Microsoft.Health.Extensions.Fhir\Microsoft.Health.Extensions.Fhir.csproj" />
 		<ProjectReference Include="..\Microsoft.Health.Extensions.Host\Microsoft.Health.Extensions.Host.csproj" />
 		<ProjectReference Include="..\Microsoft.Health.Logger\Microsoft.Health.Logging.csproj" />
-		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="3.0.36" />
+		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="2.0.55" />
 	</ItemGroup>
 </Project>

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Service/FhirService.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Service/FhirService.cs
@@ -78,7 +78,11 @@ namespace Microsoft.Health.Extensions.Fhir.Service
 
             if (string.IsNullOrWhiteSpace(ifMatchVersion) && resource.HasVersionId)
             {
-                ifMatchVersion = @$"W/""{resource.VersionId}""";
+                // Underlying FhirClient already adds the W/"" formating and inserts content of the ifMatchVersion
+                // Later versions of the FhirClient removed the implict inclusion of the W/"".
+                // If switching to the latest version update to ifMatchVersion = @$"W/""{resource.VersionId}""";
+                // Change was introduced in this PR https://github.com/microsoft/fhir-server/pull/2467
+                ifMatchVersion = resource.VersionId.ToString();
             }
 
             return await _fhirClient.UpdateAsync(resource, ifMatchVersion, provenanceHeader, cancellationToken).ConfigureAwait(false);

--- a/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
+++ b/test/Microsoft.Health.Common.UnitTests/Microsoft.Health.Common.UnitTests.csproj
@@ -17,7 +17,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="3.0.36" />
+		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="2.0.55" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
Revert previous package upgrade of the FhirClient library.  Latest versions introduces new dependencies that cause downstream build problems.

Also revert FhirService ETag handling change needed for the latest client.