### PR TITLE
Address component vulnerability

### DIFF
--- a/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
+++ b/src/console/Microsoft.Health.Fhir.Ingest.Console.csproj
@@ -13,7 +13,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Azure.Storage.Queues" Version="12.11.0" />		
+		<PackageReference Include="Azure.Storage.Queues" Version="12.11.0" />
+		<PackageReference Include="System.Drawing.Common" Version="4.7.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
@@ -22,6 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
+	  <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
@@ -1,119 +1,119 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
-    <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-    <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
-    <IsPackable>false</IsPackable>
-    <SpaRoot>ClientApp\</SpaRoot>
-    <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<CodeAnalysisRuleSet>..\..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
+		<TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
+		<TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
+		<IsPackable>false</IsPackable>
+		<SpaRoot>ClientApp\</SpaRoot>
+		<DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
-	  <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
+		<PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <!-- Don't publish the SPA source files, but do show them in the project files list -->
-    <Content Remove="$(SpaRoot)**" />
-    <None Remove="$(SpaRoot)**" />
-    <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
-  </ItemGroup>
+	<ItemGroup>
+		<!-- Don't publish the SPA source files, but do show them in the project files list -->
+		<Content Remove="$(SpaRoot)**" />
+		<None Remove="$(SpaRoot)**" />
+		<None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Remove="ClientApp\src\components\Constants.ts" />
-    <None Remove="ClientApp\src\components\Icons.tsx" />
-    <None Remove="ClientApp\src\components\JsonValidator.tsx" />
-    <None Remove="ClientApp\src\components\mapping\Detail - Copy.DeviceEdit.tsx" />
-    <None Remove="ClientApp\src\components\mapping\Detail.Fhir.tsx" />
-    <None Remove="ClientApp\src\components\mapping\Detail.Forms.Tutorials.tsx" />
-    <None Remove="ClientApp\src\components\mapping\Detail.Page.tsx" />
-    <None Remove="ClientApp\src\components\mapping\List.Modals.Export.tsx" />
-    <None Remove="ClientApp\src\components\mapping\List.Modals.Import.tsx" />
-    <None Remove="ClientApp\src\components\mapping\List.Modals.Name.tsx" />
-    <None Remove="ClientApp\src\components\mapping\List.Page.tsx" />
-    <None Remove="ClientApp\src\services\PersistService.ts" />
-    <None Remove="ClientApp\src\services\TestService.ts" />
-    <None Remove="ClientApp\src\services\Utils.ts" />
-    <None Remove="ClientApp\src\store\Mapping.Actions.ts" />
-    <None Remove="ClientApp\src\store\Mapping.Constants.ts" />
-    <None Remove="ClientApp\src\store\Mapping.Reducers.ts" />
-    <None Remove="ClientApp\src\store\Mapping.States.ts" />
-    <None Remove="ClientApp\src\store\Mapping.ts" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="ClientApp\src\components\Constants.ts" />
+		<None Remove="ClientApp\src\components\Icons.tsx" />
+		<None Remove="ClientApp\src\components\JsonValidator.tsx" />
+		<None Remove="ClientApp\src\components\mapping\Detail - Copy.DeviceEdit.tsx" />
+		<None Remove="ClientApp\src\components\mapping\Detail.Fhir.tsx" />
+		<None Remove="ClientApp\src\components\mapping\Detail.Forms.Tutorials.tsx" />
+		<None Remove="ClientApp\src\components\mapping\Detail.Page.tsx" />
+		<None Remove="ClientApp\src\components\mapping\List.Modals.Export.tsx" />
+		<None Remove="ClientApp\src\components\mapping\List.Modals.Import.tsx" />
+		<None Remove="ClientApp\src\components\mapping\List.Modals.Name.tsx" />
+		<None Remove="ClientApp\src\components\mapping\List.Page.tsx" />
+		<None Remove="ClientApp\src\services\PersistService.ts" />
+		<None Remove="ClientApp\src\services\TestService.ts" />
+		<None Remove="ClientApp\src\services\Utils.ts" />
+		<None Remove="ClientApp\src\store\Mapping.Actions.ts" />
+		<None Remove="ClientApp\src\store\Mapping.Constants.ts" />
+		<None Remove="ClientApp\src\store\Mapping.Reducers.ts" />
+		<None Remove="ClientApp\src\store\Mapping.States.ts" />
+		<None Remove="ClientApp\src\store\Mapping.ts" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Common\Microsoft.Health.Common.csproj" />
-    <ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Extensions.Fhir.R4\Microsoft.Health.Extensions.Fhir.R4.csproj" />
-    <ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Extensions.Fhir\Microsoft.Health.Extensions.Fhir.csproj" />
-    <ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Extensions.Host\Microsoft.Health.Extensions.Host.csproj" />
-    <ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Fhir.Ingest.Schema\Microsoft.Health.Fhir.Ingest.Schema.csproj" />
-    <ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Fhir.Ingest.Template\Microsoft.Health.Fhir.Ingest.Template.csproj" />
-    <ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />
-    <ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Fhir.R4.Ingest\Microsoft.Health.Fhir.R4.Ingest.csproj" />
-    <ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Common\Microsoft.Health.Common.csproj" />
+		<ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Extensions.Fhir.R4\Microsoft.Health.Extensions.Fhir.R4.csproj" />
+		<ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Extensions.Fhir\Microsoft.Health.Extensions.Fhir.csproj" />
+		<ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Extensions.Host\Microsoft.Health.Extensions.Host.csproj" />
+		<ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Fhir.Ingest.Schema\Microsoft.Health.Fhir.Ingest.Schema.csproj" />
+		<ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Fhir.Ingest.Template\Microsoft.Health.Fhir.Ingest.Template.csproj" />
+		<ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Fhir.Ingest\Microsoft.Health.Fhir.Ingest.csproj" />
+		<ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Fhir.R4.Ingest\Microsoft.Health.Fhir.R4.Ingest.csproj" />
+		<ProjectReference Include="..\..\..\src\lib\Microsoft.Health.Expressions\Microsoft.Health.Expressions.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <TypeScriptCompile Include="ClientApp\src\components\JsonValidator.tsx" />
-    <TypeScriptCompile Include="ClientApp\src\components\Constants.ts" />
-    <TypeScriptCompile Include="ClientApp\src\components\Icons.tsx" />
-    <TypeScriptCompile Include="ClientApp\src\components\mapping\Detail.Forms.Tutorials.tsx" />
-    <TypeScriptCompile Include="ClientApp\src\components\mapping\Detail.Page.tsx" />
-    <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Export.tsx" />
-    <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Import.tsx" />
-    <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Name.tsx" />
-    <TypeScriptCompile Include="ClientApp\src\components\mapping\List.Page.tsx" />
-    <TypeScriptCompile Include="ClientApp\src\services\PersistService.ts" />
-    <TypeScriptCompile Include="ClientApp\src\services\TestService.ts" />
-    <TypeScriptCompile Include="ClientApp\src\services\Utils.ts" />
-    <TypeScriptCompile Include="ClientApp\src\store\Mapping.Actions.ts" />
-    <TypeScriptCompile Include="ClientApp\src\store\Mapping.Constants.ts" />
-    <TypeScriptCompile Include="ClientApp\src\store\Mapping.ts" />
-    <TypeScriptCompile Include="ClientApp\src\store\Mapping.States.ts" />
-    <TypeScriptCompile Include="ClientApp\src\store\Mapping.Reducers.ts" />
-  </ItemGroup>
+	<ItemGroup>
+		<TypeScriptCompile Include="ClientApp\src\components\JsonValidator.tsx" />
+		<TypeScriptCompile Include="ClientApp\src\components\Constants.ts" />
+		<TypeScriptCompile Include="ClientApp\src\components\Icons.tsx" />
+		<TypeScriptCompile Include="ClientApp\src\components\mapping\Detail.Forms.Tutorials.tsx" />
+		<TypeScriptCompile Include="ClientApp\src\components\mapping\Detail.Page.tsx" />
+		<TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Export.tsx" />
+		<TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Import.tsx" />
+		<TypeScriptCompile Include="ClientApp\src\components\mapping\List.Modals.Name.tsx" />
+		<TypeScriptCompile Include="ClientApp\src\components\mapping\List.Page.tsx" />
+		<TypeScriptCompile Include="ClientApp\src\services\PersistService.ts" />
+		<TypeScriptCompile Include="ClientApp\src\services\TestService.ts" />
+		<TypeScriptCompile Include="ClientApp\src\services\Utils.ts" />
+		<TypeScriptCompile Include="ClientApp\src\store\Mapping.Actions.ts" />
+		<TypeScriptCompile Include="ClientApp\src\store\Mapping.Constants.ts" />
+		<TypeScriptCompile Include="ClientApp\src\store\Mapping.ts" />
+		<TypeScriptCompile Include="ClientApp\src\store\Mapping.States.ts" />
+		<TypeScriptCompile Include="ClientApp\src\store\Mapping.Reducers.ts" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <AdditionalFiles Include=".\stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<AdditionalFiles Include=".\stylecop.json" Link="stylecop.json" />
+	</ItemGroup>
 
-  <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">
-    <!-- Ensure Node.js is installed -->
-    <Exec Command="node --version" ContinueOnError="true">
-      <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
-    </Exec>
-    <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
-    <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-  </Target>
+	<Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">
+		<!-- Ensure Node.js is installed -->
+		<Exec Command="node --version" ContinueOnError="true">
+			<Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
+		</Exec>
+		<Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
+		<Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
+		<Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
+	</Target>
 
-  <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
-    <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build" />
+	<Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
+		<!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
+		<Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
+		<Exec WorkingDirectory="$(SpaRoot)" Command="npm run build" />
 
-    <!-- Include the newly-built files in the publish output -->
-    <ItemGroup>
-      <DistFiles Include="$(SpaRoot)build\**; $(SpaRoot)build-ssr\**" />
-      <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
-        <RelativePath>%(DistFiles.Identity)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      </ResolvedFileToPublish>
-    </ItemGroup>
-  </Target>
+		<!-- Include the newly-built files in the publish output -->
+		<ItemGroup>
+			<DistFiles Include="$(SpaRoot)build\**; $(SpaRoot)build-ssr\**" />
+			<ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
+				<RelativePath>%(DistFiles.Identity)</RelativePath>
+				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+				<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+			</ResolvedFileToPublish>
+		</ItemGroup>
+	</Target>
 
 </Project>


### PR DESCRIPTION
CVE-2021-24112
A remote code execution vulnerability exists when parsing certain types of graphics files. This vulnerability only exists on systems running on MacOS or Linux. This CVE ID is unique from CVE-2021-26701.

Upgrade System.Drawing.Common from 4.7.0 to 4.7.2 to fix the vulnerability.