### PR TITLE
Reset batch queues when partition initialized

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
             return _eventPartitions[partitionId];
         }
 
-        private bool EventPartitionExists(string partitionId)
+        public bool EventPartitionExists(string partitionId)
         {
             return _eventPartitions.ContainsKey(partitionId);
         }
@@ -65,6 +65,14 @@ namespace Microsoft.Health.Events.EventConsumers.Service
         private EventPartition CreatePartitionIfMissing(string partitionId, DateTime initTime, TimeSpan flushTimespan)
         {
             return _eventPartitions.GetOrAdd(partitionId, new EventPartition(partitionId, initTime, flushTimespan, _logger));
+        }
+
+        public void NewPartitionInitialized(string partitionId)
+        {
+            if (EventPartitionExists(partitionId))
+            {
+                _eventPartitions.TryRemove(partitionId, out _);
+            }
         }
 
         public async Task ConsumeEvent(IEventMessage eventArg)

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
@@ -46,5 +46,10 @@ namespace Microsoft.Health.Events.EventConsumers.Service
                 }
             }
         }
+
+        public void NewPartitionInitialized(string partitionId)
+        {
+            // do nothing
+        }
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/IEventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/IEventConsumerService.cs
@@ -14,5 +14,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
         Task ConsumeEvents(IEnumerable<IEventMessage> events);
 
         Task ConsumeEvent(IEventMessage eventArg);
+
+        void NewPartitionInitialized(string partitionId);
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
 
             try
             {
+                EventConsumerService.NewPartitionInitialized(partitionId);
                 var checkpoint = await CheckpointClient.GetCheckpointForPartitionAsync(partitionId, initArgs.CancellationToken);
                 initArgs.DefaultStartingPosition = EventPosition.FromEnqueuedTime(checkpoint.LastProcessed);
                 Logger.LogTrace($"Starting to read partition {partitionId} from checkpoint {checkpoint.LastProcessed}");

--- a/test/Microsoft.Health.Events.UnitTest/EventBatchingTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventBatchingTests.cs
@@ -159,5 +159,36 @@ namespace Microsoft.Health.Events.UnitTest
 
             await _checkpointClient.Received(1).SetCheckpointAsync(firstEvent);
         }
+
+        [Fact]
+        public async void GivenBatchServiceCreated_WhenPartitionAcquired_ThenPartitionQueueCleared_Test()
+        {
+            var partitionId = "0";
+            var eventReader = new EventBatchingService(_eventConsumerService, _options, _checkpointClient, _logger);
+
+            var enqueuedTime = DateTime.UtcNow;
+
+            var event1 = new EventMessage(partitionId, new ReadOnlyMemory<byte>(), null, 1, 1, enqueuedTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            await eventReader.ConsumeEvent(event1);
+
+            var endWindow = enqueuedTime.Add(TimeSpan.FromSeconds(_options.FlushTimespan));
+            var partitionWindow = eventReader.GetPartition(partitionId).GetPartitionWindow();
+
+            Assert.Equal(endWindow, partitionWindow);
+
+            eventReader.NewPartitionInitialized(partitionId);
+            var partitionExists = eventReader.EventPartitionExists(partitionId);
+
+            Assert.False(partitionExists);
+
+            var enqueuedTime2 = DateTime.UtcNow;
+            var event2 = new EventMessage(partitionId, new ReadOnlyMemory<byte>(), null, 1, 1, enqueuedTime2, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            await eventReader.ConsumeEvent(event2);
+
+            var endWindow2 = enqueuedTime2.Add(TimeSpan.FromSeconds(_options.FlushTimespan));
+            var partitionWindow2 = eventReader.GetPartition(partitionId).GetPartitionWindow();
+
+            Assert.Equal(endWindow2, partitionWindow2);
+        }
     }
 }


### PR DESCRIPTION
There is a bug where we can read from a partition, then lose partition ownership to a another reader, then regain ownership. In the case where we regain ownership it is possible for previous events to exists in the event batching queues for that partition (from the previous point in time when reader had ownership). This is a problem because the next event read will flush the queue with the old events and update the checkpoint with the timestamp of the last old event. 

In the case where we regain partition ownership we should delete any previous knowledge/events, and start reading from the checkpoint provided. This PR ensures that the queue in cleared (deleted) when we begin reading from a partition so that it is not possible to retain any old events.