### PR TITLE
Add freshness delay metric

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
@@ -263,6 +263,8 @@ namespace Microsoft.Health.Events.EventConsumers.Service
             // If no events were flushed for the partition (eg: trigger reason is ThresholdWaitReached - due to receival of MaxTimeEvent), then use the current timestamp.
             var eventTimestampLastProcessed = events?.Any() ?? false ? events.Last().EnqueuedTime.UtcDateTime : DateTime.UtcNow;
             _logger.LogMetric(EventMetrics.EventTimestampLastProcessedPerPartition(partitionId, triggerReason), double.Parse(eventTimestampLastProcessed.ToString("yyyyMMddHHmmss")));
+
+            _logger.LogMetric(EventMetrics.EventFreshnessDelayPerPartition(partitionId, triggerReason), DateTime.UtcNow.Subtract(eventTimestampLastProcessed).TotalMinutes);
         }
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
             var eventTimestampLastProcessed = events?.Any() ?? false ? events.Last().EnqueuedTime.UtcDateTime : DateTime.UtcNow;
             _logger.LogMetric(EventMetrics.EventTimestampLastProcessedPerPartition(partitionId, triggerReason), double.Parse(eventTimestampLastProcessed.ToString("yyyyMMddHHmmss")));
 
-            _logger.LogMetric(EventMetrics.EventFreshnessDelayPerPartition(partitionId), DateTime.UtcNow.Subtract(eventTimestampLastProcessed).TotalMinutes);
+            _logger.LogMetric(EventMetrics.EventFreshnessDelayPerPartition(partitionId), DateTime.UtcNow.Subtract(eventTimestampLastProcessed).TotalMilliseconds);
         }
     }
 }

--- a/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
+++ b/src/lib/Microsoft.Health.Events/EventConsumers/Service/EventBatchingService.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Health.Events.EventConsumers.Service
             var eventTimestampLastProcessed = events?.Any() ?? false ? events.Last().EnqueuedTime.UtcDateTime : DateTime.UtcNow;
             _logger.LogMetric(EventMetrics.EventTimestampLastProcessedPerPartition(partitionId, triggerReason), double.Parse(eventTimestampLastProcessed.ToString("yyyyMMddHHmmss")));
 
-            _logger.LogMetric(EventMetrics.EventFreshnessDelayPerPartition(partitionId, triggerReason), DateTime.UtcNow.Subtract(eventTimestampLastProcessed).TotalMinutes);
+            _logger.LogMetric(EventMetrics.EventFreshnessDelayPerPartition(partitionId), DateTime.UtcNow.Subtract(eventTimestampLastProcessed).TotalMinutes);
         }
     }
 }

--- a/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetricDefinition.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetricDefinition.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Health.Events.Telemetry
 
         public static EventMetricDefinition EventTimestampLastProcessedPerPartition { get; } = new EventMetricDefinition(nameof(EventTimestampLastProcessedPerPartition));
 
+        public static EventMetricDefinition EventFreshnessDelayPerPartition { get; } = new EventMetricDefinition(nameof(EventFreshnessDelayPerPartition));
+
         public static EventMetricDefinition EventsWatermarkUpdated { get; } = new EventMetricDefinition(nameof(EventsWatermarkUpdated));
 
         public static EventMetricDefinition DeviceIngressSizeBytes { get; } = new EventMetricDefinition(nameof(DeviceIngressSizeBytes));

--- a/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
@@ -126,13 +126,11 @@ namespace Microsoft.Health.Events.Telemetry
         /// Signals the amount of time that has passed since the timestamp corresponding to the last processed event per partition. Calculated by subtracting the timestamp of the last processed event from the current time. If there are no events to be processed, the delay is 0.
         /// </summary>
         /// <param name="partitionId">The partition id of the event hub</param>
-        /// <param name="triggerReason">The trigger that caused the events to be flushed and processed</param
-        public static Metric EventFreshnessDelayPerPartition(string partitionId, string triggerReason)
+        public static Metric EventFreshnessDelayPerPartition(string partitionId)
         {
             return EventMetricDefinition.EventFreshnessDelayPerPartition
                 .CreateBaseMetric(Category.Latency, _connectorOperation)
-                .AddDimension(_partitionDimension, partitionId)
-                .AddDimension(_reasonDimension, triggerReason);
+                .AddDimension(_partitionDimension, partitionId);
         }
 
         /// <summary>

--- a/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
@@ -130,9 +130,9 @@ namespace Microsoft.Health.Events.Telemetry
         public static Metric EventFreshnessDelayPerPartition(string partitionId, string triggerReason)
         {
             return EventMetricDefinition.EventFreshnessDelayPerPartition
-            .CreateBaseMetric(Category.Latency, _connectorOperation)
-            .AddDimension(_partitionDimension, partitionId)
-            .AddDimension(_reasonDimension, triggerReason);
+                .CreateBaseMetric(Category.Latency, _connectorOperation)
+                .AddDimension(_partitionDimension, partitionId)
+                .AddDimension(_reasonDimension, triggerReason);
         }
 
         /// <summary>

--- a/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Health.Events.Telemetry
         }
 
         /// <summary>
-        /// Signals the amount of time that has passed since the timestamp corresponding to the last processed event per partition. Calculated by subtracting the timestamp of the last processed event from the current time.
+        /// Signals the amount of time that has passed since the timestamp corresponding to the last processed event per partition. Calculated by subtracting the timestamp of the last processed event from the current time. If there are no events to be processed, the delay is 0.
         /// </summary>
         /// <param name="partitionId">The partition id of the event hub</param>
         /// <param name="triggerReason">The trigger that caused the events to be flushed and processed</param

--- a/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
+++ b/src/lib/Microsoft.Health.Events/Telemetry/Metrics/EventMetrics.cs
@@ -123,6 +123,19 @@ namespace Microsoft.Health.Events.Telemetry
         }
 
         /// <summary>
+        /// Signals the amount of time that has passed since the timestamp corresponding to the last processed event per partition. Calculated by subtracting the timestamp of the last processed event from the current time.
+        /// </summary>
+        /// <param name="partitionId">The partition id of the event hub</param>
+        /// <param name="triggerReason">The trigger that caused the events to be flushed and processed</param
+        public static Metric EventFreshnessDelayPerPartition(string partitionId, string triggerReason)
+        {
+            return EventMetricDefinition.EventFreshnessDelayPerPartition
+            .CreateBaseMetric(Category.Latency, _connectorOperation)
+            .AddDimension(_partitionDimension, partitionId)
+            .AddDimension(_reasonDimension, triggerReason);
+        }
+
+        /// <summary>
         /// A metric recorded when there is an error reading from or connecting with an Event Hub.
         /// </summary>
         /// <param name="exceptionName">The name of the exception</param>


### PR DESCRIPTION
Added freshness delay metric and logic for it to be invoked in the case of a healthy service (i.e. if a large freshness delay were to be reported after these changes, we would expect it to be due to a large volume of events, rather than an issue with the service itself). The next iteration of this work will involve adding logic to invoke this metric in the case where processing fails, leading to a backlog of events to process.

**Testing**
Provisioned a MedTech service in my personal cluster and observed the metric flowing through as expected.