### PR TITLE
Expand identifier search parameters for Observation resources

### DIFF
--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Microsoft.Health.Extensions.Fhir.R4.csproj
@@ -38,6 +38,7 @@
 		<ProjectReference Include="..\Microsoft.Health.Common\Microsoft.Health.Common.csproj" />
 		<ProjectReference Include="..\Microsoft.Health.Extensions.Fhir\Microsoft.Health.Extensions.Fhir.csproj" />
 		<ProjectReference Include="..\Microsoft.Health.Extensions.Host\Microsoft.Health.Extensions.Host.csproj" />
+		<ProjectReference Include="..\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />
 		<ProjectReference Include="..\Microsoft.Health.Logger\Microsoft.Health.Logging.csproj" />
 		<PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="2.0.55" />
 	</ItemGroup>

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
         protected virtual async Task<Model.Observation> GetObservationFromServerAsync(Model.Identifier identifier)
         {
-            var result = await _fhirService.SearchForResourceAsync(Model.ResourceType.Observation, identifier.ToSearchQueryParameter()).ConfigureAwait(false);
+            var result = await _fhirService.SearchForResourceAsync(Model.ResourceType.Observation, identifier.ToExpandedSearchQueryParameters()).ConfigureAwait(false);
 
             var foundObservations = (await result.ReadFromBundleWithContinuationAsync<Model.Observation>(_fhirService).ConfigureAwait(false))
                 .ToArray();

--- a/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/SearchExtensionsTests.cs
+++ b/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/SearchExtensionsTests.cs
@@ -1,0 +1,81 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Extensions.Fhir.Search;
+using Xunit;
+
+namespace Microsoft.Health.Extensions.Fhir.R4.UnitTests
+{
+    public class SearchExtensionsTests
+    {
+        [Fact]
+        public void GivenIdentifierIsNull_WhenToExpandedSearchQueryParameters_Throws()
+        {
+            Identifier identifier = null;
+            Assert.Throws<ArgumentNullException>(() => identifier.ToExpandedSearchQueryParameters());
+        }
+
+        [Fact]
+        public void GivenIdentifierValueIsNull_WhenToExpandedSearchQueryParameters_Throws()
+        {
+            Identifier identifier = new Identifier();
+            Assert.Throws<ArgumentNullException>(() => identifier.ToExpandedSearchQueryParameters());
+        }
+
+        [Fact]
+        public void GivenIdentifierValueDoesNotContainTimePeriod_WhenToExpandedSearchQueryParameters_DefaultSearchStringReturned()
+        {
+            Identifier identifier = new Identifier
+            {
+                Value = "patient.device.typeName.correlationId",
+            };
+
+            string parameters = identifier.ToExpandedSearchQueryParameters();
+
+            Assert.Equal("identifier=patient.device.typeName.correlationId", parameters);
+        }
+
+        [Fact]
+        public void GivenIdentifierValueTimePeriodsDoNotHaveExpectedFormat_WhenToExpandedSearchQueryParameters_DefaultSearchStringReturned()
+        {
+            Identifier identifier = new Identifier
+            {
+                Value = "patient.device.typeName.2022090912131415Z.2022090912131415Z",
+            };
+
+            string parameters = identifier.ToExpandedSearchQueryParameters();
+
+            Assert.Equal("identifier=patient.device.typeName.2022090912131415Z.2022090912131415Z", parameters);
+        }
+
+        [Fact]
+        public void GivenIdentifierValueTimePeriodsHaveExpectedFormat_WhenToExpandedSearchQueryParameters_ExpandedSearchStringReturned()
+        {
+            Identifier identifier = new Identifier
+            {
+                Value = "patient.device.typeName.20220909121314Z.20220909121314Z",
+            };
+
+            string parameters = identifier.ToExpandedSearchQueryParameters();
+
+            Assert.Equal("subject=patient&device=device&code=typeName&date=ge2022-09-09T12:13:14Z&date=le2022-09-09T12:13:14Z", parameters);
+        }
+
+        [Fact]
+        public void GivenIdentifierValueTypeNameHasMultipleComponents_WhenToExpandedSearchQueryParameters_ExpandedSearchStringReturned()
+        {
+            Identifier identifier = new Identifier
+            {
+                Value = "patient.device.type.name.components.20220909121314Z.20220909121314Z",
+            };
+
+            string parameters = identifier.ToExpandedSearchQueryParameters();
+
+            Assert.Equal("subject=patient&device=device&code=type.name.components&date=ge2022-09-09T12:13:14Z&date=le2022-09-09T12:13:14Z", parameters);
+        }
+    }
+}


### PR DESCRIPTION
This PR updates the way MeasurementToFhir operations search for Observations that might already exist because data is being updated or resubmitted. Instead of searching using the identifier, the identifier is split into components (patient resource id, device resource id, typeName or code, start date and end date) a query string is generated using the individual components and used to make a search request on the FHIR service. 