### PR TITLE
Add attempt to resolve a single observation when FHIR server returns multiple records in a bundle

### DIFF
--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/BundleExtensions.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/BundleExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Extensions.Fhir
 
             if (throwOnMultipleFound && resourceCount > 1)
             {
-                throw new MultipleResourceFoundException<TResource>(resourceCount);
+                throw new MultipleResourceFoundException<TResource>(resourceCount, resources.Select(r => r.Id));
             }
 
             return resources.FirstOrDefault();
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Extensions.Fhir
             return bundle?.Entry?.Count ?? 0;
         }
 
-        private static async Task<IEnumerable<TResource>> ReadFromBundleWithContinuationAsync<TResource>(
+        public static async Task<IEnumerable<TResource>> ReadFromBundleWithContinuationAsync<TResource>(
             this Bundle bundle,
             IFhirService fhirService,
             int? count = null)

--- a/src/lib/Microsoft.Health.Extensions.Fhir/MultipleResourceFoundException.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/MultipleResourceFoundException.cs
@@ -4,6 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Text;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Common.Telemetry.Exceptions;
 
@@ -12,11 +14,16 @@ namespace Microsoft.Health.Extensions.Fhir
     public class MultipleResourceFoundException<T> : ThirdPartyLoggedFormattableException
     {
         public MultipleResourceFoundException(int resourceCount)
-            : base($"Multiple resources {resourceCount} of type {typeof(T)} found, expected one")
+            : base(GenerateErrorMessage<T>(resourceCount, null))
         {
         }
 
         public MultipleResourceFoundException()
+        {
+        }
+
+        public MultipleResourceFoundException(int resourceCount, IEnumerable<string> ids)
+            : base(GenerateErrorMessage<T>(resourceCount, ids))
         {
         }
 
@@ -35,5 +42,19 @@ namespace Microsoft.Health.Extensions.Fhir
         public override string ErrType => ErrorType.FHIRResourceError;
 
         public override string Operation => ConnectorOperation.FHIRConversion;
+
+        private static string GenerateErrorMessage<TResource>(int resourceCount, IEnumerable<string> ids)
+        {
+            var sb = new StringBuilder($"Multiple resources {resourceCount} of type {typeof(T)} found, expected one.");
+
+            if (ids != null)
+            {
+                sb.Append(" Resource internal ids: ");
+                sb.Append(string.Join(", ", ids));
+                sb.Append(".");
+            }
+
+            return sb.ToString();
+        }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementFhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementFhirImportService.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                         }
 
                         // group
-                        groupedMeasurements = measurementGroup.GroupBy(m => $"{m.DeviceId}-{m.Type}-{m.PatientId}-{m.EncounterId}-{m.CorrelationId}")
+                        groupedMeasurements = measurementGroup.GroupBy(GetMeasurementKey)
                         .Select(g =>
                         {
                             IList<Measurement> measurements = g.ToList();
@@ -301,7 +301,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                         .AddEventContext(e);
                 }
             })
-            .GroupBy(m => $"{m.DeviceId}-{m.Type}-{m.PatientId}-{m.EncounterId}-{m.CorrelationId}")
+            .GroupBy(GetMeasurementKey)
             .Select(g =>
             {
                 IList<Measurement> measurements = g.ToList();
@@ -352,6 +352,11 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                         (nowRef - m.IngestionTimeUtc.Value).TotalMilliseconds);
                 }
             }).ConfigureAwait(false);
+        }
+
+        private static string GetMeasurementKey(Measurement m)
+        {
+            return $"{m.DeviceId}-{m.Type}-{m.PatientId}-{m.EncounterId}-{m.CorrelationId}";
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
@@ -14,7 +14,6 @@ using Microsoft.Health.Common.Config;
 using Microsoft.Health.Events.Model;
 using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
-using Microsoft.Health.Fhir.Ingest.Telemetry;
 using Microsoft.Health.Fhir.Ingest.Template;
 using Microsoft.Health.Logging.Telemetry;
 using Microsoft.Health.Tests.Common;


### PR DESCRIPTION
- Update MultipleResourceFoundException to include optional collection of ids that will be included in the error message.
- Add logic to R4FhirImportService to not immediately fail if multiple Observations are return.  Attempt to find only one observation in the returned collection that matches the desired identifier. If multiple observations still exist throw the expection as normal.
- Add method, GetMeasurementKey, to ensure same logic is used for generating keys for measurement grouping.