### PR TITLE
Catch additional normalization mapping exceptions

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationEventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationEventConsumerService.cs
@@ -232,20 +232,20 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
             using (ITimed normalizeDuration = _logger.TrackDuration(IomtMetrics.NormalizedEventGenerationTimeMs(evt.PartitionId)))
             {
-                foreach (var measurement in template.GetMeasurements(token))
+                try
                 {
-                    try
+                    foreach (var measurement in template.GetMeasurements(token))
                     {
                         measurement.IngestionTimeUtc = evt.EnqueuedTime.UtcDateTime;
                         collector.Add((evt.PartitionId, measurement));
                         projections++;
                     }
-                    catch (Exception ex)
-                    {
-                        // Translate all Normalization Mapping exceptions into a common type for easy identification.
-                        throw new NormalizationDataMappingException(ex, nameof(NormalizationDataMappingException))
-                            .AddEventContext(evt);
-                    }
+                }
+                catch (Exception ex)
+                {
+                    // Translate all Normalization Mapping exceptions into a common type for easy identification.
+                    throw new NormalizationDataMappingException(ex, nameof(NormalizationDataMappingException))
+                        .AddEventContext(evt);
                 }
             }
 


### PR DESCRIPTION
When normalizing a device message there are some exceptions that can be thrown in [template.GetMeasurements(token)](https://github.com/microsoft/iomt-fhir/blob/36ea37f11f09e2e6cdfad167be48be91b62d0091/src/lib/Microsoft.Health.Fhir.Ingest/Service/NormalizationEventConsumerService.cs#L213). 

For example, if a user specifies a timestamp expression below and `matchedToken.pathNotFoundInDeviceMessage` resolves to null, then an exception is thrown internally: "System.Exception Error: invalid-type, function fromUnixTimestampMs expects argument 0 to be one of the following: Integer"

```json
        "timestampExpression": {
          "value": "fromUnixTimestampMs(matchedToken.pathNotFoundInDeviceMessage)",
          "language": "JmesPath"
        },
```

In this Pull Request we are adjusting the try/catch block to capture any exceptions that happen to occur in template.GetMeasurements(token).

The end result is that a NormalizationDataMappingException will be logged to the user and internally. However since we also [log the inner exception internally](https://github.com/microsoft/iomt-fhir/blob/726cf7dd7afd011b9e593cb6eae425d79ef7ab56/src/lib/Microsoft.Health.Logger/Telemetry/IomtTelemetryLogger.cs#L38) (in this case it would be a System.Exception) we will still continue to log a System.Exception internally.