### PR TITLE
Handle case where an event reader with epoch ownership is connected

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
                 }
 
                 Logger.LogTrace("Unable to read from event hub. Retrying in 1 minute");
-                await Task.Delay(TimeSpan.FromMinutes(1));
+                await Task.Delay(TimeSpan.FromMinutes(1), ct);
             }
 
             // Wait indefinitely until cancellation is requested

--- a/src/lib/Microsoft.Health.Events/Resources/EventResources.Designer.cs
+++ b/src/lib/Microsoft.Health.Events/Resources/EventResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Events.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class EventResources {
@@ -93,6 +93,15 @@ namespace Microsoft.Health.Events.Resources {
         internal static string EventHubInvalidConsumerGroup {
             get {
                 return ResourceManager.GetString("EventHubInvalidConsumerGroup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Verify that no other Event Consumers are connected to the source Event Hub..
+        /// </summary>
+        internal static string EventHubMultipleConsumersError {
+            get {
+                return ResourceManager.GetString("EventHubMultipleConsumersError", resourceCulture);
             }
         }
         

--- a/src/lib/Microsoft.Health.Events/Resources/EventResources.resx
+++ b/src/lib/Microsoft.Health.Events/Resources/EventResources.resx
@@ -129,6 +129,9 @@
   <data name="EventHubInvalidConsumerGroup" xml:space="preserve">
     <value>Verify that the provided Event Hub contains the provided consumer group.</value>
   </data>
+  <data name="EventHubMultipleConsumersError" xml:space="preserve">
+    <value>Verify that no other Event Consumers are connected to the source Event Hub.</value>
+  </data>
   <data name="EventHubResourceNotFound" xml:space="preserve">
     <value>Verify that the provided Event Hubs Namespace contains the provided Event Hub and that the provided Event Hub contains the provided consumer group.</value>
   </data>

--- a/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Exceptions/EventHubExceptionProcessor.cs
@@ -55,6 +55,9 @@ namespace Microsoft.Health.Events.Telemetry.Exceptions
                         case EventHubsException.FailureReason.ServiceCommunicationProblem:
                             message = EventResources.EventHubServiceCommunicationProblem;
                             break;
+                        case EventHubsException.FailureReason.ConsumerDisconnected:
+                            message = EventResources.EventHubMultipleConsumersError;
+                            break;
                         default:
                             return (exception, reason.ToString());
                     }


### PR DESCRIPTION
The recommended way to read from Event Hub from production workloads is using the [EventProcessorClient](https://docs.microsoft.com/en-us/azure/event-hubs/event-processor-balance-partition-load). This utilizes blob storage to manage ownership and partition balancing. The iomt-fhir project current using the EventProcessorClient to connect to Event Hub.

However there are also other ways to read from Event Hub. When reading from an Event Hub using the [EventHubConsumerClient](https://docs.microsoft.com/en-us/dotnet/api/azure.messaging.eventhubs.consumer.eventhubconsumerclient?view=azure-dotnet) (not recommended for production) or the [EventHubClient (legacy)](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.eventhubs.eventhubclient.createepochreceiver?view=azure-dotnet) it is possible to supply a unique identifier that indicates partition ownership. For EventHubConsumerClient ownership is done via [ReadEventOptions.OwnerLevel](https://docs.microsoft.com/en-us/dotnet/api/azure.messaging.eventhubs.consumer.readeventoptions.ownerlevel?view=azure-dotnet#azure-messaging-eventhubs-consumer-readeventoptions-ownerlevel) and for EventHubClient ownership is done via [CreateEpochReceiver](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.eventhubs.eventhubclient.createepochreceiver?view=azure-dotnet).

It is possible that a user could do the following two things simultaneously:
1. User sets up an event reader to read from their device Event Hub and supplies ownership values
2. User tries to run the Iot Connector (which also reads from the device Event Hub).

In this scenario, when the Iot Connector uses the EventProcessorClient to attempt to read messages, the outcomes is that the Iot Connector will not be able to read because it is not able to obtain ownership. An error will be thrown:

`Receiver 'nil' with a higher epoch <epoch value> already exists. Receiver 'validate' with epoch 0 cannot be created. Make sure you are creating receiver with increasing epoch value to ensure connectivity, or ensure all old epoch receivers are closed or disconnected`

This PR will handle the exception that is currently being thrown and will log an appropriate error message to the user. We will then also try and reconnect in 1 minute.


 