### PR TITLE
Adapt batch size when horizontal scaling enabled

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingOptions.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingOptions.cs
@@ -12,5 +12,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
         public int FlushTimespan { get; set; }
 
         public int MaxEvents { get; set; }
+
+        public int? MaxEventsAllPartitions { get; set; }
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
@@ -115,10 +115,9 @@ namespace Microsoft.Health.Events.EventConsumers.Service
             // Use locking to prevent multiple threads from changing the maximum events value at the same time.
             lock (_lock)
             {
-                _logger.LogTrace($"Currently processing {_partitionCount} partitions");
                 var newMaxEventsValue = Math.Max(_scaledOutMaxEventsAllPartitions.Value / Math.Max(_partitionCount, 1), _maxEvents);
                 var oldMaxEventsValue = _scaledOutMaxEventsPerPartition;
-                _logger.LogTrace($"Updating maximum events from {oldMaxEventsValue} to {newMaxEventsValue}");
+                _logger.LogTrace($"Currently processing {_partitionCount} partitions. Updating maximum events from {oldMaxEventsValue} to {newMaxEventsValue}");
                 _scaledOutMaxEventsPerPartition = newMaxEventsValue;
             }
         }
@@ -139,6 +138,9 @@ namespace Microsoft.Health.Events.EventConsumers.Service
             }
         }
 
+        // Retrieves the maximum events for a partition
+        // The code does not lock when reading _scaledOutMaxEventsPerPartition since there is a performance hit with locking
+        // and it is acceptible to read a snapshot of the value
         public int GetMaximumEventsForPartition()
         {
             if (_scaledOutMaxEventsPerPartition <= 0)

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
@@ -51,5 +51,10 @@ namespace Microsoft.Health.Events.EventConsumers.Service
         {
             // do nothing
         }
+
+        public void PartitionProcessingStopped(string partitionId)
+        {
+            // do nothing
+        }
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/IEventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/IEventConsumerService.cs
@@ -16,5 +16,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
         Task ConsumeEvent(IEventMessage eventArg);
 
         void NewPartitionInitialized(string partitionId);
+
+        void PartitionProcessingStopped(string partitionId);
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
@@ -122,12 +122,21 @@ namespace Microsoft.Health.Events.EventHubProcessor
             throw ex;
         }
 
-        protected virtual void PartitionClosingAsync(PartitionClosingEventArgs partitionClosingEventArgs)
+        protected virtual Task PartitionClosingHandler(PartitionClosingEventArgs partitionClosingEventArgs)
         {
-            var partitionId = partitionClosingEventArgs.PartitionId;
-            var reason = partitionClosingEventArgs.Reason;
-            Logger.LogTrace($"Stopping processing for partition {partitionId}. Reason {reason}");
-            EventConsumerService.PartitionProcessingStopped(partitionId);
+            try
+            {
+                var partitionId = partitionClosingEventArgs.PartitionId;
+                var reason = partitionClosingEventArgs.Reason;
+                Logger.LogTrace($"Stopping processing for partition {partitionId}. Reason {reason}");
+                EventConsumerService.PartitionProcessingStopped(partitionId);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex);
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
@@ -121,5 +121,13 @@ namespace Microsoft.Health.Events.EventHubProcessor
 
             throw ex;
         }
+
+        protected virtual void PartitionClosingAsync(PartitionClosingEventArgs partitionClosingEventArgs)
+        {
+            var partitionId = partitionClosingEventArgs.PartitionId;
+            var reason = partitionClosingEventArgs.Reason;
+            Logger.LogTrace($"Stopping processing for partition {partitionId}. Reason {reason}");
+            EventConsumerService.PartitionProcessingStopped(partitionId);
+        }
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/EventProcessor.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
             EventProcessorClient.ProcessEventAsync += ProcessEventHandler;
             EventProcessorClient.ProcessErrorAsync += ProcessErrorHandler;
             EventProcessorClient.PartitionInitializingAsync += ProcessInitializingHandler;
+            EventProcessorClient.PartitionClosingAsync += PartitionClosingHandler;
 
             // Try to connect and read events
             bool connected = false;
@@ -61,6 +62,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
                 EventProcessorClient.ProcessEventAsync -= ProcessEventHandler;
                 EventProcessorClient.ProcessErrorAsync -= ProcessErrorHandler;
                 EventProcessorClient.PartitionInitializingAsync -= ProcessInitializingHandler;
+                EventProcessorClient.PartitionClosingAsync -= PartitionClosingHandler;
             }
         }
     }


### PR DESCRIPTION
For the FHIR transformation there are some performance gains from scaling out and increasing the batch size. Currently the batch size is static but as we scale out (think 1 partition per application instance) then we technically have more memory and can increase the batch size. This will result in fewer FHIR application calls (assuming most of the data is for once device, which often is the case for needing to scale out) and will increase throughput.

The PR allows a variable to be set called `EventBatching__MaxEventsAllPartitions` which allows the user to specify the maximum events we should process across all the partitions. If this variable is set, and we are processing only 1 partition for example, then the number of events specified in EventBatching__MaxEventsAllPartitions will be the maximum batch size for that partition. If the application instance starts processing events from another partition (2 partitions total) then the number of total events allocated to each partition will be split (EventBatching__MaxEventsAllPartition divided by 2), and so on. The maximum batch size is calculated based on how many partitions the application is reading from, which correlates to how horizontally scaled the application is.