### PR TITLE
fix "Deploy to Azure" button

### DIFF
--- a/docs/ARMInstallation.md
+++ b/docs/ARMInstallation.md
@@ -3,7 +3,7 @@ This article details provisioning and installation of the IoMT FHIR Connector fo
 
 ## ARM Template Provisioning
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2Fiomt-fhir%2Fmain%2Fdeploy%2Ftemplates%2Fdefault-managed-identity-azuredeploy.json" target="_blank">
-    <img src="https://azuredeploy.net/deploybutton.png"/>
+    <img src="https://aka.ms/deploytoazurebutton"/>
 </a>
 
 An [ARM Template](../deploy/templates/default-managed-identity-azuredeploy.json) is provided for easy provisioning of an environment within Azure with the Azure API for FHIR. When executed, the ARM template will provision the following:


### PR DESCRIPTION
The URL for the site that hosted the "Deploy to Azure" button appears to no longer a have a valid SSL certificate which unfortunately means that the button does not show up when viewing the [ARM Installation page](https://github.com/microsoft/iomt-fhir/blob/main/docs/ARMInstallation.md) :(

![image](https://github.com/microsoft/iomt-fhir/assets/59618266/b1ba2dcc-3e75-4bbd-95aa-ed0958cd381e)


The old hosting location was: https://azuredeploy.net/deploybutton.png

[These docs](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-to-azure-button) say to use https://aka.ms/deploytoazurebutton so this PR updates to URL to the new location.

![image](https://github.com/microsoft/iomt-fhir/assets/59618266/f85274b4-dcf9-4705-9959-cc890719e268)

