### PR TITLE
Fix duplicate dimension being added

### DIFF
--- a/src/lib/Microsoft.Health.Common/Telemetry/MetricExtension.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/MetricExtension.cs
@@ -3,7 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using EnsureThat;
 
 namespace Microsoft.Health.Common.Telemetry
@@ -33,12 +35,19 @@ namespace Microsoft.Health.Common.Telemetry
 
         public static Metric AddDimension(this Metric metric, string dimensionName, string dimensionValue)
         {
-            if (string.IsNullOrWhiteSpace(dimensionValue))
+            if (string.IsNullOrWhiteSpace(dimensionName) || string.IsNullOrWhiteSpace(dimensionValue))
             {
                 return metric;
             }
 
-            metric.Dimensions[dimensionName] = dimensionValue;
+            try
+            {
+                metric.Dimensions.Add(dimensionName, dimensionValue);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError($"An error occurred while adding dimension {dimensionName} to metric {metric.Name}. {ex}");
+            }
 
             return metric;
         }

--- a/src/lib/Microsoft.Health.Common/Telemetry/MetricExtension.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/MetricExtension.cs
@@ -38,7 +38,8 @@ namespace Microsoft.Health.Common.Telemetry
                 return metric;
             }
 
-            metric.Dimensions.Add(dimensionName, dimensionValue);
+            metric.Dimensions[dimensionName] = dimensionValue;
+
             return metric;
         }
 

--- a/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/DimensionNames.cs
+++ b/src/lib/Microsoft.Health.Common/Telemetry/Metrics/Dimensions/DimensionNames.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Health.Common.Telemetry
         public static string Name => nameof(Name);
 
         /// <summary>
+        /// A metric dimension for a resource type.
+        /// </summary>
+        public static string ResourceType => nameof(ResourceType);
+
+        /// <summary>
         /// A metric dimension that represents each ingestion stage of the IoMT Connector.
         /// </summary>
         public static string Operation => nameof(Operation);

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
     public static class IomtMetrics
     {
         private static readonly string _nameDimension = DimensionNames.Name;
+        private static readonly string _resourceTypeDimension = DimensionNames.ResourceType;
         private static readonly string _categoryDimension = DimensionNames.Category;
         private static readonly string _errorTypeDimension = DimensionNames.ErrorType;
         private static readonly string _errorSeverityDimension = DimensionNames.ErrorSeverity;
@@ -234,9 +235,9 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
         public static Metric FHIRResourceContention(ResourceType resourceType, string partitionId = null)
         {
             return IomtMetricDefinition.FHIRResourceContention
-                .CreateBaseMetric(Category.Traffic, ConnectorOperation.FHIRConversion)
-                .AddDimension(_nameDimension, resourceType.ToString())
-                .AddDimension(_partitionDimension, partitionId);
+               .CreateBaseMetric(Category.Traffic, ConnectorOperation.FHIRConversion)
+               .AddDimension(_resourceTypeDimension, resourceType.ToString())
+               .AddDimension(_partitionDimension, partitionId);
         }
     }
 }

--- a/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
+++ b/src/lib/Microsoft.Health.Fhir.Ingest/Telemetry/Metrics/IomtMetrics.cs
@@ -235,9 +235,9 @@ namespace Microsoft.Health.Fhir.Ingest.Telemetry
         public static Metric FHIRResourceContention(ResourceType resourceType, string partitionId = null)
         {
             return IomtMetricDefinition.FHIRResourceContention
-               .CreateBaseMetric(Category.Traffic, ConnectorOperation.FHIRConversion)
-               .AddDimension(_resourceTypeDimension, resourceType.ToString())
-               .AddDimension(_partitionDimension, partitionId);
+                .CreateBaseMetric(Category.Traffic, ConnectorOperation.FHIRConversion)
+                .AddDimension(_resourceTypeDimension, resourceType.ToString())
+                .AddDimension(_partitionDimension, partitionId);
         }
     }
 }

--- a/test/Microsoft.Health.Common.UnitTests/MetricExtensionTest.cs
+++ b/test/Microsoft.Health.Common.UnitTests/MetricExtensionTest.cs
@@ -1,0 +1,29 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Common.Telemetry;
+using Xunit;
+
+namespace Microsoft.Health.Common.UnitTests
+{
+    public class MetricExtensionTest
+    {
+        [Fact]
+        public void GivenMetric_WhenDimensionAddedAndDimensionAlreadyExists_ThenDimensionValueIsOverwritten_Test()
+        {
+            // Test the behavior where CreateBaseMetric adds a 'Name' dimension and then a user later calls .AddDimension with 'Name' as an argument
+            // Instead of throwing an exception during .AddDimension we should overwrite the dimension value.
+            var metricDefinition = new MetricDefinition("testMetricName");
+
+            var metric = MetricExtension.CreateBaseMetric(metricDefinition, Category.Traffic, ConnectorOperation.FHIRConversion);
+
+            Assert.Equal("testMetricName", metric.Dimensions[DimensionNames.Name]);
+
+            metric.AddDimension(DimensionNames.Name, "changedMetricDimensionName");
+
+            Assert.Equal("changedMetricDimensionName", metric.Dimensions[DimensionNames.Name]);
+        }
+    }
+}

--- a/test/Microsoft.Health.Common.UnitTests/MetricExtensionTest.cs
+++ b/test/Microsoft.Health.Common.UnitTests/MetricExtensionTest.cs
@@ -11,19 +11,20 @@ namespace Microsoft.Health.Common.UnitTests
     public class MetricExtensionTest
     {
         [Fact]
-        public void GivenMetric_WhenDimensionAddedAndDimensionAlreadyExists_ThenDimensionValueIsOverwritten_Test()
+        public void GivenMetric_WhenDimensionAddedAndDimensionAlreadyExists_ThenDimensionValueIsNotOverwritten_Test()
         {
             // Test the behavior where CreateBaseMetric adds a 'Name' dimension and then a user later calls .AddDimension with 'Name' as an argument
-            // Instead of throwing an exception during .AddDimension we should overwrite the dimension value.
+            // Instead of throwing an exception during .AddDimension we should not add the dimension, log an error trace, but not throw an exception.
             var metricDefinition = new MetricDefinition("testMetricName");
 
             var metric = MetricExtension.CreateBaseMetric(metricDefinition, Category.Traffic, ConnectorOperation.FHIRConversion);
 
             Assert.Equal("testMetricName", metric.Dimensions[DimensionNames.Name]);
 
-            metric.AddDimension(DimensionNames.Name, "changedMetricDimensionName");
+            metric.AddDimension(DimensionNames.Name, "attemptToChangeMetricDimensionValue");
 
-            Assert.Equal("changedMetricDimensionName", metric.Dimensions[DimensionNames.Name]);
+            // Assert metric dimension value unchanged
+            Assert.Equal("testMetricName", metric.Dimensions[DimensionNames.Name]);
         }
     }
 }


### PR DESCRIPTION
The FHIRResourceContention metric was adding a dimension called 'Name' via .AddDimension but the metric extension method .CreateBaseMetric also adds a dimension called 'Name', so the end result was the 'Name' dimension was added twice which resulted in an exception the second time 'Name' was added to the metric dimensions dictionary.

Updated the FHIRResourceContention metric to use a different dimension name for the FHIR resource so that the 'Name' dimension isn't added twice.

Also updated the metric extension class so that when .AddDimension is called and there is already a dimension with that name we no longer throw an exception and instead log an error trace. The dimension is not added/overwritten.