### PR TITLE
Expose ManagedIdentityCredentialNotFound in logs

### DIFF
--- a/src/lib/Microsoft.Health.Common/Telemetry/Exceptions/ManagedIdentityCredentialNotFound.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/Exceptions/ManagedIdentityCredentialNotFound.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Microsoft.Health.Common.Telemetry.Exceptions
 {
-    public class ManagedIdentityCredentialNotFound : IomtTelemetryFormattableException
+    public class ManagedIdentityCredentialNotFound : ThirdPartyLoggedFormattableException
     {
         public ManagedIdentityCredentialNotFound(
             string message,


### PR DESCRIPTION
Expose ManagedIdentityCredentialNotFound in customer-facing logs, to inform customers who get this exception that their MedTech service’s system assigned managed identity is disabled or does not exist.