### PR TITLE
Disable reloadOnChange for MedTech configurations

### DIFF
--- a/src/console/Program.cs
+++ b/src/console/Program.cs
@@ -9,6 +9,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Events.EventHubProcessor;
 using Microsoft.Health.Logging.Telemetry;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Health.Fhir.Ingest.Console
 {

--- a/src/console/Program.cs
+++ b/src/console/Program.cs
@@ -9,9 +9,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Events.EventHubProcessor;
 using Microsoft.Health.Logging.Telemetry;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Health.Fhir.Ingest.Console
 {
@@ -46,8 +43,8 @@ namespace Microsoft.Health.Fhir.Ingest.Console
         public static IConfiguration GetEnvironmentConfig()
         {
             IConfiguration config = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json", true, true)
-                .AddJsonFile("local.appsettings.json", true, true)
+                .AddJsonFile("appsettings.json", true, reloadOnChange: false)
+                .AddJsonFile("local.appsettings.json", true, reloadOnChange: false)
                 .AddEnvironmentVariables()
                 .Build();
 


### PR DESCRIPTION
Recent host image change in AKS has lead to following error:

```
Unhandled exception. System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached, or the per-process limit on the number of open file descriptors has been reached.
```

Disabling reloadOnChange for configurations to prevent this issue.