### PR TITLE
Filter returned checkpoint blobs by partition id

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
@@ -103,6 +103,13 @@ namespace Microsoft.Health.Events.EventCheckpointing
                 foreach (BlobItem blob in _storageClient.GetBlobs(traits: BlobTraits.Metadata, states: BlobStates.None, prefix: prefix, cancellationToken: cancellationToken))
                 {
                     var partitionId = blob.Name.Split('/').Last();
+
+                    // All checkpoint files matching the supplied blob prefix will be returned. Ensure we only work with the correct checkpoint file
+                    if (!string.Equals(partitionIdentifier, partitionId, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
                     DateTimeOffset lastEventTimestamp = DateTime.MinValue;
                     long sequenceNumber = -1;
                     long offset = -1;


### PR DESCRIPTION
Our current logic retrieves all checkpoint blobs which start with the supplied prefix. If the number of partitions on the source eventhub is greater then 10 we will return multiple results. We may end up returning checkpoint details on the wrong partition. For example, given 16 partitions and a request for the checkpoint details of partition 1, we will return blobs 1, 10,11,12,13,14 and 15. If those are returned in ascending order, we will return the checkpoint details for partition 15 instead of partition 1.

This PR checks if the current checkpoint blob corresponds the requested partition id. If it does not that blob is skipped.