### PR TITLE
Address Issue 188

### DIFF
--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/IdentifierExtensions.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/IdentifierExtensions.cs
@@ -9,9 +9,9 @@ using EnsureThat;
 
 namespace Microsoft.Health.Extensions.Fhir
 {
-    public static class SHA256HashGenerator
+    public static class IdentifierExtensions
     {
-        public static string ComputeHashForIdentifier(Hl7.Fhir.Model.Identifier identifier)
+        public static string ComputeHashForIdentifier(this Hl7.Fhir.Model.Identifier identifier)
         {
             EnsureArg.IsNotNullOrWhiteSpace(identifier.Value, nameof(identifier.Value));
 

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Service/ResourceManagementService.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Service/ResourceManagementService.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Extensions.Fhir.Service
 
             propertySetter?.Invoke(resource, identifier);
 
-            return await FhirService.CreateResourceAsync(resource).ConfigureAwait(false);
+            return await FhirService.UpdateResourceAsync(resource).ConfigureAwait(false);
         }
 
         private static Identifier BuildIdentifier(string value, string system)

--- a/src/lib/Microsoft.Health.Extensions.Fhir.R4/Service/ResourceManagementService.cs
+++ b/src/lib/Microsoft.Health.Extensions.Fhir.R4/Service/ResourceManagementService.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Extensions.Fhir.Search;
-using Model = Hl7.Fhir.Model;
 
 namespace Microsoft.Health.Extensions.Fhir.Service
 {
@@ -29,8 +28,8 @@ namespace Microsoft.Health.Extensions.Fhir.Service
         /// <param name="system">The system the identifier belongs to.</param>
         /// <param name="propertySetter">Optional setter to provide property values if the resource needs to be created.</param>
         /// <returns>Reource that was found or created.</returns>
-        public virtual async Task<TResource> EnsureResourceByIdentityAsync<TResource>(string value, string system, Action<TResource, Model.Identifier> propertySetter = null)
-            where TResource : Model.Resource, new()
+        public virtual async Task<TResource> EnsureResourceByIdentityAsync<TResource>(string value, string system, Action<TResource, Identifier> propertySetter = null)
+            where TResource : Resource, new()
         {
             EnsureArg.IsNotNullOrWhiteSpace(value, nameof(value));
 
@@ -40,7 +39,7 @@ namespace Microsoft.Health.Extensions.Fhir.Service
         }
 
         public virtual async Task<TResource> GetResourceByIdentityAsync<TResource>(string value, string system)
-            where TResource : Model.Resource, new()
+            where TResource : Resource, new()
         {
             EnsureArg.IsNotNullOrWhiteSpace(value, nameof(value));
 
@@ -48,8 +47,8 @@ namespace Microsoft.Health.Extensions.Fhir.Service
             return await GetResourceByIdentityAsync<TResource>(identifier).ConfigureAwait(false);
         }
 
-        protected async Task<TResource> GetResourceByIdentityAsync<TResource>(Model.Identifier identifier)
-            where TResource : Model.Resource, new()
+        protected async Task<TResource> GetResourceByIdentityAsync<TResource>(Identifier identifier)
+            where TResource : Resource, new()
         {
             EnsureArg.IsNotNull(identifier, nameof(identifier));
 
@@ -57,12 +56,12 @@ namespace Microsoft.Health.Extensions.Fhir.Service
 
             _ = Enum.TryParse(fhirTypeName, out ResourceType resourceType);
 
-            Model.Bundle result = await FhirService.SearchForResourceAsync(resourceType, identifier.ToSearchQueryParameter()).ConfigureAwait(false);
+            Bundle result = await FhirService.SearchForResourceAsync(resourceType, identifier.ToSearchQueryParameter()).ConfigureAwait(false);
             return await result.ReadOneFromBundleWithContinuationAsync<TResource>(FhirService);
         }
 
-        protected async Task<TResource> CreateResourceByIdentityAsync<TResource>(Model.Identifier identifier, Action<TResource, Model.Identifier> propertySetter)
-            where TResource : Model.Resource, new()
+        protected async Task<TResource> CreateResourceByIdentityAsync<TResource>(Identifier identifier, Action<TResource, Identifier> propertySetter)
+            where TResource : Resource, new()
         {
             EnsureArg.IsNotNull(identifier, nameof(identifier));
             var resource = new TResource();
@@ -72,9 +71,9 @@ namespace Microsoft.Health.Extensions.Fhir.Service
             return await FhirService.CreateResourceAsync(resource).ConfigureAwait(false);
         }
 
-        private static Model.Identifier BuildIdentifier(string value, string system)
+        private static Identifier BuildIdentifier(string value, string system)
         {
-            var identifier = new Model.Identifier { Value = value, System = string.IsNullOrWhiteSpace(system) ? null : system };
+            var identifier = new Identifier { Value = value, System = string.IsNullOrWhiteSpace(system) ? null : system };
             return identifier;
         }
     }

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4DeviceAndPatientCreateIdentityService.cs
@@ -71,7 +71,11 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             var patient = await ResourceManagementService.EnsureResourceByIdentityAsync<Model.Patient>(
                 input.PatientId,
                 null,
-                (p, id) => p.Identifier = new List<Model.Identifier> { id })
+                (p, id) =>
+                {
+                    p.Identifier = new List<Model.Identifier> { id };
+                    p.Id = id.ComputeHashForIdentifier();
+                })
                 .ConfigureAwait(false);
 
             var device = await ResourceManagementService.EnsureResourceByIdentityAsync<Model.Device>(
@@ -81,6 +85,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
                 {
                     d.Identifier = new List<Model.Identifier> { id };
                     d.Patient = patient.ToReference();
+                    d.Id = id.ComputeHashForIdentifier();
                 })
                 .ConfigureAwait(false);
 

--- a/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
+++ b/src/lib/Microsoft.Health.Fhir.R4.Ingest/Service/R4FhirImportService.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Health.Fhir.Ingest.Service
             observation.Subject = patientId.ToReference<Model.Patient>();
             observation.Device = deviceId.ToReference<Model.Device>();
             observation.Identifier = new List<Model.Identifier> { observationId };
-            observation.Id = SHA256HashGenerator.ComputeHashForIdentifier(observationId);
+            observation.Id = observationId.ComputeHashForIdentifier();
 
             if (ids.TryGetValue(ResourceType.Encounter, out string encounterId))
             {

--- a/test/Microsoft.Health.Common.UnitTests/Utilities.cs
+++ b/test/Microsoft.Health.Common.UnitTests/Utilities.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using Hl7.Fhir.Model;
 using Microsoft.Health.Extensions.Fhir.Service;
 using NSubstitute;
 
@@ -13,6 +15,28 @@ namespace Microsoft.Health.Common
         public static IFhirService CreateMockFhirService()
         {
             return Substitute.For<IFhirService>();
+        }
+
+        public static IFhirService SearchReturnsEmptyBundle(this IFhirService service)
+        {
+            service.SearchForResourceAsync(default, default)
+                .ReturnsForAnyArgs(new Bundle());
+
+            return service;
+        }
+
+        public static IFhirService UpdateReturnsResource<T>(this IFhirService service)
+            where T : Resource
+        {
+            service.UpdateResourceAsync(Arg.Any<T>()).Returns(args => args.ArgAt<T>(0));
+            return service;
+        }
+
+        public static IFhirService CreateReturnsResource<T>(this IFhirService service)
+            where T : Resource
+        {
+            service.CreateResourceAsync(Arg.Any<T>()).Returns(args => args.ArgAt<T>(0));
+            return service;
         }
     }
 }

--- a/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/Service/ResourceManagementServiceTests.cs
+++ b/test/Microsoft.Health.Extensions.Fhir.R4.UnitTests/Service/ResourceManagementServiceTests.cs
@@ -1,0 +1,80 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Extensions.Fhir.Service;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Extensions.Fhir.R4.UnitTests.Service
+{
+    public class ResourceManagementServiceTests
+    {
+        [Fact]
+        public async void GivenResourceFound_WhenEnsureResourceByIdentityAsync_ThenFoundResourceReturned_Test()
+        {
+            var identiferValue = "123";
+            var identifierSystem = "abc";
+            var patient = new Patient { Id = "1" };
+            var fhirClient = Substitute.For<IFhirService>();
+            fhirClient.SearchForResourceAsync(ResourceType.Patient, "identifier=abc|123")
+                .Returns(
+                    new Bundle
+                    {
+                        Entry = new List<Bundle.EntryComponent> { new Bundle.EntryComponent { Resource = patient } },
+                    });
+
+            var rms = new ResourceManagementService(fhirClient);
+            var setterCalled = false;
+            Action<Patient, Identifier> setter = (p, i) => { setterCalled = true; };
+
+            var result = await rms.EnsureResourceByIdentityAsync(identiferValue, identifierSystem, setter);
+
+            // Verify get path used
+            Assert.False(setterCalled);
+            Assert.Equal(expected: patient, actual: result);
+            await fhirClient.DidNotReceiveWithAnyArgs().CreateResourceAsync<Patient>(default, default, default, default);
+            await fhirClient.DidNotReceiveWithAnyArgs().UpdateResourceAsync<Patient>(default, default, default, default);
+            await fhirClient.ReceivedWithAnyArgs().SearchForResourceAsync(default, default, default, default);
+            await fhirClient.Received(1).SearchForResourceAsync(ResourceType.Patient, "identifier=abc|123", default, default);
+        }
+
+        [Fact]
+        public async void GivenResourceNotFound_WhenEnsureResourceByIdentityAsync_ThenResourceCreatedAndReturned_Test()
+        {
+            var identiferValue = "123";
+            var identifierSystem = "abc";
+            var newPatient = new Patient { Id = "1" };
+            var fhirClient = Substitute.For<IFhirService>();
+            fhirClient.SearchForResourceAsync(default, default)
+                .ReturnsForAnyArgs(new Bundle());
+            fhirClient.CreateResourceAsync(Arg.Any<Patient>()).Returns(newPatient);
+
+            var rms = new ResourceManagementService(fhirClient);
+            var setterCalled = false;
+            Action<Patient, Identifier> setter = (p, i) =>
+            {
+                setterCalled = true;
+                p.Identifier = new List<Identifier> { new Identifier { Value = identiferValue, System = identifierSystem } };
+            };
+
+            var result = await rms.EnsureResourceByIdentityAsync(identiferValue, identifierSystem, setter);
+
+            // Verify create path used
+            Assert.True(setterCalled);
+            Assert.Equal(expected: newPatient, actual: result);
+            await fhirClient.DidNotReceiveWithAnyArgs().UpdateResourceAsync<Patient>(default, default, default, default);
+            await fhirClient.Received(1).SearchForResourceAsync(ResourceType.Patient, "identifier=abc|123", default, default);
+            await fhirClient.Received(1).CreateResourceAsync(
+                Arg.Is<Patient>(p => p.Identifier[0].Value == identiferValue && p.Identifier[0].System == identifierSystem),
+                null,
+                null,
+                Arg.Any<CancellationToken>());
+        }
+    }
+}


### PR DESCRIPTION
[Address Github issue](https://github.com/microsoft/iomt-fhir/commit/31c0130ed019dc0c1854f17ef9c11b39783ca69a) https://github.com/microsoft/iomt-fhir/issues/188 

Support deterministic device and patient ids in create mode to avoid duplicates.

Switch device and patient logic to use deterministic ids based on the identifiers. Instead of using Create so the service sets the resource id, the id will be set and the Update path used (necessary per FHIR spec to set the resource id).  Logic now mirrors a recent change made to Observations.

- Added unit tests for ResourceManagementService.
- Added additional test helper extensions for IFhirService mocks for common test scenarios.
- Updated R4DeviceAndPatientCreateIdentityServiceTests to validate ids generated for resources are derived from the identifier as expected.
- Refactored SHA256HashGenerator to an extension method and renamed file to match other extension method files.