### PR TITLE
Fix event/observation updates being dropped

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.Ingest/Data/SampledDataProcessor.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Data/SampledDataProcessor.cs
@@ -67,38 +67,38 @@ namespace Microsoft.Health.Fhir.Ingest.Data
             return timeValues.ToArray();
         }
 
-        public virtual (DateTime Time, string Value)[] MergeData((DateTime Time, string Value)[] data1, (DateTime Time, string Value)[] data2)
+        public virtual (DateTime Time, string Value)[] MergeData((DateTime Time, string Value)[] existingData, (DateTime Time, string Value)[] newData)
         {
-            EnsureArg.IsNotNull(data1, nameof(data1));
-            EnsureArg.IsNotNull(data2, nameof(data2));
+            EnsureArg.IsNotNull(existingData, nameof(existingData));
+            EnsureArg.IsNotNull(newData, nameof(newData));
 
-            var output = new List<(DateTime Time, string Value)>(data1.Length + data2.Length);
-            var data1Pos = 0;
-            var data2Pos = 0;
+            var output = new List<(DateTime Time, string Value)>(existingData.Length + newData.Length);
+            var existingDataPos = 0;
+            var newDataPos = 0;
 
-            while (data1Pos < data1.Length || data2Pos < data2.Length)
+            while (existingDataPos < existingData.Length || newDataPos < newData.Length)
             {
-                if (data1Pos >= data1.Length)
+                if (existingDataPos >= existingData.Length)
                 {
-                    output.Add(data2[data2Pos++]);
+                    output.Add(newData[newDataPos++]);
                 }
-                else if (data2Pos >= data2.Length)
+                else if (newDataPos >= newData.Length)
                 {
-                    output.Add(data1[data1Pos++]);
+                    output.Add(existingData[existingDataPos++]);
                 }
-                else if (data1[data1Pos].Time < data2[data2Pos].Time)
+                else if (existingData[existingDataPos].Time < newData[newDataPos].Time)
                 {
-                    output.Add(data1[data1Pos++]);
+                    output.Add(existingData[existingDataPos++]);
                 }
-                else if (data1[data1Pos].Time > data2[data2Pos].Time)
+                else if (existingData[existingDataPos].Time > newData[newDataPos].Time)
                 {
-                    output.Add(data2[data2Pos++]);
+                    output.Add(newData[newDataPos++]);
                 }
                 else
                 {
-                    // Collision, take one and increment both
-                    output.Add(data1[data1Pos++]);
-                    data2Pos++;
+                    // In case of collision, take the new data to represent latest data, and increment both positions.
+                    output.Add(newData[newDataPos++]);
+                    existingDataPos++;
                 }
             }
 

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementFhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Service/MeasurementFhirImportService.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             .Select(g =>
             {
                 // In case of multiple measurements with the same OccurrenceTimeUtc within the batch, take the latest (based on IngestionTimeUtc) measurement
-                // to represent the recent/updated event data at that occurence timestamp.
+                // to represent the recent/updated event data at that occurrence timestamp.
                 IList<Measurement> measurements = g.GroupBy(x => x.OccurrenceTimeUtc).Select(y => y.OrderByDescending(d => d.IngestionTimeUtc).First()).ToList();
 
                 _ = CalculateMetricsAsync(measurements, logger, partitionId).ConfigureAwait(false);

--- a/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/SampledDataProcessorTests.cs
+++ b/test/Microsoft.Health.Fhir.Ingest.UnitTests/Data/SampledDataProcessorTests.cs
@@ -398,7 +398,7 @@ namespace Microsoft.Health.Fhir.Ingest.Data
         }
 
         [Fact]
-        public void GivenCollisions_WhenMergeData_ThenData1ValueUsed_Test()
+        public void GivenCollisions_WhenMergeData_ThenData2ValueUsed_Test()
         {
             var seedDt = new DateTime(2019, 1, 1, 0, 30, 0, DateTimeKind.Utc);
             var data1 = new[]
@@ -423,12 +423,12 @@ namespace Microsoft.Health.Fhir.Ingest.Data
                 v =>
                 {
                     Assert.Equal(seedDt, v.Time);
-                    Assert.Equal("1", v.Value);
+                    Assert.Equal("2", v.Value);
                 },
                 v =>
                 {
                     Assert.Equal(seedDt.AddMinutes(1), v.Time);
-                    Assert.Equal("1", v.Value);
+                    Assert.Equal("2", v.Value);
                 });
         }
 


### PR DESCRIPTION
Changes include two fixes:
* When multiple messages that contain data for the same Observation have the same timestamp, the measurement data in the first message processed is the only data persisted. 
Fix includes taking the latest event data for the same timestamp within the batch and only adding the corresponding measurement in the measurement group.

* When merging sampled data (new data with an existing observation), if the timestamp between the new and the existing value collides, the existing value was being taken which resulted in the merged observation not being considered for an 'update'. 
Fix includes taking the new data value if there is timestamp collision so that merged observation represents latest data.