### PR TITLE
Address regression in 5.7.1 by bumping to 5.7.2

### DIFF
--- a/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
+++ b/src/lib/Microsoft.Health.Events/Microsoft.Health.Events.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.6.0" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.1" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.1" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.2" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.2" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />


### PR DESCRIPTION
Eventhub SDK 5.7.1 introduced a [regression]([https://github.com/Azure/azure-sdk-for-net/blob/Azure.Messaging.EventHubs_5.7.2/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md - bugs-fixed](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Messaging.EventHubs_5.7.2/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md#bugs-fixed)) where the PartitionKey was not being used. This results in Measurements not landing on the same partition, which has undesired effects in downstream processing. This PR bumps the nuget version where the issue has been resolved.