### PR TITLE
Include version and update datetime on MultipleResourceFound exceptions

### DIFF
--- a/Microsoft.Health.Fhir.Ingest.sln
+++ b/Microsoft.Health.Fhir.Ingest.sln
@@ -111,9 +111,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Template.Generator", "tools\mapping-generator\Microsoft.Health.Fhir.Ingest.Template.Generator\Microsoft.Health.Fhir.Ingest.Template.Generator.csproj", "{3A335D57-CF8D-4C1F-89F6-AAF703A8B501}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Template.Generator.UnitTests", "tools\mapping-generator\Microsoft.Health.Fhir.Ingest.Template.Generator.Tests\Microsoft.Health.Fhir.Ingest.Template.Generator.UnitTests.csproj", "{9F9457B4-17DF-489C-A73F-25868FE64E5A}"
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Legacy", "src\lib\Microsoft.Health.Fhir.Ingest.Legacy\Microsoft.Health.Fhir.Ingest.Legacy.csproj", "{061E438E-828D-496C-B22F-507287667B0E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Legacy.UnitTests", "test\Microsoft.Health.Fhir.Ingest.Legacy.UnitTests\Microsoft.Health.Fhir.Ingest.Legacy.UnitTests.csproj", "{03DDFBF2-50B3-4B27-84DC-19D84CEB1288}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Ingest.Legacy", "src\lib\Microsoft.Health.Fhir.Ingest.Legacy\Microsoft.Health.Fhir.Ingest.Legacy.csproj", "{F35F00C4-4AB0-4E80-99F1-39F24948B7A8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -233,14 +234,14 @@ Global
 		{9F9457B4-17DF-489C-A73F-25868FE64E5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9F9457B4-17DF-489C-A73F-25868FE64E5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9F9457B4-17DF-489C-A73F-25868FE64E5A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{061E438E-828D-496C-B22F-507287667B0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{061E438E-828D-496C-B22F-507287667B0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{061E438E-828D-496C-B22F-507287667B0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{061E438E-828D-496C-B22F-507287667B0E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{03DDFBF2-50B3-4B27-84DC-19D84CEB1288}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{03DDFBF2-50B3-4B27-84DC-19D84CEB1288}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{03DDFBF2-50B3-4B27-84DC-19D84CEB1288}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{03DDFBF2-50B3-4B27-84DC-19D84CEB1288}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F35F00C4-4AB0-4E80-99F1-39F24948B7A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F35F00C4-4AB0-4E80-99F1-39F24948B7A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F35F00C4-4AB0-4E80-99F1-39F24948B7A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F35F00C4-4AB0-4E80-99F1-39F24948B7A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -280,8 +281,8 @@ Global
 		{90B4DFD0-D039-438D-9541-A12482C2D9BE} = {513D67B4-80E1-476D-955F-E7E7C79D144A}
 		{3A335D57-CF8D-4C1F-89F6-AAF703A8B501} = {80C3D951-E8D3-4DAB-9482-852EB9A6D542}
 		{9F9457B4-17DF-489C-A73F-25868FE64E5A} = {80C3D951-E8D3-4DAB-9482-852EB9A6D542}
-		{061E438E-828D-496C-B22F-507287667B0E} = {513D67B4-80E1-476D-955F-E7E7C79D144A}
 		{03DDFBF2-50B3-4B27-84DC-19D84CEB1288} = {FAF8B402-892E-4EA2-B4CF-69B0C70BA762}
+		{F35F00C4-4AB0-4E80-99F1-39F24948B7A8} = {513D67B4-80E1-476D-955F-E7E7C79D144A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A358924D-F948-4AE8-8CD0-A0F56225CE0C}

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/BundleExtensions.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/BundleExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Extensions.Fhir
 
             if (throwOnMultipleFound && resourceCount > 1)
             {
-                throw new MultipleResourceFoundException<TResource>(resourceCount, resources.Select(r => r.Id));
+                throw new MultipleResourceFoundException<TResource>(resourceCount, resources.Select(r => r.ToMetadata()));
             }
 
             return resources.FirstOrDefault();

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/ResourceExtensions.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/ResourceExtensions.cs
@@ -23,5 +23,17 @@ namespace Microsoft.Health.Extensions.Fhir
 
             return resource.DeepCopy() as TResource;
         }
+
+        public static IResourceMetadata ToMetadata(this Resource resource)
+        {
+            EnsureArg.IsNotNull(resource, nameof(resource));
+
+            return new ResourceMetadata
+            {
+                Id = resource.Id,
+                VersionId = resource.VersionId,
+                LastUpdated = resource.Meta?.LastUpdated?.UtcDateTime,
+            };
+        }
     }
 }

--- a/src/lib/Microsoft.Health.Extensions.Fhir/IResourceMetadata.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/IResourceMetadata.cs
@@ -1,0 +1,18 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Extensions.Fhir
+{
+    public interface IResourceMetadata
+    {
+        string Id { get; }
+
+        string VersionId { get;  }
+
+        DateTime? LastUpdated { get; }
+    }
+}

--- a/src/lib/Microsoft.Health.Extensions.Fhir/MultipleResourceFoundException.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/MultipleResourceFoundException.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Common.Telemetry.Exceptions;
@@ -22,8 +23,8 @@ namespace Microsoft.Health.Extensions.Fhir
         {
         }
 
-        public MultipleResourceFoundException(int resourceCount, IEnumerable<string> ids)
-            : base(GenerateErrorMessage<T>(resourceCount, ids))
+        public MultipleResourceFoundException(int resourceCount, IEnumerable<IResourceMetadata> metadata)
+            : base(GenerateErrorMessage<T>(resourceCount, metadata))
         {
         }
 
@@ -43,14 +44,14 @@ namespace Microsoft.Health.Extensions.Fhir
 
         public override string Operation => ConnectorOperation.FHIRConversion;
 
-        private static string GenerateErrorMessage<TResource>(int resourceCount, IEnumerable<string> ids)
+        private static string GenerateErrorMessage<TResource>(int resourceCount, IEnumerable<IResourceMetadata> metadata)
         {
             var sb = new StringBuilder($"Multiple resources {resourceCount} of type {typeof(T)} found, expected one.");
 
-            if (ids != null)
+            if (metadata != null)
             {
-                sb.Append(" Resource internal ids: ");
-                sb.Append(string.Join(", ", ids));
+                sb.Append(" Resource metadata: ");
+                sb.Append(string.Join(", ", metadata.Select(m => $"[Resource {nameof(m.Id)}:{m.Id}; {nameof(m.VersionId)}:{m.VersionId}; {nameof(m.LastUpdated)}:{m.LastUpdated}]")));
                 sb.Append(".");
             }
 

--- a/src/lib/Microsoft.Health.Extensions.Fhir/MultipleResourceFoundException.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/MultipleResourceFoundException.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Health.Extensions.Fhir
 
             if (metadata != null)
             {
-                sb.Append(" Resource metadata: ");
-                sb.Append(string.Join(", ", metadata.Select(m => $"[Resource {nameof(m.Id)}:{m.Id}; {nameof(m.VersionId)}:{m.VersionId}; {nameof(m.LastUpdated)}:{m.LastUpdated}]")));
-                sb.Append(".");
+                sb.Append(" Resource metadata: ")
+                    .Append(string.Join(", ", metadata.Select(m => $"[Resource {nameof(m.Id)}:{m.Id}; {nameof(m.VersionId)}:{m.VersionId}; {nameof(m.LastUpdated)}:{m.LastUpdated}]")))
+                    .Append(".");
             }
 
             return sb.ToString();

--- a/src/lib/Microsoft.Health.Extensions.Fhir/ResourceMetadata.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir/ResourceMetadata.cs
@@ -1,0 +1,18 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Extensions.Fhir
+{
+    public struct ResourceMetadata : IResourceMetadata
+    {
+        public string Id { get; set; }
+
+        public string VersionId { get; set; }
+
+        public DateTime? LastUpdated { get; set; }
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             }
 
             // More than one Observation found with the same identifier.
-            throw new MultipleResourceFoundException<Model.Observation>(matchedObservations.Length, matchedObservations.Select(obs => obs.Id));
+            throw new MultipleResourceFoundException<Model.Observation>(matchedObservations.Length, matchedObservations.Select(obs => obs.ToMetadata()));
         }
     }
 }


### PR DESCRIPTION
* Update MultipleResourceFound exception to also include the version and last updated data in addition to the internal id.
* Fix issue with solution & Legacy library.