### PR TITLE
Ignore FHIR version check on soft delete

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
@@ -128,9 +128,12 @@ namespace Microsoft.Health.Fhir.Ingest.Service
 
                             var result = await _fhirService.UpdateResourceAsync(newObservation).ConfigureAwait(false);
 
-                            if (result.VersionId != "1")
+                            // If the version id is not equal to "1" on a create then it is likely two processes modified
+                            // the resource at the same time.
+                            // However we cannot check for not equal to "1" because a resource can be soft-deleted and recreated
+                            // and on the recreate the resource version will also be not equal to "1", so instead we will check for resource version id = "2"
+                            if (result.VersionId == "2")
                             {
-                                _logger.LogError(new Exception($"Two processes modified the same Observation: {result.Id}"));
                                 _logger.LogMetric(IomtMetrics.FHIRResourceContention(ResourceType.Observation), 1);
                             }
 

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
@@ -131,7 +131,8 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                             // If the version id is not equal to "1" on a create then it is likely two processes modified
                             // the resource at the same time.
                             // However we cannot check for not equal to "1" because a resource can be soft-deleted and recreated
-                            // and on the recreate the resource version will also be not equal to "1", so instead we will check for resource version id = "2"
+                            // and on the recreate the resource version will also be not equal to "1",
+                            // so instead we will check for resource version id = "2"
                             if (result.VersionId == "2")
                             {
                                 _logger.LogMetric(IomtMetrics.FHIRResourceContention(ResourceType.Observation), 1);


### PR DESCRIPTION
Previously we checked the FHIR resource version after creating an Observation to see if the version equaled "1". If the version did not equal "1" we logged an error and a metric and continued on. This was so we had enough information on when two processes were potentially modifying an Observation at the same time. Now that we know the cause we can remove the error logging which is not needed, but we are going to keep the metric just in case. In addition we also happened to notice that there were some false positives with the error logging and metric logging. We noticed that soft-deleted resources that are recreated do not have a version equal to "1" when they are recreated, which was causing an error to be logged even though there was no resource contention. This was a missed case and this PR attempts to address this case. In the case of soft-deletes the resource needs to be created and then soft-deleted and the re-created again. When the resource is recreated again by the Iot Connector the resource version is actually "3", so in order to differentiate the soft-delete case from the "two processes modifying an observation at the same time" case we are going to check that the version is equal to "2".

The approach taken in this PR looks silly but not sure there are other options. I had wanted to determine if a resource had been previously soft-deleted and then pass a flag into the Create Observation code to ignore the FHIR version check. When a resource is soft-deleted it does return an HTTP 410 Gone if you do a GET for the resource directly (e.g. GET Observation/123456) but we cannot leverage this because the Iot Connector does a search (GET Observation?identifier="123456") which returns an HTTP 200 with an empty bundle, so we don't have any knowledge about the previous stare of the Observation and therefore can't really pass a flag indicating that the resource has been previously soft-deleted.