### PR TITLE
Store event offset and sequence number in Checkpoint

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Health.Events.EventCheckpointing
         private readonly string _blobPath;
         private readonly ITelemetryLogger _logger;
         private readonly BlobContainerClient _storageClient;
-        private const string lastProcessedKey = "LastProcessed";
-        private const string sequenceNumberKey = "SequenceNumber";
-        private const string offsetKey = "Offset";
+        private const string LastProcessedKey = "LastProcessed";
+        private const string SequenceNumberKey = "SequenceNumber";
+        private const string OffsetKey = "Offset";
 
         public StorageCheckpointClient(BlobContainerClient containerClient, StorageCheckpointOptions storageCheckpointOptions, EventHubClientOptions eventHubClientOptions, ITelemetryLogger logger)
         {
@@ -67,9 +67,9 @@ namespace Microsoft.Health.Events.EventCheckpointing
 
             var metadata = new Dictionary<string, string>()
             {
-                { lastProcessedKey,  lastProcessed },
-                { sequenceNumberKey,  checkpoint.SequenceNumber.ToString() },
-                { offsetKey,  checkpoint.Offset.ToString() },
+                { LastProcessedKey,  lastProcessed },
+                { SequenceNumberKey,  checkpoint.SequenceNumber.ToString() },
+                { OffsetKey,  checkpoint.Offset.ToString() },
             };
 
             try
@@ -107,17 +107,17 @@ namespace Microsoft.Health.Events.EventCheckpointing
                     long sequenceNumber = -1;
                     long offset = -1;
 
-                    if (blob.Metadata.TryGetValue(lastProcessedKey, out var str))
+                    if (blob.Metadata.TryGetValue(LastProcessedKey, out var str))
                     {
                         DateTimeOffset.TryParse(str, null, DateTimeStyles.AssumeUniversal, out lastEventTimestamp);
                     }
 
-                    if (blob.Metadata.TryGetValue(sequenceNumberKey, out var sequenceNumberString))
+                    if (blob.Metadata.TryGetValue(SequenceNumberKey, out var sequenceNumberString))
                     {
                         long.TryParse(sequenceNumberString, out sequenceNumber);
                     }
 
-                    if (blob.Metadata.TryGetValue(offsetKey, out var offsetString))
+                    if (blob.Metadata.TryGetValue(OffsetKey, out var offsetString))
                     {
                         long.TryParse(offsetString, out offset);
                     }

--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Health.Events.EventCheckpointing
         private readonly string _blobPath;
         private readonly ITelemetryLogger _logger;
         private readonly BlobContainerClient _storageClient;
-        private static string lastProcessedKey = "LastProcessed";
-        private static string sequenceNumberKey = "SequenceNumber";
-        private static string offsetKey = "Offset";
+        private const string lastProcessedKey = "LastProcessed";
+        private const string sequenceNumberKey = "SequenceNumber";
+        private const string offsetKey = "Offset";
 
         public StorageCheckpointClient(BlobContainerClient containerClient, StorageCheckpointOptions storageCheckpointOptions, EventHubClientOptions eventHubClientOptions, ITelemetryLogger logger)
         {

--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
@@ -31,6 +31,9 @@ namespace Microsoft.Health.Events.EventCheckpointing
         private readonly string _blobPath;
         private readonly ITelemetryLogger _logger;
         private readonly BlobContainerClient _storageClient;
+        private static string lastProcessedKey = "LastProcessed";
+        private static string sequenceNumberKey = "SequenceNumber";
+        private static string offsetKey = "Offset";
 
         public StorageCheckpointClient(BlobContainerClient containerClient, StorageCheckpointOptions storageCheckpointOptions, EventHubClientOptions eventHubClientOptions, ITelemetryLogger logger)
         {
@@ -64,7 +67,9 @@ namespace Microsoft.Health.Events.EventCheckpointing
 
             var metadata = new Dictionary<string, string>()
             {
-                { "LastProcessed",  lastProcessed },
+                { lastProcessedKey,  lastProcessed },
+                { sequenceNumberKey,  checkpoint.SequenceNumber.ToString() },
+                { offsetKey,  checkpoint.Offset.ToString() },
             };
 
             try
@@ -99,15 +104,29 @@ namespace Microsoft.Health.Events.EventCheckpointing
                 {
                     var partitionId = blob.Name.Split('/').Last();
                     DateTimeOffset lastEventTimestamp = DateTime.MinValue;
+                    long sequenceNumber = -1;
+                    long offset = -1;
 
-                    if (blob.Metadata.TryGetValue("LastProcessed", out var str))
+                    if (blob.Metadata.TryGetValue(lastProcessedKey, out var str))
                     {
                         DateTimeOffset.TryParse(str, null, DateTimeStyles.AssumeUniversal, out lastEventTimestamp);
+                    }
+
+                    if (blob.Metadata.TryGetValue(sequenceNumberKey, out var sequenceNumberString))
+                    {
+                        long.TryParse(sequenceNumberString, out sequenceNumber);
+                    }
+
+                    if (blob.Metadata.TryGetValue(offsetKey, out var offsetString))
+                    {
+                        long.TryParse(offsetString, out offset);
                     }
 
                     checkpoint.Prefix = _blobPath;
                     checkpoint.Id = partitionId;
                     checkpoint.LastProcessed = lastEventTimestamp;
+                    checkpoint.SequenceNumber = sequenceNumber;
+                    checkpoint.Offset = offset;
                 }
 
                 return Task.FromResult(checkpoint);
@@ -137,6 +156,8 @@ namespace Microsoft.Health.Events.EventCheckpointing
                     LastProcessed = eventArgs.EnqueuedTime,
                     Id = partitionId,
                     Prefix = _blobPath,
+                    SequenceNumber = eventArgs.SequenceNumber,
+                    Offset = eventArgs.Offset,
                 };
 
                 await UpdateCheckpointAsync(checkpoint);

--- a/src/lib/Microsoft.Health.Events/Model/Checkpoint.cs
+++ b/src/lib/Microsoft.Health.Events/Model/Checkpoint.cs
@@ -14,5 +14,9 @@ namespace Microsoft.Health.Events.Model
         public string Id { get; set; }
 
         public DateTimeOffset LastProcessed { get; set; }
+
+        public long SequenceNumber { get; set; } = -1;
+
+        public long Offset { get; set; } = -1;
     }
 }

--- a/src/lib/Microsoft.Health.Events/Model/EventMessageFactory.cs
+++ b/src/lib/Microsoft.Health.Events/Model/EventMessageFactory.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Health.Events.Model
                 eventArgs.Partition.PartitionId,
                 eventArgs.Data.Body,
                 eventArgs.Data.ContentType,
-                eventArgs.Data.Offset,
                 eventArgs.Data.SequenceNumber,
+                eventArgs.Data.Offset,
                 eventArgs.Data.EnqueuedTime.UtcDateTime,
                 eventArgs.Data.Properties,
                 eventArgs.Data.SystemProperties);


### PR DESCRIPTION
We currently do not store message offset or sequence number inside of our checkpoint file. This information is needed to accurately calculate the event processing backlog. This PR adds this information as metadata in our checkpoint file. It also address a bug where we were passing message offset as message sequence number, and vise versa.