### PR TITLE
Return an indicator when we resume the processor

### DIFF
--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/IResumableEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/IResumableEventProcessor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
         /// Attempts to resume the Event Processor.
         /// </summary>
         /// <param name="ct">The cancellation token</param>
-        /// <returns><true> if the Event Processor was restart. <false> if it was already running.</returns>
+        /// <returns>true if the Event Processor was restart. false if it was already running.</returns>
         Task<bool> ResumeAsync(CancellationToken ct);
 
         Task RunAsync(CancellationToken ct);

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/IResumableEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/IResumableEventProcessor.cs
@@ -11,7 +11,12 @@ namespace Microsoft.Health.Events.EventHubProcessor
 {
     public interface IResumableEventProcessor : IDisposable
     {
-        Task ResumeAsync(CancellationToken ct);
+        /// <summary>
+        /// Attempts to resume the Event Processor.
+        /// </summary>
+        /// <param name="ct">The cancellation token</param>
+        /// <returns><true> if the Event Processor was restart. <false> if it was already running.</returns>
+        Task<bool> ResumeAsync(CancellationToken ct);
 
         Task RunAsync(CancellationToken ct);
 

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/IResumableEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/IResumableEventProcessor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
         /// Attempts to resume the Event Processor.
         /// </summary>
         /// <param name="ct">The cancellation token</param>
-        /// <returns>true if the Event Processor was restart. false if it was already running.</returns>
+        /// <returns>true if the Event Processor was restarted. false if it was already running.</returns>
         Task<bool> ResumeAsync(CancellationToken ct);
 
         Task RunAsync(CancellationToken ct);

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/ResumableAssignedPartitionProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/ResumableAssignedPartitionProcessor.cs
@@ -26,9 +26,11 @@ namespace Microsoft.Health.Events.EventHubProcessor
             // todo?
         }
 
-        public async Task ResumeAsync(CancellationToken ct)
+        public async Task<bool> ResumeAsync(CancellationToken ct)
         {
+            var isRunning = Interlocked.Read(ref _isRunning) == 1;
             await RunAsync(ct);
+            return !isRunning;
         }
 
         public async Task RunAsync(CancellationToken ct)

--- a/src/lib/Microsoft.Health.Events/EventHubProcessor/ResumableEventProcessor.cs
+++ b/src/lib/Microsoft.Health.Events/EventHubProcessor/ResumableEventProcessor.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
             await ResumeAsync(ct);
         }
 
-        public async Task ResumeAsync(CancellationToken ct)
+        public async Task<bool> ResumeAsync(CancellationToken ct)
         {
             // Only start if necessary.
             if (!EventProcessorClient.IsRunning)
@@ -51,6 +51,7 @@ namespace Microsoft.Health.Events.EventHubProcessor
                 {
                     Logger.LogTrace($"Starting event hub processor at {DateTime.UtcNow}");
                     await EventProcessorClient.StartProcessingAsync(ct);
+                    return true;
                 }
                 catch (AggregateException ex)
                 {
@@ -61,6 +62,8 @@ namespace Microsoft.Health.Events.EventHubProcessor
             {
                 Logger.LogTrace("Eventhub Processor is already running");
             }
+
+            return false;
         }
 
         public async Task SuspendAsync(CancellationToken ct)


### PR DESCRIPTION
The `ResumeAsync` method will restart processing if the EventProcessorClient is not already running. This PR returns an indication of when the method has started the processor.

This indication will support downstream health checks.