### PR TITLE
Prevent duplicate observations from being created

### DIFF
--- a/src/console/Microsoft.Health.Fhir.Ingest.Console.Common/FhirTransformation/Processor.cs
+++ b/src/console/Microsoft.Health.Fhir.Ingest.Console.Common/FhirTransformation/Processor.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Ingest.Console.FhirTransformation
             {
                 if (ee is TaskCanceledException)
                 {
-                    logger.LogTrace($"The task was cancelled.");
+                    logger.LogTrace($"The FHIR import was aborted due to task cancellation.");
                     return false;
                 }
 

--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/ICheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/ICheckpointClient.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Events.EventCheckpointing
 {
     public interface ICheckpointClient
     {
-        Task SetCheckpointAsync(IEventMessage eventArg, IEnumerable<KeyValuePair<Metric, double>> metrics = null);
+        Task SetCheckpointAsync(IEventMessage eventArg, CancellationToken ct, IEnumerable<KeyValuePair<Metric, double>> metrics = null);
 
         Task<Checkpoint> GetCheckpointForPartitionAsync(string partitionId, CancellationToken cancellationToken);
 

--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
@@ -75,8 +75,6 @@ namespace Microsoft.Health.Events.EventCheckpointing
 
             try
             {
-                ct.ThrowIfCancellationRequested();
-
                 try
                 {
                     await blobClient.SetMetadataAsync(metadata, null, ct);
@@ -162,8 +160,6 @@ namespace Microsoft.Health.Events.EventCheckpointing
 
             try
             {
-                ct.ThrowIfCancellationRequested();
-
                 var partitionId = eventArgs.PartitionId;
                 var checkpoint = new Checkpoint
                 {

--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Health.Events.EventCheckpointing
             }
         }
 
-        public async Task SetCheckpointAsync(IEventMessage eventArgs, IEnumerable<KeyValuePair<Metric, double>> metrics = null)
+        public async Task SetCheckpointAsync(IEventMessage eventArgs, CancellationToken ct, IEnumerable<KeyValuePair<Metric, double>> metrics = null)
         {
             EnsureArg.IsNotNull(eventArgs);
             EnsureArg.IsNotNullOrWhiteSpace(eventArgs.PartitionId);

--- a/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
+++ b/src/lib/Microsoft.Health.Events/EventCheckpointing/StorageCheckpointClient.cs
@@ -79,13 +79,13 @@ namespace Microsoft.Health.Events.EventCheckpointing
 
                 try
                 {
-                    await blobClient.SetMetadataAsync(metadata);
+                    await blobClient.SetMetadataAsync(metadata, null, ct);
                 }
                 catch (RequestFailedException ex) when ((ex.ErrorCode == BlobErrorCode.BlobNotFound) || (ex.ErrorCode == BlobErrorCode.ContainerNotFound))
                 {
                     using (var blobContent = new MemoryStream(Array.Empty<byte>()))
                     {
-                        await blobClient.UploadAsync(blobContent, metadata: metadata).ConfigureAwait(false);
+                        await blobClient.UploadAsync(blobContent, metadata: metadata, cancellationToken: ct).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/lib/Microsoft.Health.Events/EventConsumers/EventPrinter.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/EventPrinter.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Health.Events.Model;
@@ -14,7 +15,7 @@ namespace Microsoft.Health.Events.EventConsumers
 {
     public class EventPrinter : IEventConsumer
     {
-        public Task ConsumeAsync(IEnumerable<IEventMessage> events)
+        public Task ConsumeAsync(IEnumerable<IEventMessage> events, CancellationToken ct)
         {
             EnsureArg.IsNotNull(events);
             foreach (EventMessage evt in events)

--- a/src/lib/Microsoft.Health.Events/EventConsumers/IEventConsumer.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/IEventConsumer.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Events.Model;
 
@@ -11,6 +12,6 @@ namespace Microsoft.Health.Events.EventConsumers
 {
     public interface IEventConsumer
     {
-        Task ConsumeAsync(IEnumerable<IEventMessage> events);
+        Task ConsumeAsync(IEnumerable<IEventMessage> events, CancellationToken ct);
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventConsumerService.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Health.Events.Model;
@@ -24,12 +25,12 @@ namespace Microsoft.Health.Events.EventConsumers.Service
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
         }
 
-        public Task ConsumeEvent(IEventMessage eventArg)
+        public Task ConsumeEvent(IEventMessage eventArg, CancellationToken ct)
         {
             throw new NotImplementedException();
         }
 
-        public async Task ConsumeEvents(IEnumerable<IEventMessage> events)
+        public async Task ConsumeEvents(IEnumerable<IEventMessage> events, CancellationToken ct)
         {
             if (events.Any())
             {
@@ -37,7 +38,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
                 {
                     try
                     {
-                        await eventConsumer.ConsumeAsync(events).ConfigureAwait(false);
+                        await eventConsumer.ConsumeAsync(events, ct).ConfigureAwait(false);
                     }
                     catch (Exception e)
                     {

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/IEventConsumerService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/IEventConsumerService.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Events.Model;
 
@@ -11,9 +12,9 @@ namespace Microsoft.Health.Events.EventConsumers.Service
 {
     public interface IEventConsumerService
     {
-        Task ConsumeEvents(IEnumerable<IEventMessage> events);
+        Task ConsumeEvents(IEnumerable<IEventMessage> events, CancellationToken ct);
 
-        Task ConsumeEvent(IEventMessage eventArg);
+        Task ConsumeEvent(IEventMessage eventArg, CancellationToken ct);
 
         void NewPartitionInitialized(string partitionId);
 

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/SHA256HashGenerator.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/SHA256HashGenerator.cs
@@ -1,0 +1,34 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+using System.Text;
+using EnsureThat;
+
+namespace Microsoft.Health.Extensions.Fhir
+{
+    public static class SHA256HashGenerator
+    {
+        public static string ComputeHashForIdentifier(Hl7.Fhir.Model.Identifier identifier)
+        {
+            EnsureArg.IsNotNullOrWhiteSpace(identifier.Value, nameof(identifier.Value));
+
+            string plainTextSystemAndId = $"{identifier.System}_{identifier.Value}";
+
+            using (SHA256 hashAlgorithm = SHA256.Create())
+            {
+                byte[] bytes = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(plainTextSystemAndId));
+
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    sb.Append(bytes[i].ToString("x2"));
+                }
+
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/FhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/FhirImportService.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Health.Fhir.Ingest.Data;
@@ -15,7 +16,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
     {
         public const string ServiceSystem = @"https://azure.microsoft.com/en-us/services/iomt-fhir-connector/";
 
-        public abstract Task ProcessAsync(ILookupTemplate<IFhirTemplate> config, IMeasurementGroup data, Func<Exception, IMeasurementGroup, Task<bool>> errorConsumer = null);
+        public abstract Task ProcessAsync(ILookupTemplate<IFhirTemplate> config, IMeasurementGroup data, CancellationToken ct, Func<Exception, IMeasurementGroup, Task<bool>> errorConsumer = null);
 
         protected static (string Identifer, string System) GenerateObservationId(IObservationGroup observationGroup, string deviceId, string patientId)
         {

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/IFhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/IFhirImportService.cs
@@ -4,12 +4,13 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
     public interface IFhirImportService<TData, TConfig>
     {
-        Task ProcessAsync(TConfig config, TData data, Func<Exception, TData, Task<bool>> errorConsumer = null);
+        Task ProcessAsync(TConfig config, TData data, CancellationToken ct, Func<Exception, TData, Task<bool>> errorConsumer = null);
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/IImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/IImportService.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Events.Model;
 using Microsoft.Health.Logging.Telemetry;
@@ -12,6 +13,6 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 {
     public interface IImportService
     {
-        Task ProcessEventsAsync(IEnumerable<IEventMessage> events, string templateDefinition, ITelemetryLogger log);
+        Task ProcessEventsAsync(IEnumerable<IEventMessage> events, string templateDefinition, ITelemetryLogger log, CancellationToken ct);
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementGroupFhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementGroupFhirImportService.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Health.Common.IO;
@@ -41,10 +42,10 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             var template = BuildTemplate(templateDefinition, log);
             var measurementGroups = await ParseAsync(data, log).ConfigureAwait(false);
 
-            await SendMeasurementGroups(measurementGroups, template, log).ConfigureAwait(false);
+            await SendMeasurementGroups(measurementGroups, template, log, CancellationToken.None).ConfigureAwait(false);
         }
 
-        public async Task ProcessEventsAsync(IEnumerable<IEventMessage> events, string templateDefinition, ITelemetryLogger log)
+        public async Task ProcessEventsAsync(IEnumerable<IEventMessage> events, string templateDefinition, ITelemetryLogger log, CancellationToken ct)
         {
             // Step 1: Before processing events, validate the template
             ILookupTemplate<IFhirTemplate> template = null;
@@ -85,11 +86,11 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 }
             }
 
-            await ProcessMeasurementEvents(measurements, template, log);
-            await ProcessMeasurementGroupEvents(measurementGroups, template, log);
+            await ProcessMeasurementEvents(measurements, template, log, ct);
+            await ProcessMeasurementGroupEvents(measurementGroups, template, log, ct);
         }
 
-        private async Task ProcessMeasurementEvents(IEnumerable<IEventMessage> events, ILookupTemplate<IFhirTemplate> template, ITelemetryLogger log)
+        private async Task ProcessMeasurementEvents(IEnumerable<IEventMessage> events, ILookupTemplate<IFhirTemplate> template, ITelemetryLogger log, CancellationToken ct)
         {
             if (events.Count() == 0)
             {
@@ -123,10 +124,10 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
             // Transform the Measurement Groups into Observations and write to the FHIR Server.
             // Exceptions are currently handled in SendMeasurementGroups
-            await SendMeasurementGroups(measurementGroups, template, log, measurementToEventMapping).ConfigureAwait(false);
+            await SendMeasurementGroups(measurementGroups, template, log, ct, measurementToEventMapping).ConfigureAwait(false);
         }
 
-        private async Task ProcessMeasurementGroupEvents(IEnumerable<IEventMessage> events, ILookupTemplate<IFhirTemplate> template, ITelemetryLogger log)
+        private async Task ProcessMeasurementGroupEvents(IEnumerable<IEventMessage> events, ILookupTemplate<IFhirTemplate> template, ITelemetryLogger log, CancellationToken ct)
         {
             if (events.Count() == 0)
             {
@@ -183,7 +184,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                             .AddEventContext(evt);
                     }
 
-                    await SendMeasurementGroups(groupedMeasurements, template, log, null, evt).ConfigureAwait(false);
+                    await SendMeasurementGroups(groupedMeasurements, template, log, ct, null, evt).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -215,6 +216,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             IEnumerable<IMeasurementGroup> measurementGroups,
             ILookupTemplate<IFhirTemplate> template,
             ITelemetryLogger log,
+            CancellationToken ct,
             Dictionary<IMeasurement, IEventMessage> measurementEventLookup = null,
             IEventMessage measurementGroupEvent = null)
         {
@@ -227,7 +229,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                         {
                             try
                             {
-                                await _fhirImportService.ProcessAsync(template, m).ConfigureAwait(false);
+                                await _fhirImportService.ProcessAsync(template, m, ct).ConfigureAwait(false);
                             }
                             catch (Exception ex)
                             {

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementGroupFhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementGroupFhirImportService.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             var template = BuildTemplate(templateDefinition, log);
             var measurementGroups = await ParseAsync(data, log).ConfigureAwait(false);
 
-            await SendMeasurementGroups(measurementGroups, template, log, CancellationToken.None).ConfigureAwait(false);
+            await SendMeasurementGroups(measurementGroups, template, log, default).ConfigureAwait(false);
         }
 
         public async Task ProcessEventsAsync(IEnumerable<IEventMessage> events, string templateDefinition, ITelemetryLogger log, CancellationToken ct)

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetricDefinition.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetricDefinition.cs
@@ -43,5 +43,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
         public static IomtMetricDefinition MeasurementBatchSubmissionMs { get; } = new IomtMetricDefinition(nameof(MeasurementBatchSubmissionMs));
 
         public static IomtMetricDefinition MeasurementBatchSize { get; } = new IomtMetricDefinition(nameof(MeasurementBatchSize));
+
+        public static IomtMetricDefinition FHIRResourceContention { get; } = new IomtMetricDefinition(nameof(FHIRResourceContention));
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
@@ -225,5 +225,18 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
                 .CreateBaseMetric(Category.Traffic, ConnectorOperation.Normalization)
                 .AddDimension(_partitionDimension, partitionId);
         }
+
+        /// <summary>
+        /// There are multiple processes updating the same FHIR resource.
+        /// </summary>
+        /// <param name="resourceType">The type of FHIR resource that was updated.</param>
+        /// <param name="partitionId">The partition id of the events being consumed from the event hub partition</param
+        public static Metric FHIRResourceContention(ResourceType resourceType, string partitionId = null)
+        {
+            return IomtMetricDefinition.FHIRResourceContention
+                .CreateBaseMetric(Category.Traffic, ConnectorOperation.FHIRConversion)
+                .AddDimension(_nameDimension, resourceType.ToString())
+                .AddDimension(_partitionDimension, partitionId);
+        }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                         if (result.VersionId != "1")
                         {
                             _logger.LogError(new Exception($"Two processes modified the same Obersvation: {result.Id}"));
+                            _logger.LogMetric(IomtMetrics.FHIRResourceContention(ResourceType.Observation), 1);
                         }
 
                         return (result, ResourceOperation.Created);

--- a/test/Microsoft.Health.Events.UnitTest/EventConsumerServiceTests.cs
+++ b/test/Microsoft.Health.Events.UnitTest/EventConsumerServiceTests.cs
@@ -29,14 +29,14 @@ namespace Microsoft.Health.Events.UnitTest
             var logger = Substitute.For<ITelemetryLogger>();
             var eventConsumer = Substitute.For<IEventConsumer>();
 
-            eventConsumer.ConsumeAsync(Arg.Any<IEnumerable<IEventMessage>>()).ReturnsForAnyArgs(Task.FromException(new Exception("failure")));
+            eventConsumer.ConsumeAsync(Arg.Any<IEnumerable<IEventMessage>>(), default).ReturnsForAnyArgs(Task.FromException(new Exception("failure")));
 
             var eventEventConsumers = new List<IEventConsumer>() { eventConsumer };
             var eventConsumerService = new EventConsumerService(eventEventConsumers, logger);
 
-            await eventConsumerService.ConsumeEvents(initialBatch);
+            await eventConsumerService.ConsumeEvents(initialBatch, default);
             logger.Received(1).LogError(Arg.Is<Exception>(ex => ex.Message == "failure"));
-            await eventConsumer.Received(1).ConsumeAsync(initialBatch);
+            await eventConsumer.Received(1).ConsumeAsync(initialBatch, default);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/FhirImportServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/FhirImportServiceTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Template;
@@ -38,7 +39,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 return GenerateObservationId(observationGroup, deviceId, patientId);
             }
 
-            public override Task ProcessAsync(ILookupTemplate<IFhirTemplate> config, IMeasurementGroup data, Func<Exception, IMeasurementGroup, Task<bool>> errorConsumer = null)
+            public override Task ProcessAsync(ILookupTemplate<IFhirTemplate> config, IMeasurementGroup data, CancellationToken ct, Func<Exception, IMeasurementGroup, Task<bool>> errorConsumer = null)
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementFhirImportServiceTests.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Data.Common;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -47,7 +46,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             }
 
             options.TemplateFactory.Received(1).Create(string.Empty);
-            await fhirService.DidNotReceiveWithAnyArgs().ProcessAsync(default, default);
+            await fhirService.DidNotReceiveWithAnyArgs().ProcessAsync(default, default, default);
         }
 
         [Fact]
@@ -65,7 +64,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             await fhirImport.ProcessStreamAsync(ToStream(measurements), string.Empty, log);
 
             options.TemplateFactory.Received(1).Create(string.Empty);
-            await fhirService.ReceivedWithAnyArgs(2).ProcessAsync(default, null);
+            await fhirService.ReceivedWithAnyArgs(2).ProcessAsync(default, null, default);
         }
 
         [Fact]
@@ -76,7 +75,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
             var exception = new InvalidOperationException();
             var fhirService = Substitute.For<FhirImportService>();
-            fhirService.ProcessAsync(default, default).ReturnsForAnyArgs(Task.FromException(exception));
+            fhirService.ProcessAsync(default, default, default).ReturnsForAnyArgs(Task.FromException(exception));
 
             var exceptionTelemetryProcessor = Substitute.For<IExceptionTelemetryProcessor>();
             var fhirImport = new MeasurementFhirImportService(fhirService, options, exceptionTelemetryProcessor);
@@ -93,7 +92,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 });
 
             options.TemplateFactory.Received(1).Create(string.Empty);
-            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default);
+            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default, default);
         }
 
         [Fact]
@@ -108,7 +107,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             var exception = new InvalidOperationException();
 
             var fhirService = Substitute.For<FhirImportService>();
-            fhirService.ProcessAsync(default, default).ReturnsForAnyArgs(Task.FromException(exception));
+            fhirService.ProcessAsync(default, default, default).ReturnsForAnyArgs(Task.FromException(exception));
 
             var fhirImport = new MeasurementFhirImportService(fhirService, options, exceptionProcessor);
 
@@ -117,7 +116,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             await fhirImport.ProcessStreamAsync(ToStream(measurements), string.Empty, log);
 
             options.TemplateFactory.Received(1).Create(string.Empty);
-            await fhirService.ReceivedWithAnyArgs(2).ProcessAsync(default, default);
+            await fhirService.ReceivedWithAnyArgs(2).ProcessAsync(default, default, default);
             exceptionProcessor.Received(2).HandleException(exception, log);
         }
 
@@ -140,7 +139,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             await fhirImport.ProcessStreamAsync(ToStream(measurements), string.Empty, log);
 
             Assert.Equal(1, fhirImport.WorkItemCount);
-            await fhirService.ReceivedWithAnyArgs(2).ProcessAsync(default, default);
+            await fhirService.ReceivedWithAnyArgs(2).ProcessAsync(default, default, default);
         }
 
         [Fact]
@@ -164,7 +163,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             await fhirImport.ProcessStreamAsync(ToStream(measurements), string.Empty, log);
 
             Assert.Equal(3, fhirImport.WorkItemCount);
-            await fhirService.ReceivedWithAnyArgs(4).ProcessAsync(default, default);
+            await fhirService.ReceivedWithAnyArgs(4).ProcessAsync(default, default, default);
         }
 
         [Fact]
@@ -192,7 +191,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             await fhirImport.ProcessStreamAsync(ToStream(measurements), string.Empty, log);
 
             Assert.Equal(1, fhirImport.WorkItemCount);
-            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default);
+            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default, default);
 
             // Telemetry logging is async/non-blocking. Ensure enough time has pass so section is hit.
             await Task.Delay(1000);
@@ -232,10 +231,10 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 new EventMessage("0", contentBytes, null, 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>(), new ReadOnlyDictionary<string, object>(new Dictionary<string, object>())),
             };
 
-            await fhirImport.ProcessEventsAsync(events, string.Empty, log);
+            await fhirImport.ProcessEventsAsync(events, string.Empty, log, default);
 
             options.TemplateFactory.Received(1).Create(string.Empty);
-            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default);
+            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default, default);
         }
 
         [Fact]
@@ -277,7 +276,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 new EventMessage("0", compressedBytes, Common.IO.Compression.GzipContentType, 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>() { { "IsMeasurementGroup", true } }, new ReadOnlyDictionary<string, object>(new Dictionary<string, object>())),
             };
 
-            var ex = await Assert.ThrowsAsync<CompressionNotSupportedException>(async () => await fhirImport.ProcessEventsAsync(events, string.Empty, log));
+            var ex = await Assert.ThrowsAsync<CompressionNotSupportedException>(async () => await fhirImport.ProcessEventsAsync(events, string.Empty, log, default));
 
             options.TemplateFactory.Received(1).Create(string.Empty);
             exceptionTelemetryProcessor.Received(1).HandleException(ex, log);

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementGroupFhirImportServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Service/MeasurementGroupFhirImportServiceTests.cs
@@ -57,10 +57,10 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 new EventMessage("0", contentBytes, null, 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>() { { "IsMeasurementGroup", true } }, new ReadOnlyDictionary<string, object>(new Dictionary<string, object>())),
             };
 
-            await fhirImport.ProcessEventsAsync(events, string.Empty, log);
+            await fhirImport.ProcessEventsAsync(events, string.Empty, log, default);
 
             options.TemplateFactory.Received(1).Create(string.Empty);
-            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default);
+            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default, default);
         }
 
         [Fact]
@@ -102,10 +102,10 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 new EventMessage("0", compressedBytes, Common.IO.Compression.GzipContentType, 1, 1, new DateTime(2020, 12, 31, 5, 10, 20), new Dictionary<string, object>() { { "IsMeasurementGroup", true } }, new ReadOnlyDictionary<string, object>(new Dictionary<string, object>())),
             };
 
-            await fhirImport.ProcessEventsAsync(events, string.Empty, log);
+            await fhirImport.ProcessEventsAsync(events, string.Empty, log, default);
 
             options.TemplateFactory.Received(1).Create(string.Empty);
-            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default);
+            await fhirService.ReceivedWithAnyArgs(1).ProcessAsync(default, default, default);
         }
 
         private MeasurementFhirImportOptions BuildMockOptions()

--- a/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4FhirImportServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4FhirImportServiceTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
         public async void GivenNotFoundObservation_WhenSaveObservationAsync_ThenCreateInvoked_Test()
         {
             var fhirClient = Utilities.CreateMockFhirService();
-            fhirClient.UpdateResourceAsync(Arg.Any<Observation>()).ReturnsForAnyArgs(Task.FromResult(new Observation()));
+            fhirClient.UpdateResourceAsync(Arg.Any<Observation>()).ReturnsForAnyArgs(Task.FromResult(new Observation() { Id = "123", VersionId = "1" }));
 
             var ids = BuildIdCollection();
             var identityService = Substitute.For<IResourceIdentityService>()
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             var observationGroup = Substitute.For<IObservationGroup>();
 
             var templateProcessor = Substitute.For<IFhirTemplateProcessor<ILookupTemplate<IFhirTemplate>, Observation>>()
-                .Mock(m => m.CreateObservation(default, default).ReturnsForAnyArgs(new Observation()));
+                .Mock(m => m.CreateObservation(default, default).ReturnsForAnyArgs(new Observation() { Id = "123", VersionId = "1" }));
             var cache = Substitute.For<IMemoryCache>();
             var config = Substitute.For<ILookupTemplate<IFhirTemplate>>();
 


### PR DESCRIPTION
In order to prevent duplicate observations from being created, we will be changing two things.

1. Pass cancellation tokens through to downstream methods. If an event processor loses ownership of a partition we should receive a cancellation token and pass this cancellation token to our fhir import service and stop any additional requests.
2. While cancellations are a good start, they do not necessarily handle in flight requests. So in addition, when creating an observation, we should not let the server generate the observation id. Previously, when two processors were writing to the fhir service it was possible that two creates could happen at the same time which would result in 2 observations. In this pull request the client (medtech service) will hash the id so that the id is deterministic, and only 1 observation could be created.

There are still some limitations. With option 2 you could theoretically still have a race condition. If two clients theoretically are creating an observation of the FHIR server at the same time, then two HTTP puts will occur and the 2nd HTTP put will win. This scenario should be rare because of the cancellation tokens now being checked, but I could see a case where the propagation of the cancellation token is not fast enough. If this scenario ever occurs we throw an exception. 