### PR TITLE
Switch FhirImportService back to normal identifier search parameter

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
         protected virtual async Task<Model.Observation> GetObservationFromServerAsync(Model.Identifier identifier)
         {
-            var result = await _fhirService.SearchForResourceAsync(Model.ResourceType.Observation, identifier.ToExpandedSearchQueryParameters()).ConfigureAwait(false);
+            var result = await _fhirService.SearchForResourceAsync(Model.ResourceType.Observation, identifier.ToSearchQueryParameter()).ConfigureAwait(false);
 
             var foundObservations = (await result.ReadFromBundleWithContinuationAsync<Model.Observation>(_fhirService).ConfigureAwait(false))
                 .ToArray();


### PR DESCRIPTION
Switch FhirImportService back to normal identifier search parameter instead of the expanded search parameters.  Discovered expanded search parameters generate more complex and long running queries on the FHIR service side (50 ms vs > 1 second) severely impacting performance.

This reverts #240 