### PR TITLE
Clear partition data when partition ownership is lost

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
             return _eventPartitions[partitionId];
         }
 
-        private bool EventPartitionExists(string partitionId)
+        public bool EventPartitionExists(string partitionId)
         {
             return _eventPartitions.ContainsKey(partitionId);
         }
@@ -65,6 +65,14 @@ namespace Microsoft.Health.Events.EventConsumers.Service
         private EventPartition CreatePartitionIfMissing(string partitionId, DateTime initTime, TimeSpan flushTimespan)
         {
             return _eventPartitions.GetOrAdd(partitionId, new EventPartition(partitionId, initTime, flushTimespan, _logger));
+        }
+
+        public void NewPartitionInitialized(string partitionId)
+        {
+            if (EventPartitionExists(partitionId))
+            {
+                _eventPartitions.TryRemove(partitionId, out _);
+            }
         }
 
         public async Task ConsumeEvent(IEventMessage eventArg)

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
@@ -69,6 +69,16 @@ namespace Microsoft.Health.Events.EventConsumers.Service
 
         public void NewPartitionInitialized(string partitionId)
         {
+            ClearPartition(partitionId);
+        }
+
+        public void PartitionClosing(string partitionId)
+        {
+            ClearPartition(partitionId);
+        }
+
+        public void ClearPartition(string partitionId)
+        {
             if (EventPartitionExists(partitionId))
             {
                 _eventPartitions.TryRemove(partitionId, out _);

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
@@ -46,5 +46,10 @@ namespace Microsoft.Health.Events.EventConsumers.Service
                 }
             }
         }
+
+        public void NewPartitionInitialized(string partitionId)
+        {
+            // do nothing
+        }
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
@@ -51,5 +51,10 @@ namespace Microsoft.Health.Events.EventConsumers.Service
         {
             // do nothing
         }
+
+        public void PartitionClosing(string partitionId)
+        {
+            // do nothing
+        }
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/IEventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/IEventConsumerService.cs
@@ -14,5 +14,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
         Task ConsumeEvents(IEnumerable<IEventMessage> events);
 
         Task ConsumeEvent(IEventMessage eventArg);
+
+        void NewPartitionInitialized(string partitionId);
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/IEventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/IEventConsumerService.cs
@@ -16,5 +16,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
         Task ConsumeEvent(IEventMessage eventArg);
 
         void NewPartitionInitialized(string partitionId);
+
+        void PartitionClosing(string partitionId);
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
 
             try
             {
+                EventConsumerService.NewPartitionInitialized(partitionId);
                 var checkpoint = await CheckpointClient.GetCheckpointForPartitionAsync(partitionId, initArgs.CancellationToken);
                 initArgs.DefaultStartingPosition = EventPosition.FromEnqueuedTime(checkpoint.LastProcessed);
                 Logger.LogTrace($"Starting to read partition {partitionId} from checkpoint {checkpoint.LastProcessed}");

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -105,6 +106,14 @@ namespace Microsoft.Health.Events.EventHubProcessor
 
                 EventHubExceptionProcessor.ProcessException(ex, Logger, errorMetricName: EventHubErrorCode.EventHubPartitionInitFailed.ToString());
             }
+        }
+
+        protected virtual Task PartitionClosingHandler(PartitionClosingEventArgs args)
+        {
+            var partitionId = args.PartitionId;
+            Logger.LogTrace($"Received PartitionClosingEvent for {partitionId}");
+            EventConsumerService.PartitionClosing(args.PartitionId);
+            return Task.CompletedTask;
         }
 
         protected virtual void HandleOwnershipFailure(AggregateException ex)

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
             EventProcessorClient.ProcessEventAsync += ProcessEventHandler;
             EventProcessorClient.ProcessErrorAsync += ProcessErrorHandler;
             EventProcessorClient.PartitionInitializingAsync += ProcessInitializingHandler;
+            EventProcessorClient.PartitionClosingAsync += PartitionClosingHandler;
 
             // Try to connect and read events
             bool connected = false;
@@ -61,6 +62,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
                 EventProcessorClient.ProcessEventAsync -= ProcessEventHandler;
                 EventProcessorClient.ProcessErrorAsync -= ProcessErrorHandler;
                 EventProcessorClient.PartitionInitializingAsync -= ProcessInitializingHandler;
+                EventProcessorClient.PartitionClosingAsync -= PartitionClosingHandler;
             }
         }
     }

--- a/test/Microsoft.Health.Events.UnitTest/EventBatchingTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventBatchingTests.cs
@@ -159,5 +159,36 @@ namespace Microsoft.Health.Events.UnitTest
 
             await _checkpointClient.Received(1).SetCheckpointAsync(firstEvent);
         }
+
+        [Fact]
+        public async void GivenBatchServiceCreated_WhenPartitionAcquired_ThenPartitionQueueCleared_Test()
+        {
+            var partitionId = "0";
+            var eventReader = new EventBatchingService(_eventConsumerService, _options, _checkpointClient, _logger);
+
+            var enqueuedTime = DateTime.UtcNow;
+
+            var event1 = new EventMessage(partitionId, new ReadOnlyMemory<byte>(), null, 1, 1, enqueuedTime, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            await eventReader.ConsumeEvent(event1);
+
+            var endWindow = enqueuedTime.Add(TimeSpan.FromSeconds(_options.FlushTimespan));
+            var partitionWindow = eventReader.GetPartition(partitionId).GetPartitionWindow();
+
+            Assert.Equal(endWindow, partitionWindow);
+
+            eventReader.NewPartitionInitialized(partitionId);
+            var partitionExists = eventReader.EventPartitionExists(partitionId);
+
+            Assert.False(partitionExists);
+
+            var enqueuedTime2 = DateTime.UtcNow;
+            var event2 = new EventMessage(partitionId, new ReadOnlyMemory<byte>(), null, 1, 1, enqueuedTime2, new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()));
+            await eventReader.ConsumeEvent(event2);
+
+            var endWindow2 = enqueuedTime2.Add(TimeSpan.FromSeconds(_options.FlushTimespan));
+            var partitionWindow2 = eventReader.GetPartition(partitionId).GetPartitionWindow();
+
+            Assert.Equal(endWindow2, partitionWindow2);
+        }
     }
 }


### PR DESCRIPTION
As part of the feedback for [PR#226](https://github.com/microsoft/iomt-fhir/pull/236) we should also consider resetting the partition data in our batching service when ownership is lost rather than just clearing the partition data on initialization. Clearing the partition data on ownership loss would free up memory when we clear the events from the partition queue of the partition we are no longer reader from.

This is a draft solution to reset the partition data when partition ownership is lost. The real solution unfortunately is not that simple. There could be cases where partition ownership is lost (we delete the queue), but this occurs at the same time that we are finishing [flushing events from the queue](https://github.com/microsoft/iomt-fhir/blob/main/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs#L120). We should probably handle this potential race condition so that there isn't a case where the state of the queue cannot be altered while in the middle of flushing/publishing/checkpointing. This is a bit complex to implement.

