### PR TITLE
Personal/namalu/branch specific deploy

### DIFF
--- a/deploy/templates/bicep/BuildContainerImages.bicep
+++ b/deploy/templates/bicep/BuildContainerImages.bicep
@@ -1,6 +1,6 @@
 @minLength(6)
 @maxLength(16)
-@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters.')
+@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 6 characters and less than 16 characters.')
 param baseName string
 
 @description('Location where the resources are deployed. For a list of Azure regions where Azure Health Data Services are available, see [Products available by regions](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=health-data-services)')

--- a/deploy/templates/bicep/BuildContainerImages.bicep
+++ b/deploy/templates/bicep/BuildContainerImages.bicep
@@ -131,4 +131,7 @@ resource buildFhirTransformationImage 'Microsoft.Resources/deploymentScripts@202
     retentionInterval: 'P1D'
     cleanupPreference: 'OnSuccess'
   }
+  dependsOn: [
+    buildNormalizationImage
+  ]
 }

--- a/deploy/templates/bicep/BuildContainerImages.bicep
+++ b/deploy/templates/bicep/BuildContainerImages.bicep
@@ -131,7 +131,4 @@ resource buildFhirTransformationImage 'Microsoft.Resources/deploymentScripts@202
     retentionInterval: 'P1D'
     cleanupPreference: 'OnSuccess'
   }
-  dependsOn: [
-    buildNormalizationImage
-  ]
 }

--- a/deploy/templates/bicep/ContainerApp-SingleAzureDeploy.bicep
+++ b/deploy/templates/bicep/ContainerApp-SingleAzureDeploy.bicep
@@ -2,7 +2,7 @@ targetScope = 'subscription'
 
 @minLength(6)
 @maxLength(16)
-@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters.')
+@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 6 characters and less than 16 characters.')
 param baseName string
 
 @description('Location where the resources are deployed. For a list of Azure regions where Azure Health Data Services are available, see [Products available by regions](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=health-data-services)')

--- a/deploy/templates/bicep/ContainerApp-SingleAzureDeploy.bicep
+++ b/deploy/templates/bicep/ContainerApp-SingleAzureDeploy.bicep
@@ -1,6 +1,6 @@
 targetScope = 'subscription'
 
-@minLength(3)
+@minLength(6)
 @maxLength(16)
 @description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters.')
 param baseName string
@@ -44,6 +44,12 @@ param resourceIdentityResolutionType string
 ])
 param fhirVersion string
 
+@description('The URL for the repository where the container code resides.')
+param gitRepositoryUrl string = 'https://github.com/microsoft/iomt-fhir.git'
+
+@description('The branch name or commit hash to be used when building the containers, defaults to main.')
+param gitBranch string = 'main'
+
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
   name: baseName
   location: location
@@ -86,6 +92,8 @@ module buildContainerImages 'BuildContainerImages.bicep' = {
     location: location
     resourceIdentityResolutionType: resourceIdentityResolutionType
     fhirVersion: fhirVersion
+    gitRepositoryUrl: gitRepositoryUrl
+    gitBranch: gitBranch
   }
   dependsOn: [
     infrastructureSetup

--- a/deploy/templates/bicep/ContainerApp-SingleAzureDeploy.json
+++ b/deploy/templates/bicep/ContainerApp-SingleAzureDeploy.json
@@ -4,14 +4,14 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.20.4.51522",
-      "templateHash": "13672600818265155109"
+      "version": "0.22.6.54827",
+      "templateHash": "8746001509181318699"
     }
   },
   "parameters": {
     "baseName": {
       "type": "string",
-      "minLength": 3,
+      "minLength": 6,
       "maxLength": 16,
       "metadata": {
         "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters."
@@ -64,6 +64,20 @@
       "metadata": {
         "description": "FHIR version that the FHIR Server supports"
       }
+    },
+    "gitRepositoryUrl": {
+      "type": "string",
+      "defaultValue": "https://github.com/microsoft/iomt-fhir.git",
+      "metadata": {
+        "description": "The URL for the repository where the container code resides."
+      }
+    },
+    "gitBranch": {
+      "type": "string",
+      "defaultValue": "main",
+      "metadata": {
+        "description": "The branch name or commit hash to be used when building the containers, defaults to main."
+      }
     }
   },
   "resources": [
@@ -107,14 +121,14 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "9440424175545731576"
+              "version": "0.22.6.54827",
+              "templateHash": "13080453463463393731"
             }
           },
           "parameters": {
             "baseName": {
               "type": "string",
-              "minLength": 3,
+              "minLength": 6,
               "maxLength": 16,
               "metadata": {
                 "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters."
@@ -450,8 +464,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "11639116328160071053"
+              "version": "0.22.6.54827",
+              "templateHash": "15930281173876783170"
             }
           },
           "parameters": {
@@ -660,6 +674,12 @@
           },
           "fhirVersion": {
             "value": "[parameters('fhirVersion')]"
+          },
+          "gitRepositoryUrl": {
+            "value": "[parameters('gitRepositoryUrl')]"
+          },
+          "gitBranch": {
+            "value": "[parameters('gitBranch')]"
           }
         },
         "template": {
@@ -668,14 +688,14 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "12312286705077005359"
+              "version": "0.22.6.54827",
+              "templateHash": "8458475336653759686"
             }
           },
           "parameters": {
             "baseName": {
               "type": "string",
-              "minLength": 3,
+              "minLength": 6,
               "maxLength": 16,
               "metadata": {
                 "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters."
@@ -720,6 +740,20 @@
                 "description": "Configures how patient, device, and other FHIR resource identities are resolved from the ingested data stream."
               }
             },
+            "gitRepositoryUrl": {
+              "type": "string",
+              "defaultValue": "https://github.com/microsoft/iomt-fhir.git",
+              "metadata": {
+                "description": "The URL for the repository where the container code resides."
+              }
+            },
+            "gitBranch": {
+              "type": "string",
+              "defaultValue": "main",
+              "metadata": {
+                "description": "The branch name or commit hash to be used when building the containers, defaults to main."
+              }
+            },
             "fhirVersion": {
               "type": "string",
               "allowedValues": [
@@ -729,16 +763,13 @@
                 "description": "FHIR version that the FHIR Server supports"
               }
             },
-            "gitRepositoryUrl": {
-              "type": "string",
-              "defaultValue": "https://github.com/microsoft/iomt-fhir.git"
-            },
             "acrBuildPlatform": {
               "type": "string",
               "defaultValue": "linux"
             }
           },
           "variables": {
+            "gitRepositoryAndBranch": "[format('{0}#{1}', parameters('gitRepositoryUrl'), parameters('gitBranch'))]",
             "normalizationImage": "normalization",
             "fhirTransformationImage": "fhir-transformation",
             "imageTag": "latest",
@@ -771,7 +802,7 @@
                   "containerGroupName": "[format('{0}deployContainer', parameters('baseName'))]"
                 },
                 "azCliVersion": "2.50.0",
-                "arguments": "[format('{0} {1} {2} {3} {4} {5}', format('{0}acr', parameters('baseName')), parameters('gitRepositoryUrl'), variables('normalizationImage'), variables('imageTag'), variables('normalizationDockerfile'), parameters('acrBuildPlatform'))]",
+                "arguments": "[format('{0} {1} {2} {3} {4} {5}', format('{0}acr', parameters('baseName')), variables('gitRepositoryAndBranch'), variables('normalizationImage'), variables('imageTag'), variables('normalizationDockerfile'), parameters('acrBuildPlatform'))]",
                 "scriptContent": "      az acr build --registry $1 $2 --image $3:$4 --file $5 --platform $6\r\n    ",
                 "retentionInterval": "P1D",
                 "cleanupPreference": "OnSuccess"
@@ -802,7 +833,7 @@
                   "containerGroupName": "[format('{0}deployContainer', parameters('baseName'))]"
                 },
                 "azCliVersion": "2.50.0",
-                "arguments": "[format('{0} {1} {2} {3} {4} {5}', format('{0}acr', parameters('baseName')), parameters('gitRepositoryUrl'), variables('fhirTransformationImage'), variables('imageTag'), variables('fhirTransformationDockerfile'), parameters('acrBuildPlatform'))]",
+                "arguments": "[format('{0} {1} {2} {3} {4} {5}', format('{0}acr', parameters('baseName')), variables('gitRepositoryAndBranch'), variables('fhirTransformationImage'), variables('imageTag'), variables('fhirTransformationDockerfile'), parameters('acrBuildPlatform'))]",
                 "scriptContent": "      az acr build --registry $1 $2 --image $3:$4 --file $5 --platform $6\r\n    ",
                 "retentionInterval": "P1D",
                 "cleanupPreference": "OnSuccess"
@@ -850,14 +881,14 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "18029408802853782428"
+              "version": "0.22.6.54827",
+              "templateHash": "13621101343156168702"
             }
           },
           "parameters": {
             "baseName": {
               "type": "string",
-              "minLength": 3,
+              "minLength": 6,
               "maxLength": 16,
               "metadata": {
                 "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters."

--- a/deploy/templates/bicep/ContainerApp-SingleAzureDeploy.json
+++ b/deploy/templates/bicep/ContainerApp-SingleAzureDeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.22.6.54827",
-      "templateHash": "10383856546982714086"
+      "templateHash": "13353804260323222956"
     }
   },
   "parameters": {
@@ -14,7 +14,7 @@
       "minLength": 6,
       "maxLength": 16,
       "metadata": {
-        "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters."
+        "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 6 characters and less than 16 characters."
       }
     },
     "location": {
@@ -122,7 +122,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.22.6.54827",
-              "templateHash": "13080453463463393731"
+              "templateHash": "17349789646225745736"
             }
           },
           "parameters": {
@@ -131,7 +131,7 @@
               "minLength": 6,
               "maxLength": 16,
               "metadata": {
-                "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters."
+                "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 6 characters and less than 16 characters."
               }
             },
             "location": {
@@ -465,7 +465,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.22.6.54827",
-              "templateHash": "16984454648748429824"
+              "templateHash": "11088519812661916410"
             }
           },
           "parameters": {
@@ -474,7 +474,7 @@
               "minLength": 6,
               "maxLength": 16,
               "metadata": {
-                "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters."
+                "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 6 characters and less than 16 characters."
               }
             },
             "location": {
@@ -689,7 +689,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.22.6.54827",
-              "templateHash": "8458475336653759686"
+              "templateHash": "1636373595736283998"
             }
           },
           "parameters": {
@@ -698,7 +698,7 @@
               "minLength": 6,
               "maxLength": 16,
               "metadata": {
-                "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters."
+                "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 6 characters and less than 16 characters."
               }
             },
             "location": {
@@ -882,7 +882,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.22.6.54827",
-              "templateHash": "13621101343156168702"
+              "templateHash": "17147861500615029993"
             }
           },
           "parameters": {
@@ -891,7 +891,7 @@
               "minLength": 6,
               "maxLength": 16,
               "metadata": {
-                "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters."
+                "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 6 characters and less than 16 characters."
               }
             },
             "location": {

--- a/deploy/templates/bicep/ContainerApp-SingleAzureDeploy.json
+++ b/deploy/templates/bicep/ContainerApp-SingleAzureDeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.22.6.54827",
-      "templateHash": "8746001509181318699"
+      "templateHash": "10383856546982714086"
     }
   },
   "parameters": {
@@ -465,13 +465,13 @@
             "_generator": {
               "name": "bicep",
               "version": "0.22.6.54827",
-              "templateHash": "15930281173876783170"
+              "templateHash": "16984454648748429824"
             }
           },
           "parameters": {
             "baseName": {
               "type": "string",
-              "minLength": 3,
+              "minLength": 6,
               "maxLength": 16,
               "metadata": {
                 "description": "Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters."

--- a/deploy/templates/bicep/ContainerAppSetup.bicep
+++ b/deploy/templates/bicep/ContainerAppSetup.bicep
@@ -1,4 +1,4 @@
-@minLength(3)
+@minLength(6)
 @maxLength(16)
 @description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters.')
 param baseName string

--- a/deploy/templates/bicep/ContainerAppSetup.bicep
+++ b/deploy/templates/bicep/ContainerAppSetup.bicep
@@ -1,6 +1,6 @@
 @minLength(6)
 @maxLength(16)
-@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters.')
+@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 6 characters and less than 16 characters.')
 param baseName string
 
 @description('Location where the resources are deployed. For a list of Azure regions where Azure Health Data Services are available, see [Products available by regions](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=health-data-services)')

--- a/deploy/templates/bicep/InfrastructureSetup.bicep
+++ b/deploy/templates/bicep/InfrastructureSetup.bicep
@@ -1,4 +1,4 @@
-@minLength(3)
+@minLength(6)
 @maxLength(16)
 @description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters.')
 param baseName string

--- a/deploy/templates/bicep/InfrastructureSetup.bicep
+++ b/deploy/templates/bicep/InfrastructureSetup.bicep
@@ -1,6 +1,6 @@
 @minLength(6)
 @maxLength(16)
-@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters.')
+@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 6 characters and less than 16 characters.')
 param baseName string
 
 @description('Location where the resources are deployed. For a list of Azure regions where Azure Health Data Services are available, see [Products available by regions](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=health-data-services)')

--- a/deploy/templates/bicep/Main.bicep
+++ b/deploy/templates/bicep/Main.bicep
@@ -2,7 +2,7 @@ targetScope = 'subscription'
 
 @minLength(6)
 @maxLength(16)
-@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters.')
+@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 6 characters and less than 16 characters.')
 param baseName string
 
 @description('Location where the resources are deployed. For a list of Azure regions where Azure Health Data Services are available, see [Products available by regions](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=health-data-services)')

--- a/deploy/templates/bicep/Main.bicep
+++ b/deploy/templates/bicep/Main.bicep
@@ -1,6 +1,6 @@
 targetScope = 'subscription'
 
-@minLength(3)
+@minLength(6)
 @maxLength(16)
 @description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters.')
 param baseName string

--- a/deploy/templates/bicep/UploadTemplates.bicep
+++ b/deploy/templates/bicep/UploadTemplates.bicep
@@ -1,4 +1,4 @@
-@minLength(3)
+@minLength(6)
 @maxLength(16)
 @description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters.')
 param baseName string

--- a/deploy/templates/bicep/UploadTemplates.bicep
+++ b/deploy/templates/bicep/UploadTemplates.bicep
@@ -1,6 +1,6 @@
 @minLength(6)
 @maxLength(16)
-@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 3 characters and less than 16 characters.')
+@description('Basename that is used to name provisioned resources. Should be alphanumeric, at least 6 characters and less than 16 characters.')
 param baseName string
 
 @description('Location where the resources are deployed. For a list of Azure regions where Azure Health Data Services are available, see [Products available by regions](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=health-data-services)')

--- a/src/console/Microsoft.Health.Fhir.Ingest.Console.FhirTransformation/Dockerfile
+++ b/src/console/Microsoft.Health.Fhir.Ingest.Console.FhirTransformation/Dockerfile
@@ -2,6 +2,8 @@ FROM mcr.microsoft.com/dotnet/runtime:6.0@sha256:3525f2e1a54f8e437ea98a2237e1db8
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0@sha256:5ecf5be1ce0aa12d623963336a54f588091797f75268d57d40dc01260fc58d09 AS publish
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
 COPY ["nuget.config", "."]
 COPY ["src/console/Microsoft.Health.Fhir.Ingest.Console.FhirTransformation", "src/console/Microsoft.Health.Fhir.Ingest.Console.FhirTransformation"]
 COPY ["src/console/Microsoft.Health.Fhir.Ingest.Console.Common", "src/console/Microsoft.Health.Fhir.Ingest.Console.Common"]

--- a/src/console/Microsoft.Health.Fhir.Ingest.Console.Normalization/Dockerfile
+++ b/src/console/Microsoft.Health.Fhir.Ingest.Console.Normalization/Dockerfile
@@ -2,6 +2,8 @@ FROM mcr.microsoft.com/dotnet/runtime:6.0@sha256:3525f2e1a54f8e437ea98a2237e1db8
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0@sha256:5ecf5be1ce0aa12d623963336a54f588091797f75268d57d40dc01260fc58d09 AS publish
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
 COPY ["nuget.config", "."]
 COPY ["src/console/Microsoft.Health.Fhir.Ingest.Console.Normalization", "src/console/Microsoft.Health.Fhir.Ingest.Console.Normalization"]
 COPY ["src/console/Microsoft.Health.Fhir.Ingest.Console.Common", "src/console/Microsoft.Health.Fhir.Ingest.Console.Common"]


### PR DESCRIPTION
This PR updates the `ContainerApp-SingleAzureDeploy.bicep` to provide a way to specify a specific GitHub url (for cases where a user may want to deploy from a fork) and/or a specific branch (this can be used by users and pipelines).