### PR TITLE
Initialize event hub partition reading from the next event after the checkpoint

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/BaseEventProcessor.cs
@@ -94,9 +94,11 @@ namespace Microsoft.Health.Events.EventHubProcessor
             {
                 EventConsumerService.NewPartitionInitialized(partitionId);
                 var checkpoint = await CheckpointClient.GetCheckpointForPartitionAsync(partitionId, initArgs.CancellationToken);
-                initArgs.DefaultStartingPosition = EventPosition.FromEnqueuedTime(checkpoint.LastProcessed);
 
-                Logger.LogTrace($"Starting to read partition {partitionId} from checkpoint {checkpoint.LastProcessed}");
+                // Get the last checkpointed event offset and begin reading from the next event by setting isInclusive = false
+                initArgs.DefaultStartingPosition = EventPosition.FromOffset(checkpoint.Offset, isInclusive: false);
+
+                Logger.LogTrace($"Starting to read partition {partitionId} from next event after checkpoint offset {checkpoint.Offset} checkpoint time {checkpoint.LastProcessed}");
                 Logger.LogMetric(EventMetrics.EventHubPartitionInitialized(partitionId), 1);
             }
             catch (TaskCanceledException ex)


### PR DESCRIPTION
Previously the iot connector would begin reading from a partition based on the last checkpointed event's enqueued time. The date compassion used `EventPosition.FromEnqueuedTime(checkpoint.LastProcessed)` was inclusive, meaning that the last checkpointed event was included in the first batch on initialization. This is not desirable because it reprocesses one event on shutdown/startup or when partition ownership is lost, which is unnecessary. Reprocessing this one event also causes issues with the data freshness calculations since the reprocess of an older event makes it seem like the iot connector had fallen behind.

There are options to instead use the event offset or the event sequence id to resume processing events from a checkpoint. Since we already store the event offset and sequence id in the checkpoint the only change is to change the intialization logic to use the offset instead of a datetime. There is also an option to either include the last checkpointed event (isInclusive = true) or to exclude the last checkpointed event (isInclusive = false). We are choosing to exclude the last checkpointed event since it has already been processed.