### PR TITLE
Support optional encounter linking in Lookup & Create

### DIFF
--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             }
             catch (FhirResourceNotFoundException ex)
             {
-                // Continue with create path if device  or patient wasn't found.
+                // Continue with create path if device or patient wasn't found.
                 if (!(ex.FhirResourceType == ResourceType.Device || ex.FhirResourceType == ResourceType.Patient))
                 {
                     throw;

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientWithEncounterLookupIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientWithEncounterLookupIdentityService.cs
@@ -10,7 +10,6 @@ using Microsoft.Health.Extensions.Fhir.Service;
 using Microsoft.Health.Fhir.Ingest.Config;
 using Microsoft.Health.Fhir.Ingest.Data;
 using Microsoft.Health.Fhir.Ingest.Host;
-using Model = Hl7.Fhir.Model;
 
 namespace Microsoft.Health.Fhir.Ingest.Service
 {
@@ -42,9 +41,6 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             {
                 throw new ResourceIdentityNotDefinedException(ResourceType.Encounter);
             }
-
-            var encounter = await ResourceManagementService.GetResourceByIdentityAsync<Model.Encounter>(input.EncounterId, null).ConfigureAwait(false) ?? throw new FhirResourceNotFoundException(ResourceType.Encounter);
-            identities[ResourceType.Encounter] = encounter?.Id;
 
             return identities;
         }

--- a/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4DeviceAndPatientCreateIdentityServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4DeviceAndPatientCreateIdentityServiceTests.cs
@@ -277,5 +277,75 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             await resourceService.Received(1).EnsureResourceByIdentityAsync("deviceId", null, Arg.Any<Action<Model.Device, Model.Identifier>>());
             await resourceService.Received(1).EnsureResourceByIdentityAsync("patientId", null, Arg.Any<Action<Model.Patient, Model.Identifier>>());
         }
+
+        [Fact]
+        public async void GivenValidEncounterIdentifier_WhenResolveResourceIdentitiesAsync_ThenEncounterIdReturned_Test()
+        {
+            var fhirClient = Utilities.CreateMockFhirService();
+            var resourceService = Substitute.For<ResourceManagementService>(fhirClient);
+            var device = new Model.Device
+            {
+                Id = "1",
+                Patient = new Model.ResourceReference("Patient/123"),
+            };
+
+            var encounter = new Model.Encounter
+            {
+                Id = "abc",
+            };
+
+            var mg = Substitute.For<IMeasurementGroup>();
+            mg.DeviceId.Returns("deviceId");
+            mg.EncounterId.Returns("eId");
+
+            resourceService.GetResourceByIdentityAsync<Model.Device>(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(Task.FromResult(device));
+
+            resourceService.GetResourceByIdentityAsync<Model.Encounter>(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(Task.FromResult(encounter));
+
+            using (var idSrv = new R4DeviceAndPatientCreateIdentityService(fhirClient, resourceService))
+            {
+                var ids = await idSrv.ResolveResourceIdentitiesAsync(mg);
+
+                Assert.Equal("1", ids[ResourceType.Device]);
+                Assert.Equal("123", ids[ResourceType.Patient]);
+                Assert.Equal("abc", ids[ResourceType.Encounter]);
+            }
+
+            await resourceService.Received(1).GetResourceByIdentityAsync<Model.Device>("deviceId", null);
+            await resourceService.Received(1).GetResourceByIdentityAsync<Model.Encounter>("eId", null);
+        }
+
+        [Fact]
+        public async void GivenInValidEncounterIdentifier_WhenResolveResourceIdentitiesAsync_ThenFhirResourceNotFoundExceptionThrown_Test()
+        {
+            var fhirClient = Utilities.CreateMockFhirService();
+            var resourceService = Substitute.For<ResourceManagementService>(fhirClient);
+            var device = new Model.Device
+            {
+                Id = "1",
+                Patient = new Model.ResourceReference("Patient/123"),
+            };
+
+            var mg = Substitute.For<IMeasurementGroup>();
+            mg.DeviceId.Returns("deviceId");
+            mg.EncounterId.Returns("eId");
+
+            resourceService.GetResourceByIdentityAsync<Model.Device>(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(Task.FromResult(device));
+
+            resourceService.GetResourceByIdentityAsync<Model.Encounter>(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(Task.FromResult((Model.Encounter)null));
+
+            using (var idSrv = new R4DeviceAndPatientCreateIdentityService(fhirClient, resourceService))
+            {
+                var ex = await Assert.ThrowsAsync<FhirResourceNotFoundException>(async () => await idSrv.ResolveResourceIdentitiesAsync(mg));
+                Assert.Equal(ResourceType.Encounter, ex.FhirResourceType);
+            }
+
+            await resourceService.Received(1).GetResourceByIdentityAsync<Model.Device>("deviceId", null);
+            await resourceService.Received(1).GetResourceByIdentityAsync<Model.Encounter>("eId", null);
+        }
     }
 }

--- a/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4DeviceAndPatientLookupIdentityServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Ingest.UnitTests/Service/R4DeviceAndPatientLookupIdentityServiceTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             }
 
             await resourceService.Received(1).GetResourceByIdentityAsync<Model.Device>("deviceId", null);
+            await resourceService.DidNotReceiveWithAnyArgs().GetResourceByIdentityAsync<Model.Encounter>(default, default);
         }
 
         [Fact]
@@ -124,6 +125,76 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             }
 
             await resourceService.Received(1).GetResourceByIdentityAsync<Model.Device>("deviceId", null);
+        }
+
+        [Fact]
+        public async void GivenValidEncounterIdentifier_WhenResolveResourceIdentitiesAsync_ThenEncounterIdReturned_Test()
+        {
+            var fhirClient = Utilities.CreateMockFhirService();
+            var resourceService = Substitute.For<ResourceManagementService>(fhirClient);
+            var device = new Model.Device
+            {
+                Id = "1",
+                Patient = new Model.ResourceReference("Patient/123"),
+            };
+
+            var encounter = new Model.Encounter
+            {
+                Id = "abc",
+            };
+
+            var mg = Substitute.For<IMeasurementGroup>();
+            mg.DeviceId.Returns("deviceId");
+            mg.EncounterId.Returns("eId");
+
+            resourceService.GetResourceByIdentityAsync<Model.Device>(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(Task.FromResult(device));
+
+            resourceService.GetResourceByIdentityAsync<Model.Encounter>(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(Task.FromResult(encounter));
+
+            using (var idSrv = new R4DeviceAndPatientLookupIdentityService(fhirClient, resourceService))
+            {
+                var ids = await idSrv.ResolveResourceIdentitiesAsync(mg);
+
+                Assert.Equal("1", ids[ResourceType.Device]);
+                Assert.Equal("123", ids[ResourceType.Patient]);
+                Assert.Equal("abc", ids[ResourceType.Encounter]);
+            }
+
+            await resourceService.Received(1).GetResourceByIdentityAsync<Model.Device>("deviceId", null);
+            await resourceService.Received(1).GetResourceByIdentityAsync<Model.Encounter>("eId", null);
+        }
+
+        [Fact]
+        public async void GivenInValidEncounterIdentifier_WhenResolveResourceIdentitiesAsync_ThenFhirResourceNotFoundExceptionThrown_Test()
+        {
+            var fhirClient = Utilities.CreateMockFhirService();
+            var resourceService = Substitute.For<ResourceManagementService>(fhirClient);
+            var device = new Model.Device
+            {
+                Id = "1",
+                Patient = new Model.ResourceReference("Patient/123"),
+            };
+
+            var mg = Substitute.For<IMeasurementGroup>();
+            mg.DeviceId.Returns("deviceId");
+            mg.EncounterId.Returns("eId");
+
+            resourceService.GetResourceByIdentityAsync<Model.Device>(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(Task.FromResult(device));
+
+            resourceService.GetResourceByIdentityAsync<Model.Encounter>(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(Task.FromResult((Model.Encounter)null));
+
+            using (var idSrv = new R4DeviceAndPatientLookupIdentityService(fhirClient, resourceService))
+            {
+                var ex = await Assert.ThrowsAsync<FhirResourceNotFoundException>(async () => await idSrv.ResolveResourceIdentitiesAsync(mg));
+                Assert.Equal(ResourceType.Encounter, ex.FhirResourceType);
+            }
+
+            await resourceService.Received(1).GetResourceByIdentityAsync<Model.Device>("deviceId", null);
+            await resourceService.Received(1).GetResourceByIdentityAsync<Model.Encounter>("eId", null);
         }
     }
 }


### PR DESCRIPTION
Update the IdentityService to always link and encounter id if specified in the measurement group.

This will allow optional encounter linking in the LookupIdentityService & CreateIdentityService.

The DeviceAndPatientWithEncounterIdentityService will still require the encounter id present or a ResourceIdentityNotDefinedException will be thrown.