### PR TITLE
Address CVE-2022-41032 in Data Mapper

### DIFF
--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
@@ -11,18 +11,18 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
+		<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
-		<PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+		<PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
+		<PackageReference Include="System.Drawing.Common" Version="7.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
+++ b/tools/data-mapper/Microsoft.Health.Tools.DataMapper/Microsoft.Health.Tools.DataMapper.csproj
@@ -17,6 +17,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
+		<PackageReference Include="NuGet.Protocol" Version="6.4.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Addresses component governance alert CVE-2022-41032 in NuGet.Protocol 5.11.0. Severity: High

Explicitly reference the Nuget.Protocol package to force a version > 5.11. The previous upgrade of root package Microsoft.VisualStudio.Web.CodeGeneration.Design wasn't enough.