### PR TITLE
Updating assembly version to match Semantic Version

### DIFF
--- a/build/package.yml
+++ b/build/package.yml
@@ -12,6 +12,7 @@ steps:
       versionEnvVar: 'nuget_version'
       nobuild: true
       zipAfterPublish: true
+      buildProperties: AssemblyVersion="$(assemblySemVer)";FileVersion="$(assemblySemFileVer)"
     env:
       nuget_version: $(build.buildNumber)
 


### PR DESCRIPTION
The assembly version inside of the nuget is getting defaulted to `1.0.0.0`. Because this differs from the semantic version .Net is having trouble locating the nuget. This PR sets the assembly version details within the nuget to match the generated semantic version