### PR TITLE
Add additional exceptions to be surfaced as logs

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateNotFoundException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest.Template/TemplateNotFoundException.cs
@@ -9,7 +9,7 @@ using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Fhir.Ingest.Template
 {
-    public class TemplateNotFoundException : IomtTelemetryFormattableException
+    public class TemplateNotFoundException : ThirdPartyLoggedFormattableException
     {
         public TemplateNotFoundException(string message)
             : base(message)

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Exceptions/CorrelationIdNotDefinedException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Exceptions/CorrelationIdNotDefinedException.cs
@@ -9,7 +9,7 @@ using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Fhir.Ingest.Data
 {
-    public class CorrelationIdNotDefinedException : IomtTelemetryFormattableException
+    public class CorrelationIdNotDefinedException : ThirdPartyLoggedFormattableException
     {
         public CorrelationIdNotDefinedException(string message)
             : base(message)

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Exceptions/InvalidDataFormatException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Exceptions/InvalidDataFormatException.cs
@@ -9,7 +9,7 @@ using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
-    public class InvalidDataFormatException : IomtTelemetryFormattableException
+    public class InvalidDataFormatException : ThirdPartyLoggedFormattableException
     {
         public InvalidDataFormatException()
             : base()

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Exceptions/InvalidQuantityFhirValueException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Exceptions/InvalidQuantityFhirValueException.cs
@@ -9,7 +9,7 @@ using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
-    public class InvalidQuantityFhirValueException : IomtTelemetryFormattableException
+    public class InvalidQuantityFhirValueException : ThirdPartyLoggedFormattableException
     {
         public InvalidQuantityFhirValueException()
             : base()

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Exceptions/NormalizationDataMappingException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Exceptions/NormalizationDataMappingException.cs
@@ -11,7 +11,7 @@ using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
-    public class NormalizationDataMappingException : IomtTelemetryFormattableException
+    public class NormalizationDataMappingException : ThirdPartyLoggedFormattableException
     {
         private static readonly string _errorType = ErrorType.DeviceTemplateError;
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/FhirDataMappingException.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/FhirDataMappingException.cs
@@ -9,7 +9,7 @@ using Microsoft.Health.Common.Telemetry.Exceptions;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
-    public class FhirDataMappingException : IomtTelemetryFormattableException
+    public class FhirDataMappingException : ThirdPartyLoggedFormattableException
     {
         private static readonly string _errorType = ErrorType.FHIRConversionError;
 


### PR DESCRIPTION
It would be helpful to customers to make a few more exceptions customer-facing (emitted in logs).

TemplateNotFoundException 
CorrelationIdNotDefinedException 
InvalidDataFormatException 
InvalidQuantityFhirValueException 
NormalizationDataMappingException 
FhirDataMappingException 