### PR TITLE
Handle task cancelled exceptions

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
@@ -86,6 +86,10 @@ namespace Microsoft.Health.Events.EventCheckpointing
                     }
                 }
             }
+            catch (TaskCanceledException ex)
+            {
+                _logger.LogTrace(ex.Message);
+            }
             catch (Exception ex)
             {
                 _logger.LogError(new StorageCheckpointClientException($"Unable to update checkpoint. {ex.Message}", ex));
@@ -136,6 +140,11 @@ namespace Microsoft.Health.Events.EventCheckpointing
                 _logger.LogTrace($"The checkpoint file {partitionIdentifier} does not exist");
                 return new Checkpoint();
             }
+            catch (TaskCanceledException ex)
+            {
+                _logger.LogTrace(ex.Message);
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(new StorageCheckpointClientException($"Unable to get checkpoint for partition. {ex.Message}", ex));
@@ -171,6 +180,10 @@ namespace Microsoft.Health.Events.EventCheckpointing
                         _logger.LogMetric(metric.Key, metric.Value);
                     }
                 }
+            }
+            catch (TaskCanceledException ex)
+            {
+                _logger.LogTrace(ex.Message);
             }
             catch (Exception ex)
             {
@@ -217,6 +230,10 @@ namespace Microsoft.Health.Events.EventCheckpointing
 
                 _logger.LogTrace($"Exiting {nameof(ResetCheckpointsAsync)}.");
             }
+            catch (TaskCanceledException ex)
+            {
+                _logger.LogTrace(ex.Message);
+            }
             catch (Exception ex)
             {
                 _logger.LogError(new StorageCheckpointClientException($"Unable to reset checkpoints. {ex.Message}", ex));
@@ -239,6 +256,10 @@ namespace Microsoft.Health.Events.EventCheckpointing
                     var eventHubsConnectionStringProperties = EventHubsConnectionStringProperties.Parse(eventHubClientOptions.ConnectionString);
                     eventHubNamespaceFQDN = eventHubsConnectionStringProperties.FullyQualifiedNamespace;
                     eventHubName = eventHubsConnectionStringProperties.EventHubName;
+                }
+                catch (TaskCanceledException ex)
+                {
+                    _logger.LogTrace(ex.Message);
                 }
                 catch (Exception ex)
                 {

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
@@ -97,9 +97,11 @@ namespace Microsoft.Health.Events.EventHubProcessor
                 Logger.LogTrace($"Starting to read partition {partitionId} from checkpoint {checkpoint.LastProcessed}");
                 Logger.LogMetric(EventMetrics.EventHubPartitionInitialized(partitionId), 1);
             }
-#pragma warning disable CA1031
+            catch (TaskCanceledException ex)
+            {
+                Logger.LogTrace($"PartitionInitializingEventArgs received a cancellation request for partition {partitionId} {ex.Message}");
+            }
             catch (Exception ex)
-#pragma warning restore CA1031
             {
                 Logger.LogTrace($"Failed to initialize partition {partitionId} from checkpoint");
 


### PR DESCRIPTION
For task cancelled exceptions, we are now logging a trace instead of an error.